### PR TITLE
reduce RBAC permissions of operator-controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,12 +21,8 @@ rules:
   resources:
   - operators
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - operators.operatorframework.io

--- a/controllers/operator_controller.go
+++ b/controllers/operator_controller.go
@@ -51,7 +51,7 @@ func NewOperatorReconciler(c client.Client, s *runtime.Scheme, r *resolution.Ope
 	}
 }
 
-//+kubebuilder:rbac:groups=operators.operatorframework.io,resources=operators,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=operators.operatorframework.io,resources=operators,verbs=get;list;watch
 //+kubebuilder:rbac:groups=operators.operatorframework.io,resources=operators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=operators.operatorframework.io,resources=operators/finalizers,verbs=update
 


### PR DESCRIPTION
Another facet of #107 

operator-controller does not (and should not ever) need permission to create/update/patch/delete Operator objects. It needs:
- write on Operator status
- write on Operator finalizers
- read on all other operator fields