### PR TITLE
Actions Updates

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,18 +14,9 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Run e2e tests
       run: |

--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -9,17 +9,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - uses: joelanford/go-apidiff@main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: "go.mod"
 
     - name: Docker Login
       if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -55,7 +55,8 @@ jobs:
     - name: Generate the operator-controller release manifests
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
-        make quickstart VERSION=${GITHUB_REF#refs/tags/}
+        echo VERSION="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        make quickstart
 
     - name: Run goreleaser
       run: make release

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,18 +14,9 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Run basic unit tests
       run: |


### PR DESCRIPTION
Brings a bunch of our github actions back up to date to remove more deprecation warnings and also removes an unnecessary caching step since actions/setup-go@v4 does this by default.

I'll carry these changes over to rukpak as well if they work correctly :)