### PR TITLE
update .goreleaser.yaml to properly build multi-arch images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,21 +26,33 @@ dockers:
   dockerfile: Dockerfile
   goos: linux
   goarch: amd64
+  use: buildx
+  build_flag_templates:
+    - "--platform=linux/amd64"
 - image_templates:
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
   dockerfile: Dockerfile
   goos: linux
   goarch: arm64
+  use: buildx
+  build_flag_templates:
+    - "--platform=linux/arm64"
 - image_templates:
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
   dockerfile: Dockerfile
   goos: linux
   goarch: ppc64le
+  use: buildx
+  build_flag_templates:
+    - "--platform=linux/ppc64le"
 - image_templates:
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
   dockerfile: Dockerfile
   goos: linux
   goarch: s390x
+  use: buildx
+  build_flag_templates:
+    - "--platform=linux/s390x"
 docker_manifests:
 - name_template: "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
   image_templates:


### PR DESCRIPTION
The quay.io/operator-framework/operator-controller images have not been built properly for multiple architectures and all manifests show as being for the amd64 arch.

This PR updates the .goreleaser.yaml file to use buildx and explicitly sets the build platform with the --platform flag.

