### PR TITLE
Update status remove bundle path

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -55,7 +55,6 @@ type OperatorStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-	BundlePath string             `json:"BundlePath,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -45,8 +45,6 @@ spec:
           status:
             description: OperatorStatus defines the observed state of Operator
             properties:
-              BundlePath:
-                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current

--- a/controllers/operator_controller.go
+++ b/controllers/operator_controller.go
@@ -19,9 +19,6 @@ package controllers
 import (
 	"context"
 
-	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
-	"github.com/operator-framework/operator-controller/internal/resolution"
-	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/bundles_and_dependencies"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +27,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/internal/resolution"
+	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/bundles_and_dependencies"
 )
 
 // OperatorReconciler reconciles a Operator object

--- a/controllers/operator_controller.go
+++ b/controllers/operator_controller.go
@@ -112,7 +112,6 @@ func (r *OperatorReconciler) reconcile(ctx context.Context, op *operatorsv1alpha
 		message = err.Error()
 	} else {
 		// extract package bundle path from resolved variable
-		var bundlePath = ""
 		for _, variable := range solution.SelectedVariables() {
 			switch v := variable.(type) {
 			case *bundles_and_dependencies.BundleVariable:
@@ -121,15 +120,16 @@ func (r *OperatorReconciler) reconcile(ctx context.Context, op *operatorsv1alpha
 					return ctrl.Result{}, err
 				}
 				if packageName == op.Spec.PackageName {
-					bundlePath, err = v.BundleEntity().BundlePath()
+					bundlePath, err := v.BundleEntity().BundlePath()
 					if err != nil {
 						return ctrl.Result{}, err
 					}
+					// TODO(perdasilva): use bundlePath to stamp out bundle deployment
+					_ = bundlePath
 					break
 				}
 			}
 		}
-		op.Status.BundlePath = bundlePath
 	}
 
 	// update operator status

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,9 +25,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
-	"github.com/operator-framework/operator-controller/controllers"
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -38,6 +35,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/controllers"
+	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
This PR removes `Operator.Status.BundlePath` from the Operator API and updates the reconciliation process to _only_ update the reconciled resource after resolution