### PR TITLE
Update RELEASE.md to point to correct url

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,4 +50,4 @@ git push upstream v1.2.0
 ```
 
 ### Post-Steps
-Once the tag has been pushed the release action should run automatically. You can view the progress [here](https://github.com/operator-framework/operator-lifecycle-manager/actions/workflows/goreleaser.yaml). When finished, the release should then be available on the [releases page](https://github.com/operator-framework/operator-controller/releases).
+Once the tag has been pushed the release action should run automatically. You can view the progress [here](https://github.com/operator-framework/operator-controller/actions/workflows/release.yaml). When finished, the release should then be available on the [releases page](https://github.com/operator-framework/operator-controller/releases).


### PR DESCRIPTION
Problem: The RELEASE.md file currently points to the operator-lifecycle-manager's release github action instead of the operator-controller's release github action.

Solution: Update the RELEASE.md document to points to the correct github action.
