### PR TITLE
internal,test: Ensure cross-catalog upgrades are prohibited

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,14 +55,12 @@ func main() {
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
-		systemNamespace      string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&systemNamespace, "system-namespace", "openshift-platform-operators", "Configures the namespace that gets used to deploy system resources.")
 	opts := zap.Options{
 		Development: true,
 	}

--- a/internal/sourcer/registry_sourcer.go
+++ b/internal/sourcer/registry_sourcer.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
@@ -49,7 +48,6 @@ func (cs catalogSource) Source(ctx context.Context, o *operatorv1alpha1.Operator
 
 func (s sources) GetCandidates(ctx context.Context, o *operatorv1alpha1.Operator) (bundles, error) {
 	matchesDesiredVersion := getVersionFilter(o.Spec.Package.Version)
-	log := logr.FromContext(ctx)
 
 	// TODO(tflannag): Revisit this implementation as it's expensive.
 	var (
@@ -67,7 +65,7 @@ func (s sources) GetCandidates(ctx context.Context, o *operatorv1alpha1.Operator
 		}
 		it, err := rc.ListBundles(ctx)
 		if err != nil {
-			log.Info("failed to list bundles from catalog", "name", cs.GetName(), "namespace", cs.GetNamespace(), "error", err.Error())
+			errors = append(errors, fmt.Errorf("failed to list bundles from the %s/%s catalog: %w", cs.GetName(), cs.GetNamespace(), err))
 			continue
 		}
 


### PR DESCRIPTION
Update the CatalogSource registry implementation, and ensure that an Operator tracks the catalog source that was initially selected during installation when no spec.Catalog configuration has been specified by the user.

In the case that multiple catalogs exist on the cluster (e.g. c1, c2, ..., cN) and a subset of those catalogs all contain the same package name, then the expected behavior is that one of those catalogs that contains the highest semver bundle will be selected during installation. After installation, a different catalog has been updated and now contains the highest semver bundle in the desired package name. We'd like to prohibit an Operator upgrading to another catalog source in this case to avoid the scenario where packages within those different catalogs define different upgrade graphs.

Note: We may want to do something similar with cross-channel updates, but it's unclear whether this cross-catalog UX is something worth enforcing as a long term behavior.