### PR TITLE
Add additional prometheus support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ export XDG_DATA_HOME ?= /tmp/.local/share
 # bingo manages consistent tooling versions for things like kind, kustomize, etc.
 include .bingo/Variables.mk
 
+# Update these values to support kube-prometheus
+ifndef KUBE_PROMETHEUS_VERSION
+KUBE_PROMETHEUS_VERSION =
+endif
+export KUBE_PROMETHEUS_VERSION
+KUSTOMIZE_TARGET ?= config/default
+
 OPERATOR_CONTROLLER_NAMESPACE ?= operator-controller-system
 KIND_CLUSTER_NAME ?= operator-controller
 
@@ -225,7 +232,7 @@ release: $(GORELEASER) #EXHELP Runs goreleaser for the operator-controller. By d
 quickstart: export MANIFEST="https://github.com/operator-framework/operator-controller/releases/download/$(VERSION)/operator-controller.yaml"
 quickstart: $(KUSTOMIZE) manifests #EXHELP Generate the installation release manifests and scripts.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | sed "s/:devel/:$(VERSION)/g" > operator-controller.yaml
-	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh > install.sh
+	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST,$$KUBE_PROMETHEUS_VERSION' < scripts/install.tpl.sh > install.sh
 
 #SECTION Deployment
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ make manifests
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 
+### Additional Components
+
+To add support for Prometheus via `prometheus-operator/kube-prometheus`, add the following to the `make` command-line:
+* `KUSTOMIZE_TARGET=config/kube-prometheus` - add `ServiceMonitor`, `Role` and `RoleBinding` resources
+* `KUBE_PROMETHEUS_VERSION=v0.12.0` - install this version of `prometheus-operator/kube-prometheus`
+
+```sh
+make quickstart KUSTOMIZE_TARGET=config/kube-prometheus KUBE_PROMETHEUS_VERSION=v0.12.0
+
+make install KUSTOMIZE_TARGET=config/kube-prometheus KUBE_PROMETHEUS_VERSION=v0.12.0
+```
+
 ## License
 
 Copyright 2022-2023.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,6 +24,8 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+# This adds custom resources for use by Prometheus, this is a bit of a chicken-and-egg thing, as the prometheus operator
+# might be managed by operator-controller!
 #- ../prometheus
 
 patches:

--- a/config/kube-prometheus/kustomization.yaml
+++ b/config/kube-prometheus/kustomization.yaml
@@ -1,0 +1,9 @@
+# Using this file as a target for kustomize will install resources for use with
+# prometheus-operator/kube-promethus, and possibly other installations of prometheus
+
+# Adds namespace to all resources.
+namespace: operator-controller-system
+
+resources:
+- ../default
+- ../prometheus

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - monitor.yaml
+- role.yaml
+- rolebinding.yaml

--- a/config/prometheus/role.yaml
+++ b/config/prometheus/role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/prometheus/rolebinding.yaml
+++ b/config/prometheus/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -12,6 +12,7 @@ fi
 catalogd_version=$CATALOGD_VERSION
 cert_mgr_version=$CERT_MGR_VERSION
 rukpak_version=$RUKPAK_VERSION
+kube_prometheus_version=$KUBE_PROMETHEUS_VERSION
 
 if [[ -z "$catalogd_version" || -z "$cert_mgr_version" || -z "$rukpak_version" ]]; then
     err="Error: Missing component version(s) for: "
@@ -23,7 +24,8 @@ if [[ -z "$catalogd_version" || -z "$cert_mgr_version" || -z "$rukpak_version" ]
     fi 
     if [[ -z "$rukpak_version" ]]; then
         err+="rukpak "
-    fi 
+    fi
+    # We're ok with not installing kube-prometheus
     echo "$err"
     exit 1
 fi
@@ -36,16 +38,45 @@ function kubectl_wait() {
     kubectl wait --for=condition=Available --namespace="${namespace}" "${runtime}" --timeout="${timeout}"
 }
 
+function get_git_repo() {
+    local repo=$1
+    local ver=$2
+    local dest=$3
+    if [[ -d "${dest}" ]]; then
+        local cur=$(git -C ${dest} symbolic-ref -q --short HEAD)
+        cur=${cur:-$(git -C ${dest} describe --tags --exact-match 2>/dev/null)}
+        cur=${cur:-HEAD}
+        if [[ "${cur}" != "${ver}" ]]; then
+            rm -rf ${dest}
+        fi
+    fi
+    if [[ ! -d "${dest}" ]]; then
+        git clone "${repo}" "${dest}" --branch "${ver}" --depth 1 --quiet 2>/dev/null
+    fi
+}
+
+echo -e "\nInstalling cert-manager ${cert_mgr_version}\n"
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 
+echo -e "\nInstalling rukpak ${rukpak_version}\n"
 kubectl apply -f "https://github.com/operator-framework/rukpak/releases/download/${rukpak_version}/rukpak.yaml"
 kubectl_wait "rukpak-system" "deployment/core" "60s"
 kubectl_wait "rukpak-system" "deployment/helm-provisioner" "60s"
 kubectl_wait "rukpak-system" "deployment/rukpak-webhooks" "60s"
 
+if [[ -n "$kube_prometheus_version" ]]; then
+    echo -e "\nInstalling kube-prometheus ${kube_prometheus_version}\n"
+    get_git_repo "https://github.com/prometheus-operator/kube-prometheus.git" "${kube_prometheus_version}" bin/kube-prometheus
+    kubectl apply --server-side -f bin/kube-prometheus/manifests/setup
+    kubectl wait --for condition=Established --all CustomResourceDefinition --namespace=monitoring --timeout=60s
+    kubectl apply -f bin/kube-prometheus/manifests/
+fi
+
+echo -e "\nInstalling catalogd ${catalogd_version}\n"
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
 kubectl_wait "catalogd-system" "deployment/catalogd-controller-manager" "60s"
 
+echo -e "\nInstalling operator-controller\n"
 kubectl apply -f "${operator_controller_manifest}"
 kubectl_wait "operator-controller-system" "deployment/operator-controller-controller-manager" "60s"


### PR DESCRIPTION
Kustomize the necessary role/rolebinding to work with kube-prometheus

# Description

Installs kube-promethus when certain variables are set during the build.
Update README.md with this information.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
