### PR TITLE
github workflow additions/updates

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,18 +1,13 @@
-name: e2e
-
-on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-    - main
-
+name: go-apidiff
+on: [ pull_request ]
 jobs:
-  e2e-kind:
+  go-apidiff:
     runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - uses: actions/setup-go@v3
       with:
@@ -27,6 +22,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Run e2e tests
-      run: |
-        make e2e
+    - uses: joelanford/go-apidiff@main

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -11,10 +11,22 @@ jobs:
   unit-test-basic:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+
+    - uses: actions/checkout@v3
+
     - uses: actions/setup-go@v3
       with:
-        go-version-file: "go.mod"
+        go-version-file: go.mod
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Run basic unit tests
       run: |
         make test


### PR DESCRIPTION
* add go-apidiff workflow to run on all PRs (informational to make sure we're aware of Go API changes)
* add go module caching to speed up builds and tests