### PR TITLE
Tools Bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ vendor
 *.dylib
 bin/*
 testbin/*
+/hack/tools/bin/*
 Dockerfile.cross
 
 # Test binary, build with `go test -c`
@@ -33,5 +34,3 @@ install.sh
 \#*\#
 .\#*
 
-# TODO dfranz remove this line and the bin folder when tools binaries are moved to their own folder
-!bin/.dockerignore

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ kind-cluster-cleanup: kind ## Delete the kind cluster
 
 .PHONY: build
 build: manifests generate fmt vet goreleaser ## Build manager binary using goreleaser for current GOOS and GOARCH.
+	mkdir -p bin
 	${GORELEASER} build ${GORELEASER_ARGS} --single-target -o bin/manager
 
 .PHONY: run
@@ -174,10 +175,12 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-##@ Build Dependencies
+################
+# Hack / Tools #
+################
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
+LOCALBIN ?= $(shell pwd)/hack/tools/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 

--- a/bin/.dockerignore
+++ b/bin/.dockerignore
@@ -1,8 +1,0 @@
-# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore tools binaries
-# TODO dfranz: We don't need this file anymore once we move the tool binaries out.
-controller-gen
-ginkgo
-goreleaser
-kind
-kustomize


### PR DESCRIPTION
Separates the tools binaries out to their own folder so we can stop doing funky stuff to ignore them when building the operator-controller image.