### PR TITLE
Operator Controller Release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore build and test binaries.
-bin/
-testbin/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: "go.mod"
+
+    - name: Docker Login
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Set the release related variables
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          # Release tags.
+          echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--rm-dist" >> $GITHUB_ENV
+          echo DISABLE_RELEASE_PIPELINE=false >> $GITHUB_ENV
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          # Branch build.
+          echo IMAGE_TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--rm-dist --skip-validate" >> $GITHUB_ENV
+        elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          # PR build.
+          echo IMAGE_TAG="pr-$(echo "${GITHUB_REF}" | sed -E 's|refs/pull/([^/]+)/?.*|\1|')" >> $GITHUB_ENV
+        else
+          echo IMAGE_TAG="$(git describe --tags --always)" >> $GITHUB_ENV
+        fi
+
+    - name: Generate the operator-controller release manifests
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        make quickstart VERSION=${GITHUB_REF#refs/tags/}
+
+    - name: Run goreleaser
+      run: make release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+bin/*
 testbin/*
 Dockerfile.cross
 
@@ -14,6 +14,11 @@ Dockerfile.cross
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Release output
+dist/**
+.goreleaser.yml
+operator-controller.yaml
 
 # Kubernetes Generated files - skip generated files, except for vendored files
 
@@ -24,3 +29,6 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+
+# TODO dfranz remove this line and the bin folder when tools binaries are moved to their own folder
+!bin/.dockerignore

--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -1,0 +1,50 @@
+env:
+- GOPROXY=https://proxy.golang.org|direct
+- GO111MODULE=on
+- CGO_ENABLED=0
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+builds:
+  - id: operator-controller
+    main: ./
+    binary: bin/manager
+    tags: $GO_BUILD_TAGS
+    goos:
+    - linux
+    ldflags:
+    - -X main.Version={{ .Version }}
+dockers:
+- image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+  dockerfile: Dockerfile
+  goos: linux
+docker_manifests:
+- name_template: "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+  image_templates:
+  - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  use: github-native
+  skip: $DISABLE_RELEASE_PIPELINE
+release:
+  disable: $DISABLE_RELEASE_PIPELINE
+  extra_files:
+  - glob: 'operator-controller.yaml'
+  header: |
+    ## Installation
+
+    ```bash
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{{ .Env.CERT_MGR_VERSION }}/cert-manager.yaml
+    kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
+    kubectl apply -f https://github.com/operator-framework/rukpak/releases/latest/download/rukpak.yaml
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/core --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/helm-provisioner --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/rukpak-webhooks --timeout=60s
+    kubectl apply -f https://github.com/operator-framework/operator-controller/releases/download/{{ .Tag }}/operator-controller.yaml
+    kubectl wait --for=condition=Available --namespace=operator-controller-system deployment/operator-controller-controller-manager --timeout=60s
+    ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,14 @@
-# Build the manager binary
-FROM golang:1.19 as builder
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-COPY internal/ internal/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Note: This dockerfile does not build the binaries 
+# required and is intended to be built only with the
+# 'make build' or 'make release' targets.
 FROM gcr.io/distroless/static:nonroot
+
 WORKDIR /
-COPY --from=builder /workspace/manager .
+
+COPY manager manager
+
+EXPOSE 8080
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/bin/.dockerignore
+++ b/bin/.dockerignore
@@ -1,0 +1,8 @@
+# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Ignore tools binaries
+# TODO dfranz: We don't need this file anymore once we move the tool binaries out.
+controller-gen
+ginkgo
+goreleaser
+kind
+kustomize


### PR DESCRIPTION
Adds a release github action and implements goreleaser, borrowing heavily from rukpak but stripped down a bit.

See my fork here for an example release output: https://github.com/dtfranz/operator-controller/releases/tag/v0.0.2

Some of the additional build targets found in rukpak have been stripped out to keep this smaller.

Addresses #132 and #109