### PR TITLE
Add .spec.version

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -29,8 +29,8 @@ type OperatorSpec struct {
 	PackageName string `json:"packageName"`
 
 	//+kubebuilder:validation:MaxLength:=64
-	//+kubebuilder:validation:Pattern:=^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
-	//+kubebuilder:optional
+	//+kubebuilder:validation:Pattern=^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
+	//+kubebuilder:Optional
 	// Version is an optional is semver constraint on the package version. If not specified, the latest version available of the package will be installed.
 	// If specified, the specific version of the package will be installed so long as it is available in any of the content sources available.
 	// Examples:
@@ -51,6 +51,7 @@ const (
 	ReasonBundleLookupFailed        = "BundleLookupFailed"
 	ReasonInstallationFailed        = "InstallationFailed"
 	ReasonInstallationStatusUnknown = "InstallationStatusUnknown"
+	ReasonInvalidSpec               = "InvalidSpec"
 )
 
 func init() {
@@ -65,6 +66,7 @@ func init() {
 		ReasonBundleLookupFailed,
 		ReasonInstallationFailed,
 		ReasonInstallationStatusUnknown,
+		ReasonInvalidSpec,
 	)
 }
 

--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -31,12 +31,9 @@ type OperatorSpec struct {
 	//+kubebuilder:validation:MaxLength:=64
 	//+kubebuilder:validation:Pattern=^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
 	//+kubebuilder:Optional
-	// Version is an optional is semver constraint on the package version. If not specified, the latest version available of the package will be installed.
+	// Version is an optional semver constraint on the package version. If not specified, the latest version available of the package will be installed.
 	// If specified, the specific version of the package will be installed so long as it is available in any of the content sources available.
-	// Examples:
-	//  - 1.2.3
-	//  - 1.0.0-alpha
-	//  - 1.0.0-rc.1
+	// Examples: 1.2.3, 1.0.0-alpha, 1.0.0-rc.1
 	//
 	// For more information on semver, please see https://semver.org/
 	Version string `json:"version,omitempty"`

--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -31,6 +31,14 @@ type OperatorSpec struct {
 	//+kubebuilder:validation:MaxLength:=64
 	//+kubebuilder:validation:Pattern:=^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
 	//+kubebuilder:optional
+	// Version is an optional is semver constraint on the package version. If not specified, the latest version available of the package will be installed.
+	// If specified, the specific version of the package will be installed so long as it is available in any of the content sources available.
+	// Examples:
+	//  - 1.2.3
+	//  - 1.0.0-alpha
+	//  - 1.0.0-rc.1
+	//
+	// For more information on semver, please see https://semver.org/
 	Version string `json:"version,omitempty"`
 }
 

--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -27,6 +27,11 @@ type OperatorSpec struct {
 	//+kubebuilder:validation:MaxLength:=48
 	//+kubebuilder:validation:Pattern:=^[a-z0-9]+(-[a-z0-9]+)*$
 	PackageName string `json:"packageName"`
+
+	//+kubebuilder:validation:MaxLength:=64
+	//+kubebuilder:validation:Pattern:=^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
+	//+kubebuilder:optional
+	Version string `json:"version,omitempty"`
 }
 
 const (

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -39,6 +39,10 @@ spec:
                 maxLength: 48
                 pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
                 type: string
+              version:
+                maxLength: 64
+                pattern: ^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
+                type: string
             required:
             - packageName
             type: object

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -47,7 +47,7 @@ spec:
                   sources available. Examples: - 1.2.3 - 1.0.0-alpha - 1.0.0-rc.1
                   \n For more information on semver, please see https://semver.org/"
                 maxLength: 64
-                pattern: ^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
+                pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
                 type: string
             required:
             - packageName

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -40,12 +40,12 @@ spec:
                 pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
                 type: string
               version:
-                description: "Version is an optional is semver constraint on the package
+                description: "Version is an optional semver constraint on the package
                   version. If not specified, the latest version available of the package
                   will be installed. If specified, the specific version of the package
                   will be installed so long as it is available in any of the content
-                  sources available. Examples: - 1.2.3 - 1.0.0-alpha - 1.0.0-rc.1
-                  \n For more information on semver, please see https://semver.org/"
+                  sources available. Examples: 1.2.3, 1.0.0-alpha, 1.0.0-rc.1 \n For
+                  more information on semver, please see https://semver.org/"
                 maxLength: 64
                 pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$
                 type: string

--- a/config/crd/bases/operators.operatorframework.io_operators.yaml
+++ b/config/crd/bases/operators.operatorframework.io_operators.yaml
@@ -40,6 +40,12 @@ spec:
                 pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
                 type: string
               version:
+                description: "Version is an optional is semver constraint on the package
+                  version. If not specified, the latest version available of the package
+                  will be installed. If specified, the specific version of the package
+                  will be installed so long as it is available in any of the content
+                  sources available. Examples: - 1.2.3 - 1.0.0-alpha - 1.0.0-rc.1
+                  \n For more information on semver, please see https://semver.org/"
                 maxLength: 64
                 pattern: ^(\|\||\s+)?([\s~^><=]*)v?(\d+)(\.(\d+))?(\.(\d+))?(\-(.+))?$
                 type: string

--- a/config/samples/operators_v1alpha1_operator.yaml
+++ b/config/samples/operators_v1alpha1_operator.yaml
@@ -11,4 +11,3 @@ metadata:
 spec:
   # TODO(user): Add fields here
   packageName: prometheus
-  version: 3.0.0

--- a/config/samples/operators_v1alpha1_operator.yaml
+++ b/config/samples/operators_v1alpha1_operator.yaml
@@ -11,3 +11,4 @@ metadata:
 spec:
   # TODO(user): Add fields here
   packageName: prometheus
+  version: 3.0.0

--- a/controllers/admission_test.go
+++ b/controllers/admission_test.go
@@ -1,0 +1,61 @@
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func operator(spec operatorsv1alpha1.OperatorSpec) *operatorsv1alpha1.Operator {
+	return &operatorsv1alpha1.Operator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-operator",
+		},
+		Spec: spec,
+	}
+}
+
+var _ = Describe("Operator Spec Validations", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+	})
+	AfterEach(func() {
+		cancel()
+	})
+	It("should fail if the spec is empty", func() {
+		err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{}))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.packageName in body should match '^[a-z0-9]+(-[a-z0-9]+)*$'"))
+	})
+	It("should fail if package name length is greater than 48 characters", func() {
+		err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{
+			PackageName: "this-is-a-really-long-package-name-that-is-greater-than-48-characters",
+		}))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Too long: may not be longer than 48"))
+	})
+	It("should fail if version is valid semver but length is greater than 64 characters", func() {
+		err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{
+			PackageName: "package",
+			Version:     "1234567890.1234567890.12345678901234567890123456789012345678901234",
+		}))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Too long: may not be longer than 64"))
+	})
+	It("should fail if an invalid semver range is given", func() {
+		err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{
+			PackageName: "package",
+			Version:     "this-is-not-a-valid-semver",
+		}))
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.version in body should match '^(\\|\\||\\s+)?([\\s~^><=]*)v?(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\-(.+))?$"))
+	})
+})

