### PR TITLE
Makefile: remove unused ENVTEST_K8S_VERSION variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ IMG?=$(IMAGE_REPO):$(IMAGE_TAG)
 OPERATOR_CONTROLLER_NAMESPACE ?= operator-controller-system
 KIND_CLUSTER_NAME ?= operator-controller
 
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
It looks like this should have been removed as part of the fix for #83, which seems to have already made it in in #103 