### PR TITLE
Reduce reconcile complexity

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 )
 
 // OperatorSpec defines the desired state of Operator
@@ -32,9 +33,10 @@ const (
 	// TODO(user): add more Types, here and into init()
 	TypeReady = "Ready"
 
-	ReasonNotImplemented      = "NotImplemented"
-	ReasonResolutionFailed    = "ResolutionFailed"
-	ReasonResolutionSucceeded = "ResolutionSucceeded"
+	ReasonResolutionSucceeded    = "ResolutionSucceeded"
+	ReasonResolutionFailed       = "ResolutionFailed"
+	ReasonBundleLookupFailed     = "BundleLookupFailed"
+	ReasonBundleDeploymentFailed = "BundleDeploymentFailed"
 )
 
 func init() {
@@ -44,7 +46,10 @@ func init() {
 	)
 	// TODO(user): add Reasons from above
 	operatorutil.ConditionReasons = append(operatorutil.ConditionReasons,
-		ReasonNotImplemented, ReasonResolutionSucceeded, ReasonResolutionFailed,
+		ReasonResolutionSucceeded,
+		ReasonResolutionFailed,
+		ReasonBundleLookupFailed,
+		ReasonBundleDeploymentFailed,
 	)
 }
 


### PR DESCRIPTION
This PR reduces the [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) of the `reconcile` method of the operator controller from 8 to 5 (as measured by gocyclo), mainly by factoring out the bundle entity lookup from the solution into a separate function.

It also ensures all code paths set the `Ready` condition, which required two new reasons (`BundleLookupFailed` and `BundleDeploymentFailed`)

This is built on top of #115, so
/hold
until that has merged and we've rebased this one.