--- a/controllers/admission_test.go
+++ b/controllers/admission_test.go
@@ -49,13 +49,26 @@ var _ = Describe("Operator Spec Validations", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("Too long: may not be longer than 64"))
 	})
-	It("should fail if an invalid semver range is given", func() {
-		err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{
-			PackageName: "package",
-			Version:     "this-is-not-a-valid-semver",
-		}))
+	It("should fail if an invalid semver is given", func() {
+		invalidSemvers := []string{
+			"1.2.3.4",
+			"1.02.3",
+			"1.2.03",
+			"1.2.3-beta!",
+			"1.2.3.alpha",
+			"1..2.3",
+			"1.2.3-pre+bad_metadata",
+			"1.2.-3",
+			".1.2.3",
+		}
+		for _, invalidSemver := range invalidSemvers {
+			err := cl.Create(ctx, operator(operatorsv1alpha1.OperatorSpec{
+				PackageName: "package",
+				Version:     invalidSemver,
+			}))
 
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("spec.version in body should match '^(\\|\\||\\s+)?([\\s~^><=]*)v?(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\-(.+))?$"))
+			Expect(err).To(HaveOccurred(), "expected error for invalid semver %q", invalidSemver)
+			Expect(err.Error()).To(ContainSubstring("spec.version in body should match '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?$"))
+		}
 	})
 })

