### PR TITLE
controller code/test refactoring/additions

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 )
 
 // OperatorSpec defines the desired state of Operator
@@ -32,9 +33,10 @@ const (
 	// TODO(user): add more Types, here and into init()
 	TypeReady = "Ready"
 
-	ReasonNotImplemented      = "NotImplemented"
-	ReasonResolutionFailed    = "ResolutionFailed"
-	ReasonResolutionSucceeded = "ResolutionSucceeded"
+	ReasonResolutionSucceeded    = "ResolutionSucceeded"
+	ReasonResolutionFailed       = "ResolutionFailed"
+	ReasonBundleLookupFailed     = "BundleLookupFailed"
+	ReasonBundleDeploymentFailed = "BundleDeploymentFailed"
 )
 
 func init() {
@@ -44,7 +46,10 @@ func init() {
 	)
 	// TODO(user): add Reasons from above
 	operatorutil.ConditionReasons = append(operatorutil.ConditionReasons,
-		ReasonNotImplemented, ReasonResolutionSucceeded, ReasonResolutionFailed,
+		ReasonResolutionSucceeded,
+		ReasonResolutionFailed,
+		ReasonBundleLookupFailed,
+		ReasonBundleDeploymentFailed,
 	)
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,12 +21,8 @@ rules:
   resources:
   - operators
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - operators.operatorframework.io

--- a/controllers/operator_controller_test.go
+++ b/controllers/operator_controller_test.go
@@ -1,0 +1,222 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/deppy/pkg/deppy"
+	"github.com/operator-framework/deppy/pkg/deppy/input"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/controllers"
+	"github.com/operator-framework/operator-controller/internal/resolution"
+	operatorutil "github.com/operator-framework/operator-controller/internal/util"
+)
+
+var _ = Describe("Reconcile Test", func() {
+	var (
+		ctx        context.Context
+		reconciler *controllers.OperatorReconciler
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		reconciler = &controllers.OperatorReconciler{
+			Client:   cl,
+			Scheme:   sch,
+			Resolver: resolution.NewOperatorResolver(cl, testEntitySource),
+		}
+	})
+	When("the operator does not exist", func() {
+		It("returns no error", func() {
+			res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "non-existent"}})
+			Expect(res).To(Equal(ctrl.Result{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+	When("the operator exists", func() {
+		var (
+			operator *operatorsv1alpha1.Operator
+			opKey    types.NamespacedName
+		)
+		BeforeEach(func() {
+			opKey = types.NamespacedName{Name: fmt.Sprintf("operator-test-%s", rand.String(8))}
+		})
+		When("the operator specifies a non-existent package", func() {
+			var pkgName string
+			BeforeEach(func() {
+				By("initializing cluster state")
+				pkgName = fmt.Sprintf("non-existent-%s", rand.String(6))
+				operator = &operatorsv1alpha1.Operator{
+					ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
+					Spec:       operatorsv1alpha1.OperatorSpec{PackageName: pkgName},
+				}
+				err := cl.Create(ctx, operator)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("running reconcile")
+				res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
+				Expect(res).To(Equal(ctrl.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("fetching updated operator after reconcile")
+				Expect(cl.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
+			})
+			It("sets resolution failure status", func() {
+				cond := apimeta.FindStatusCondition(operator.Status.Conditions, operatorsv1alpha1.TypeReady)
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonResolutionFailed))
+				Expect(cond.Message).To(Equal(fmt.Sprintf("package '%s' not found", pkgName)))
+			})
+		})
+		When("the operator specifies a valid available package", func() {
+			// TODO: add sub-scenarios -- When("BD does not exist") and When("BD already exists").
+			const pkgName = "prometheus"
+			BeforeEach(func() {
+				By("initializing cluster state")
+				operator = &operatorsv1alpha1.Operator{
+					ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
+					Spec:       operatorsv1alpha1.OperatorSpec{PackageName: pkgName},
+				}
+				err := cl.Create(ctx, operator)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("running reconcile")
+				res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
+				Expect(res).To(Equal(ctrl.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("fetching updated operator after reconcile")
+				Expect(cl.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
+			})
+			It("results in the expected BundleDeployment", func() {
+				bd := &rukpakv1alpha1.BundleDeployment{}
+				err := cl.Get(ctx, types.NamespacedName{Name: opKey.Name}, bd)
+				Expect(err).NotTo(HaveOccurred())
+				// TODO: verify other fields
+			})
+			It("sets resolution success status", func() {
+				cond := apimeta.FindStatusCondition(operator.Status.Conditions, operatorsv1alpha1.TypeReady)
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonResolutionSucceeded))
+				Expect(cond.Message).To(Equal("resolution was successful"))
+			})
+		})
+		When("the selected bundle's image ref cannot be parsed", func() {
+			const pkgName = "badimage"
+			BeforeEach(func() {
+				By("initializing cluster state")
+				operator = &operatorsv1alpha1.Operator{
+					ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
+					Spec:       operatorsv1alpha1.OperatorSpec{PackageName: pkgName},
+				}
+				err := cl.Create(ctx, operator)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("sets resolution failure status and returns an error", func() {
+				By("running reconcile")
+				res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
+				Expect(res).To(Equal(ctrl.Result{}))
+				Expect(err).To(MatchError(ContainSubstring(`error determining bundle path for entity`)))
+
+				By("fetching updated operator after reconcile")
+				Expect(cl.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
+
+				cond := apimeta.FindStatusCondition(operator.Status.Conditions, operatorsv1alpha1.TypeReady)
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonBundleLookupFailed))
+				Expect(cond.Message).To(ContainSubstring(`error determining bundle path for entity`))
+			})
+		})
+		When("the operator specifies a duplicate package", func() {
+			const pkgName = "prometheus"
+			BeforeEach(func() {
+				By("initializing cluster state")
+				err := cl.Create(ctx, &operatorsv1alpha1.Operator{
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("orig-%s", opKey.Name)},
+					Spec:       operatorsv1alpha1.OperatorSpec{PackageName: pkgName},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				operator = &operatorsv1alpha1.Operator{
+					ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
+					Spec:       operatorsv1alpha1.OperatorSpec{PackageName: pkgName},
+				}
+				err = cl.Create(ctx, operator)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("running reconcile")
+				res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
+				Expect(res).To(Equal(ctrl.Result{}))
+				Expect(err).To(BeNil())
+
+				By("fetching updated operator after reconcile")
+				Expect(cl.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
+			})
+			It("sets resolution failure status", func() {
+				cond := apimeta.FindStatusCondition(operator.Status.Conditions, operatorsv1alpha1.TypeReady)
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonResolutionFailed))
+				Expect(cond.Message).To(Equal(`duplicate identifier "required package prometheus" in input`))
+			})
+		})
+		AfterEach(func() {
+			verifyInvariants(ctx, operator)
+
+			err := cl.Delete(ctx, operator)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+})
+
+func verifyInvariants(ctx context.Context, op *operatorsv1alpha1.Operator) {
+	key := client.ObjectKeyFromObject(op)
+	err := cl.Get(ctx, key, op)
+	Expect(err).To(BeNil())
+
+	verifyConditionsInvariants(op)
+}
+
+func verifyConditionsInvariants(op *operatorsv1alpha1.Operator) {
+	// Expect that the operator's set of conditions contains all defined
+	// condition types for the Operator API. Every reconcile should always
+	// ensure every condition type's status/reason/message reflects the state
+	// read during _this_ reconcile call.
+	Expect(op.Status.Conditions).To(HaveLen(len(operatorutil.ConditionTypes)))
+	for _, t := range operatorutil.ConditionTypes {
+		cond := apimeta.FindStatusCondition(op.Status.Conditions, t)
+		Expect(cond).To(Not(BeNil()))
+		Expect(cond.Status).NotTo(BeEmpty())
+		Expect(cond.Reason).To(BeElementOf(operatorutil.ConditionReasons))
+		Expect(cond.ObservedGeneration).To(Equal(op.GetGeneration()))
+	}
+}
+
+var testEntitySource = input.NewCacheQuerier(map[deppy.Identifier]input.Entity{
+	"operatorhub/prometheus/0.37.0": *input.NewEntity("operatorhub/prometheus/0.37.0", map[string]string{
+		"olm.bundle.path": `"quay.io/operatorhubio/prometheus@sha256:3e281e587de3d03011440685fc4fb782672beab044c1ebadc42788ce05a21c35"`,
+		"olm.channel":     `{"channelName":"beta","priority":0}`,
+		"olm.package":     `{"packageName":"prometheus","version":"0.37.0"}`,
+	}),
+	"operatorhub/prometheus/0.47.0": *input.NewEntity("operatorhub/prometheus/0.47.0", map[string]string{
+		"olm.bundle.path": `"quay.io/operatorhubio/prometheus@sha256:5b04c49d8d3eff6a338b56ec90bdf491d501fe301c9cdfb740e5bff6769a21ed"`,
+		"olm.channel":     `{"channelName":"beta","priority":0,"replaces":"prometheusoperator.0.37.0"}`,
+		"olm.package":     `{"packageName":"prometheus","version":"0.47.0"}`,
+	}),
+	"operatorhub/badimage/0.1.0": *input.NewEntity("operatorhub/badimage/0.1.0", map[string]string{
+		"olm.bundle.path": `{"name": "quay.io/operatorhubio/badimage:v0.1.0"}`,
+		"olm.package":     `{"packageName":"badimage","version":"0.1.0"}`,
+	}),
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,42 +17,30 @@ limitations under the License.
 package controllers_test
 
 import (
-	"context"
-	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/kubernetes/scheme"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
-	"github.com/operator-framework/operator-controller/controllers"
-	"github.com/operator-framework/operator-controller/internal/resolution"
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
-	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
+	cfg     *rest.Config
+	cl      client.Client
+	sch     *runtime.Scheme
+	testEnv *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -77,123 +65,19 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = operatorsv1alpha1.AddToScheme(scheme.Scheme)
+	sch = runtime.NewScheme()
+	err = operatorsv1alpha1.AddToScheme(sch)
+	Expect(err).NotTo(HaveOccurred())
+	err = rukpakv1alpha1.AddToScheme(sch)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = rukpakv1alpha1.AddToScheme(scheme.Scheme)
+	cl, err = client.New(cfg, client.Options{Scheme: sch})
 	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-	})
-	Expect(err).ToNot(HaveOccurred())
-
-	err = controllers.NewOperatorReconciler(
-		k8sManager.GetClient(),
-		k8sManager.GetScheme(),
-		resolution.NewOperatorResolver(k8sManager.GetClient(), resolution.HardcodedEntitySource),
-	).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	ctx, cancel = context.WithCancel(context.Background())
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
+	Expect(cl).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {
-	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
-})
-
-var _ = Describe("Reconcile Test", func() {
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
-
-	When("an Operator is created", func() {
-		var (
-			operator *operatorsv1alpha1.Operator
-			ctx      context.Context
-			opName   string
-			pkgName  string
-			err      error
-		)
-		BeforeEach(func() {
-			ctx = context.Background()
-			opName = fmt.Sprintf("operator-test-%s", rand.String(8))
-			pkgName = fmt.Sprintf("package-test-%s", rand.String(8))
-			operator = &operatorsv1alpha1.Operator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: opName,
-				},
-				Spec: operatorsv1alpha1.OperatorSpec{
-					PackageName: pkgName,
-				},
-			}
-			err = k8sClient.Create(ctx, operator)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-		AfterEach(func() {
-			err = k8sClient.Delete(ctx, operator)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-		It("has all Conditions created", func() {
-			op := &operatorsv1alpha1.Operator{}
-			opLookupKey := client.ObjectKey{Name: opName}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, opLookupKey, op)
-				if err != nil {
-					return false
-				}
-				return len(op.Status.Conditions) > 0
-			}, timeout, interval).Should(BeTrue())
-
-			// All defined condition Types MUST exist after reconciliation
-			conds := op.Status.Conditions
-			Expect(conds).To(Not(BeEmpty()))
-			Expect(conds).To(HaveLen(len(operatorutil.ConditionTypes)))
-			for _, t := range operatorutil.ConditionTypes {
-				Expect(apimeta.FindStatusCondition(conds, t)).To(Not(BeNil()))
-			}
-		})
-		It("has matching generations in Conditions", func() {
-			op := &operatorsv1alpha1.Operator{}
-
-			err = k8sClient.Get(ctx, client.ObjectKey{
-				Name: opName,
-			}, op)
-			Expect(err).To(Not(HaveOccurred()))
-
-			// The ObservedGeneration MUST match the resource generation after reconciliation
-			for _, c := range op.Status.Conditions {
-				Expect(c.ObservedGeneration).To(Equal(op.GetGeneration()))
-			}
-		})
-		It("has only pre-defined Reasons", func() {
-			op := &operatorsv1alpha1.Operator{}
-
-			err = k8sClient.Get(ctx, client.ObjectKey{
-				Name: opName,
-			}, op)
-			Expect(err).To(Not(HaveOccurred()))
-
-			// A given Reason MUST be in the list of ConditionReasons
-			for _, c := range op.Status.Conditions {
-				Expect(c.Reason).To(BeElementOf(operatorutil.ConditionReasons))
-			}
-		})
-	})
 })

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/operator-framework/rukpak v0.11.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
@@ -80,7 +81,6 @@ require (
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/internal/resolution/variable_sources/entity/bundle_entity_test.go
+++ b/internal/resolution/variable_sources/entity/bundle_entity_test.go
@@ -96,12 +96,12 @@ var _ = Describe("BundleEntity", func() {
 				{Group: "bar.io", Kind: "Bar", Version: "v1alpha1"},
 			}))
 		})
-		It("should return an error if the property is not found", func() {
+		It("should return nil if the property is not found", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{})
 			bundleEntity := olmentity.NewBundleEntity(entity)
 			providedGvks, err := bundleEntity.ProvidedGVKs()
+			Expect(err).ToNot(HaveOccurred())
 			Expect(providedGvks).To(BeNil())
-			Expect(err.Error()).To(Equal("error determining bundle provided gvks for entity 'operatorhub/prometheus/0.14.0': property 'olm.gvk' not found"))
 		})
 		It("should return error if the property is malformed", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{
@@ -127,12 +127,12 @@ var _ = Describe("BundleEntity", func() {
 				{Group: "bar.io", Kind: "Bar", Version: "v1alpha1"},
 			}))
 		})
-		It("should return an error if the property is not found", func() {
+		It("should return nil if the property is not found", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{})
 			bundleEntity := olmentity.NewBundleEntity(entity)
 			requiredGvks, err := bundleEntity.RequiredGVKs()
+			Expect(err).ToNot(HaveOccurred())
 			Expect(requiredGvks).To(BeNil())
-			Expect(err.Error()).To(Equal("error determining bundle required gvks for entity 'operatorhub/prometheus/0.14.0': property 'olm.gvk.required' not found"))
 		})
 		It("should return error if the property is malformed", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{
@@ -158,12 +158,12 @@ var _ = Describe("BundleEntity", func() {
 				{PackageRequired: property.PackageRequired{PackageName: "packageB", VersionRange: ">0.5.0 <0.8.6"}},
 			}))
 		})
-		It("should return an error if the property is not found", func() {
+		It("should return nil if the property is not found", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{})
 			bundleEntity := olmentity.NewBundleEntity(entity)
 			requiredPackages, err := bundleEntity.RequiredPackages()
+			Expect(err).ToNot(HaveOccurred())
 			Expect(requiredPackages).To(BeNil())
-			Expect(err.Error()).To(Equal("error determining bundle required packages for entity 'operatorhub/prometheus/0.14.0': property 'olm.package.required' not found"))
 		})
 		It("should return error if the property is malformed", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{

--- a/main.go
+++ b/main.go
@@ -20,13 +20,11 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -34,8 +32,6 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/controllers"
 	"github.com/operator-framework/operator-controller/internal/resolution"
-	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -92,11 +88,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controllers.NewOperatorReconciler(
-		mgr.GetClient(),
-		mgr.GetScheme(),
-		resolution.NewOperatorResolver(mgr.GetClient(), resolution.HardcodedEntitySource),
-	).SetupWithManager(mgr); err != nil {
+	if err = (&controllers.OperatorReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Resolver: resolution.NewOperatorResolver(mgr.GetClient(), resolution.HardcodedEntitySource),
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Operator")
 		os.Exit(1)
 	}


### PR DESCRIPTION
I noticed y'all made some great progress this week, and got the itch to stay in the loop and pitch in. This PR is a whole bunch of changes all wrapped up together, so I have no illusions about it being merged as is. I'm curious what folks think!

Main bullet points are:
- [x] remove unnecessary RBAC rules for create/update/patch/delete Operator
  objects. this leaves only get, list, watch, update status, and update
  finalizers. (#116)
- [x] use server-side apply to manage bundle deployments (#114)
- [x] unit test refactoring (#115)
   - move reconciler unit tests to a separate file from the suite. if we add other controllers in the future, we'll likely want separate test files for each controller.
   - export the reconciler's resolver field to make it easy to swap out for tests (also add a test entity source)
   - remove the manager setup in the unit tests. this ensures we can test individual runs of the Reconcile function, which is good for two reasons: 
       1. no need to use `Eventually`, no polling, etc. so it speeds up the tests 
       2. it ensures that we fully understand the individual transitions that occur from a beginning state to an end state when multiple Reconcile calls are necessary. (e.g. r1: create BD, r2: update Op based on BD status change to unpacking, r3: update Op again based on BD status change to installed successfully)
   - added more unit tests to increase code coverage.
   - moved conditions and reasons checks to invariants that run after every test of reconciling an existing Operator object.
- [x] decrease nesting in main reconcile code by setting conditions and returning early when handling unexpected errors. (#118)
- [ ] make certain bundle entity properties optional. not all bundles will provide/require GVKs or require other packages. lookups for those entities should return nil slices rather than an error.

EDIT: I split each of these main things out into separate PRs now that it seems like folks are generally onboard.