### PR TITLE
Use server-side apply to ensure the desired bundle deployments exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/operator-framework/rukpak v0.11.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
@@ -80,7 +81,6 @@ require (
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
One facet of #107

Server-side apply is the preferred way to manage owned resources on a cluster. With forced ownership of the fields we care about, it give the operator controller the ability to always ensure the desired fields are set, while also allowing other controllers to manipulate fields we don't care about and that are irrelevant to the core functionality of the operator controller.