--- a/controllers/admission_test.go
+++ b/controllers/admission_test.go
@@ -5,8 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
 
 func operator(spec operatorsv1alpha1.OperatorSpec) *operatorsv1alpha1.Operator {
@@ -68,7 +69,7 @@ var _ = Describe("Operator Spec Validations", func() {
 			}))
 
 			Expect(err).To(HaveOccurred(), "expected error for invalid semver %q", invalidSemver)
-			Expect(err.Error()).To(ContainSubstring("spec.version in body should match '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?$"))
+			Expect(err.Error()).To(ContainSubstring("spec.version in body should match '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?$'"))
 		}
 	})
 })

--- a/controllers/operator_controller.go
+++ b/controllers/operator_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/deppy/pkg/deppy/solver"
-	"github.com/operator-framework/operator-controller/controllers/validators"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -34,6 +33,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/operator-framework/operator-controller/controllers/validators"
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/resolution"

--- a/controllers/operator_controller_test.go
+++ b/controllers/operator_controller_test.go
@@ -80,16 +80,16 @@ var _ = Describe("Operator Controller Test", func() {
 				Expect(cond.Message).To(Equal(fmt.Sprintf("package '%s' not found", pkgName)))
 			})
 		})
-		When("the operator specifies a version range for which there are no bundles", func() {
+		When("the operator specifies a version that does not exist", func() {
 			var pkgName string
 			BeforeEach(func() {
 				By("initializing cluster state")
-				pkgName = fmt.Sprintf("non-existent-%s", rand.String(6))
+				pkgName = fmt.Sprintf("exists-%s", rand.String(6))
 				operator = &operatorsv1alpha1.Operator{
 					ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
 					Spec: operatorsv1alpha1.OperatorSpec{
 						PackageName: pkgName,
-						Version:     ">=0.50.0",
+						Version:     "0.50.0", // this version of the package does not exist
 					},
 				}
 				err := cl.Create(ctx, operator)
@@ -99,7 +99,7 @@ var _ = Describe("Operator Controller Test", func() {
 				By("running reconcile")
 				res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
 				Expect(res).To(Equal(ctrl.Result{}))
-				Expect(err).To(MatchError(fmt.Sprintf("package '%s' in version range '>=0.50.0' not found", pkgName)))
+				Expect(err).To(MatchError(fmt.Sprintf("package '%s' at version '0.50.0' not found", pkgName)))
 
 				By("fetching updated operator after reconcile")
 				Expect(cl.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
@@ -109,7 +109,7 @@ var _ = Describe("Operator Controller Test", func() {
 				Expect(cond).NotTo(BeNil())
 				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 				Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonResolutionFailed))
-				Expect(cond.Message).To(Equal(fmt.Sprintf("package '%s' in version range '>=0.50.0' not found", pkgName)))
+				Expect(cond.Message).To(Equal(fmt.Sprintf("package '%s' at version '0.50.0' not found", pkgName)))
 			})
 		})
 		When("the operator specifies a valid available package", func() {

--- a/controllers/operator_controller_test.go
+++ b/controllers/operator_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/controllers"
@@ -598,6 +599,54 @@ var _ = Describe("Operator Controller Test", func() {
 
 			err := cl.Delete(ctx, operator)
 			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+	When("an invalid semver is provided that bypasses the regex validation", func() {
+		var (
+			operator   *operatorsv1alpha1.Operator
+			opKey      types.NamespacedName
+			pkgName    string
+			fakeClient client.Client
+		)
+		BeforeEach(func() {
+			opKey = types.NamespacedName{Name: fmt.Sprintf("operator-validation-test-%s", rand.String(8))}
+
+			By("injecting creating a client with the bad operator CR")
+			pkgName = fmt.Sprintf("exists-%s", rand.String(6))
+			operator = &operatorsv1alpha1.Operator{
+				ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
+				Spec: operatorsv1alpha1.OperatorSpec{
+					PackageName: pkgName,
+					Version:     "1.2.3-123abc_def", // bad semver that matches the regex on the CR validation
+				},
+			}
+
+			// this bypasses client/server-side CR validation and allows us to test the reconciler's validation
+			fakeClient = fake.NewClientBuilder().WithScheme(sch).WithObjects(operator).Build()
+
+			By("changing the reconciler client to the fake client")
+			reconciler.Client = fakeClient
+		})
+		AfterEach(func() {
+			By("changing the reconciler client back to the real client")
+			reconciler.Client = cl
+		})
+
+		It("should add an invalid spec condition and *not* re-enqueue for reconciliation", func() {
+			By("running reconcile")
+			res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: opKey})
+			Expect(res).To(Equal(ctrl.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+
+			By("fetching updated operator after reconcile")
+			Expect(fakeClient.Get(ctx, opKey, operator)).NotTo(HaveOccurred())
+
+			By("checking the expected conditions")
+			cond := apimeta.FindStatusCondition(operator.Status.Conditions, operatorsv1alpha1.TypeReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(operatorsv1alpha1.ReasonInvalidSpec))
+			Expect(cond.Message).To(Equal("invalid .spec.version: Invalid character(s) found in prerelease \"123abc_def\""))
 		})
 	})
 })

--- a/controllers/validators/validators.go
+++ b/controllers/validators/validators.go
@@ -1,0 +1,37 @@
+package validators
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+)
+
+type operatorCRValidatorFunc func(operator *operatorsv1alpha1.Operator) error
+
+// validateSemver validates that the operator's version is a valid SemVer.
+// this validation should already be happening at the CRD level. But, it depends
+// on a regex that could possibly fail to validate a valid SemVer. This is added as an
+// extra measure to ensure a valid spec before the CR is processed for resolution
+func validateSemver(operator *operatorsv1alpha1.Operator) error {
+	if operator.Spec.Version == "" {
+		return nil
+	}
+	if _, err := semver.Parse(operator.Spec.Version); err != nil {
+		return fmt.Errorf("invalid .spec.version: %w", err)
+	}
+	return nil
+}
+
+// ValidateOperatorSpec validates the operator spec, e.g. ensuring that .spec.version, if provided, is a valid SemVer
+func ValidateOperatorSpec(operator *operatorsv1alpha1.Operator) error {
+	validators := []operatorCRValidatorFunc{
+		validateSemver,
+	}
+	for _, validator := range validators {
+		if err := validator(operator); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/validators/validators.go
+++ b/controllers/validators/validators.go
@@ -29,6 +29,11 @@ func ValidateOperatorSpec(operator *operatorsv1alpha1.Operator) error {
 	validators := []operatorCRValidatorFunc{
 		validateSemver,
 	}
+
+	// TODO: currently we only have a single validator, but more will likely be added in the future
+	//  we need to make a decision on whether we want to run all validators or stop at the first error. If the the former,
+	//  we should consider how to present this to the user in a way that is easy to understand and fix.
+	//  this issue is tracked here: https://github.com/operator-framework/operator-controller/issues/167
 	for _, validator := range validators {
 		if err := validator(operator); err != nil {
 			return err

--- a/controllers/validators/validators.go
+++ b/controllers/validators/validators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
 

--- a/controllers/validators/validators_suite_test.go
+++ b/controllers/validators/validators_suite_test.go
@@ -1,0 +1,13 @@
+package validators
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidators(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validators Suite")
+}

--- a/controllers/validators/validators_test.go
+++ b/controllers/validators/validators_test.go
@@ -1,0 +1,62 @@
+package validators_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/controllers/validators"
+)
+
+var _ = Describe("Validators", func() {
+	Describe("ValidateOperatorSpec", func() {
+		It("should not return an error for valid SemVer", func() {
+			operator := &v1alpha1.Operator{
+				Spec: v1alpha1.OperatorSpec{
+					Version: "1.2.3",
+				},
+			}
+			err := validators.ValidateOperatorSpec(operator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error for invalid SemVer", func() {
+			operator := &v1alpha1.Operator{
+				Spec: v1alpha1.OperatorSpec{
+					Version: "invalid-semver",
+				},
+			}
+			err := validators.ValidateOperatorSpec(operator)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return an error for empty SemVer", func() {
+			operator := &v1alpha1.Operator{
+				Spec: v1alpha1.OperatorSpec{
+					Version: "",
+				},
+			}
+			err := validators.ValidateOperatorSpec(operator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not return an error for valid SemVer with pre-release and metadata", func() {
+			operator := &v1alpha1.Operator{
+				Spec: v1alpha1.OperatorSpec{
+					Version: "1.2.3-alpha.1+metadata",
+				},
+			}
+			err := validators.ValidateOperatorSpec(operator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not return an error for valid SemVer with pre-release", func() {
+			operator := &v1alpha1.Operator{
+				Spec: v1alpha1.OperatorSpec{
+					Version: "1.2.3-alpha-beta",
+				},
+			}
+			err := validators.ValidateOperatorSpec(operator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/controllers/validators/validators_test.go
+++ b/controllers/validators/validators_test.go
@@ -3,6 +3,7 @@ package validators_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/controllers/validators"
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/operator-framework/deppy v0.0.0-20230125110717-dc02e928470f
 	github.com/operator-framework/operator-registry v1.26.2
 	github.com/operator-framework/rukpak v0.11.0
+	go.uber.org/zap v1.21.0
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	google.golang.org/grpc v1.47.0
 	k8s.io/api v0.25.0
@@ -70,7 +71,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect

--- a/internal/resolution/variable_sources/olm/olm.go
+++ b/internal/resolution/variable_sources/olm/olm.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
-
+	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/bundles_and_dependencies"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/crd_constraints"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/required_package"
@@ -14,12 +14,12 @@ import (
 var _ input.VariableSource = &OLMVariableSource{}
 
 type OLMVariableSource struct {
-	packageNames []string
+	operators []operatorsv1alpha1.Operator
 }
 
-func NewOLMVariableSource(packageNames ...string) *OLMVariableSource {
+func NewOLMVariableSource(operators ...operatorsv1alpha1.Operator) *OLMVariableSource {
 	return &OLMVariableSource{
-		packageNames: packageNames,
+		operators: operators,
 	}
 }
 
@@ -27,11 +27,23 @@ func (o *OLMVariableSource) GetVariables(ctx context.Context, entitySource input
 	var inputVariableSources []input.VariableSource
 
 	// build required package variable sources
-	for _, packageName := range o.packageNames {
-		inputVariableSources = append(inputVariableSources, required_package.NewRequiredPackage(packageName))
+	for _, operator := range o.operators {
+		rps, err := o.requiredPackageFromOperator(&operator)
+		if err != nil {
+			return nil, err
+		}
+		inputVariableSources = append(inputVariableSources, rps)
 	}
 
 	// build variable source pipeline
 	variableSource := crd_constraints.NewCRDUniquenessConstraintsVariableSource(bundles_and_dependencies.NewBundlesAndDepsVariableSource(inputVariableSources...))
 	return variableSource.GetVariables(ctx, entitySource)
+}
+
+func (o *OLMVariableSource) requiredPackageFromOperator(operator *operatorsv1alpha1.Operator) (*required_package.RequiredPackageVariableSource, error) {
+	var opts []required_package.RequiredPackageOption
+	if operator.Spec.Version != "" {
+		opts = append(opts, required_package.InVersionRange(operator.Spec.Version))
+	}
+	return required_package.NewRequiredPackage(operator.Spec.PackageName, opts...)
 }

--- a/internal/resolution/variable_sources/olm/olm.go
+++ b/internal/resolution/variable_sources/olm/olm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
+
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/bundles_and_dependencies"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/crd_constraints"

--- a/internal/resolution/variable_sources/required_package/required_package.go
+++ b/internal/resolution/variable_sources/required_package/required_package.go
@@ -94,8 +94,12 @@ func (r *RequiredPackageVariableSource) GetVariables(ctx context.Context, entity
 }
 
 func (r *RequiredPackageVariableSource) notFoundError() error {
+	// TODO: update this error message when/if we decide to support version ranges as opposed to fixing the version
+	//  context: we originally wanted to support version ranges and take the highest version that satisfies the range
+	//  during the upstream call on the 2023-04-11 we decided to pin the version instead. But, we'll keep version range
+	//  support under the covers in case we decide to pivot back.
 	if r.versionRange != "" {
-		return fmt.Errorf("package '%s' in version range '%s' not found", r.packageName, r.versionRange)
+		return fmt.Errorf("package '%s' at version '%s' not found", r.packageName, r.versionRange)
 	}
 	return fmt.Errorf("package '%s' not found", r.packageName)
 }

--- a/internal/resolution/variable_sources/required_package/required_package.go
+++ b/internal/resolution/variable_sources/required_package/required_package.go
@@ -8,6 +8,7 @@ import (
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/constraint"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
+
 	olmentity "github.com/operator-framework/operator-controller/internal/resolution/variable_sources/entity"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/util/predicates"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/util/sort"

--- a/internal/resolution/variable_sources/required_package/required_package_test.go
+++ b/internal/resolution/variable_sources/required_package/required_package_test.go
@@ -125,7 +125,7 @@ var _ = Describe("RequiredPackageVariableSource", func() {
 	It("should filter by version range", func() {
 		// recreate source with version range option
 		var err error
-		rpvs, err = required_package.NewRequiredPackage(packageName, required_package.InVersionRange(">=1.0.0 !1.0.0 <3.0.0"))
+		rpvs, err = required_package.NewRequiredPackage(packageName, required_package.InVersionRange(">=1.0.0 !2.0.0 <3.0.0"))
 		Expect(err).NotTo(HaveOccurred())
 
 		variables, err := rpvs.GetVariables(context.TODO(), mockEntitySource)
@@ -137,8 +137,8 @@ var _ = Describe("RequiredPackageVariableSource", func() {
 
 		// ensure bundle entities are in version order (high to low)
 		Expect(reqPackageVar.BundleEntities()).To(Equal([]*olmentity.BundleEntity{
-			olmentity.NewBundleEntity(input.NewEntity("bundle-3", map[string]string{
-				property.TypePackage: `{"packageName": "test-package", "version": "2.0.0"}`,
+			olmentity.NewBundleEntity(input.NewEntity("bundle-1", map[string]string{
+				property.TypePackage: `{"packageName": "test-package", "version": "1.0.0"}`,
 				property.TypeChannel: `{"channelName":"stable","priority":0}`,
 			})),
 		}))

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	olmv0v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -65,7 +66,7 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.StacktraceLevel(zapcore.DPanicLevel)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
Adds `.spec.version` property to the Operator CRD. Some small changes were made to the resolver and top level variable sources to accommodate for this change and, hopefully, future ones. When reviewing, we should be asking ourselves how easy it would be to add the next property.

This PR also adds a small admissions unit test, so we can validate the OpenApi validation rules we apply using the kubebuilder annotations.

I've also nerfed the stackdumps down to panic. Otherwise we just get logs pointing to internal controller-runtime code...