### PR TITLE
GitHub Checkout Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
The goreleaser workflow is using actions/checkout@v2 and is giving a deprecation warning, this should fix that and also bring it in-line with the other actions.