### PR TITLE
Removes `util` package

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
 )
 
 // OperatorSpec defines the desired state of Operator
@@ -61,12 +61,12 @@ const (
 
 func init() {
 	// TODO(user): add Types from above
-	operatorutil.ConditionTypes = append(operatorutil.ConditionTypes,
+	conditionsets.ConditionTypes = append(conditionsets.ConditionTypes,
 		TypeInstalled,
 		TypeResolved,
 	)
 	// TODO(user): add Reasons from above
-	operatorutil.ConditionReasons = append(operatorutil.ConditionReasons,
+	conditionsets.ConditionReasons = append(conditionsets.ConditionReasons,
 		ReasonInstallationSucceeded,
 		ReasonResolutionFailed,
 		ReasonResolutionUnknown,

--- a/api/v1alpha1/operator_types_test.go
+++ b/api/v1alpha1/operator_types_test.go
@@ -12,30 +12,30 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
 )
 
 var _ = Describe("OperatorTypes", func() {
 	Describe("Condition Type and Reason constants", func() {
-		It("should register types in operatorutil.ConditionTypes", func() {
+		It("should register types in conditionsets.ConditionTypes", func() {
 			types, err := parseConstants("Type")
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, t := range types {
-				Expect(t).To(BeElementOf(operatorutil.ConditionTypes), "Append Type%s to operatorutil.ConditionTypes in this package's init function.", t)
+				Expect(t).To(BeElementOf(conditionsets.ConditionTypes), "Append Type%s to conditionsets.ConditionTypes in this package's init function.", t)
 			}
-			for _, t := range operatorutil.ConditionTypes {
+			for _, t := range conditionsets.ConditionTypes {
 				Expect(t).To(BeElementOf(types), "There must be a Type%[1]s string literal constant for type %[1]q (i.e. 'const Type%[1]s = %[1]q')", t)
 			}
 		})
-		It("should register reasons in operatorutil.ConditionReasons", func() {
+		It("should register reasons in conditionsets.ConditionReasons", func() {
 			reasons, err := parseConstants("Reason")
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, r := range reasons {
-				Expect(r).To(BeElementOf(operatorutil.ConditionReasons), "Append Reason%s to operatorutil.ConditionReasons in this package's init function.", r)
+				Expect(r).To(BeElementOf(conditionsets.ConditionReasons), "Append Reason%s to conditionsets.ConditionReasons in this package's init function.", r)
 			}
-			for _, r := range operatorutil.ConditionReasons {
+			for _, r := range conditionsets.ConditionReasons {
 				Expect(r).To(BeElementOf(reasons), "There must be a Reason%[1]s string literal constant for reason %[1]q (i.e. 'const Reason%[1]s = %[1]q')", r)
 			}
 		})

--- a/controllers/operator_controller_test.go
+++ b/controllers/operator_controller_test.go
@@ -20,8 +20,8 @@ import (
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/controllers"
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
 	"github.com/operator-framework/operator-controller/internal/resolution"
-	operatorutil "github.com/operator-framework/operator-controller/internal/util"
 )
 
 var _ = Describe("Operator Controller Test", func() {
@@ -1033,12 +1033,12 @@ func verifyConditionsInvariants(op *operatorsv1alpha1.Operator) {
 	// condition types for the Operator API. Every reconcile should always
 	// ensure every condition type's status/reason/message reflects the state
 	// read during _this_ reconcile call.
-	Expect(op.Status.Conditions).To(HaveLen(len(operatorutil.ConditionTypes)))
-	for _, t := range operatorutil.ConditionTypes {
+	Expect(op.Status.Conditions).To(HaveLen(len(conditionsets.ConditionTypes)))
+	for _, t := range conditionsets.ConditionTypes {
 		cond := apimeta.FindStatusCondition(op.Status.Conditions, t)
 		Expect(cond).To(Not(BeNil()))
 		Expect(cond.Status).NotTo(BeEmpty())
-		Expect(cond.Reason).To(BeElementOf(operatorutil.ConditionReasons))
+		Expect(cond.Reason).To(BeElementOf(conditionsets.ConditionReasons))
 		Expect(cond.ObservedGeneration).To(Equal(op.GetGeneration()))
 	}
 }

--- a/internal/conditionsets/conditionsets.go
+++ b/internal/conditionsets/conditionsets.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package conditionsets
 
 // ConditionTypes is the full set of Operator condition Types.
 // ConditionReasons is the full set of Operator condition Reasons.


### PR DESCRIPTION
# Description

`util` is too generic for a package name.

Let's try and avoid packages like `utils`, `common`, etc as packages like this tend to become dumping grounds.


## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
