### PR TITLE
Operator Spec PackageName

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -20,23 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // OperatorSpec defines the desired state of Operator
 type OperatorSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of Operator. Edit operator_types.go to remove/update
-	Foo string `json:"foo,omitempty"`
+	//+kubebuilder:validation:MaxLength:=48
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]+(-[a-z0-9]+)*$
+	PackageName string `json:"packageName"`
 }
 
 // OperatorStatus defines the observed state of Operator
-type OperatorStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-}
+type OperatorStatus struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -35,10 +35,12 @@ spec:
           spec:
             description: OperatorSpec defines the desired state of Operator
             properties:
-              foo:
-                description: Foo is an example field of Operator. Edit operator_types.go
-                  to remove/update
+              packageName:
+                maxLength: 48
+                pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
                 type: string
+            required:
+            - packageName
             type: object
           status:
             description: OperatorStatus defines the observed state of Operator

--- a/config/samples/operators_v1alpha1_operator.yaml
+++ b/config/samples/operators_v1alpha1_operator.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/created-by: operator-controller
   name: operator-sample
 spec:
+  # TODO(user): Add fields here
   packageName: my-operator

--- a/config/samples/operators_v1alpha1_operator.yaml
+++ b/config/samples/operators_v1alpha1_operator.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/created-by: operator-controller
   name: operator-sample
 spec:
-  # TODO(user): Add fields here
+  packageName: my-operator


### PR DESCRIPTION
Addresses Issue #69 
Add package name to spec with validation, clear generated comments, run make, update sample CR

Tested by running:
```
kind create cluster
make install
kubectl apply -f config/samples/operators_v1alpha1_operator.yaml
```