### PR TITLE
Update Makefile targets for consistency

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,29 @@
+name: deploy-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  deploy-basic:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - name: Run basic deploy/undeploy
+      run: |
+        make kind-cluster
+        make deploy
+        kubectl get crds operators.operators.operatorframework.io
+        kubectl get ns operator-controller-system
+        make undeploy
+        ! kubectl get ns operator-controller-system
+        ! kubectl get crds operators.operators.operatorframework.io

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
         # after failing tests.
         # With -k flag make will continue the build, but will return non-zero
         # exit code in case of any errors.
-        make -k e2e
+        make -k test-e2e
 
     - uses: codecov/codecov-action@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -43,102 +43,112 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .DEFAULT_GOAL := build
 
-##@ General
+#SECTION General
 
 # The help target prints out all targets with their descriptions organized
-# beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
+# beneath their categories. The categories are represented by '#SECTION' and the
+# target descriptions by '#HELP' or '#EXHELP'. The awk commands is responsible for reading the
 # entire set of makefiles included in this invocation, looking for lines of the
-# file as xyz: ## something, and then pretty-format the target and help. Then,
-# if there's a line with ##@ something, that gets pretty-printed as a category.
+# file as xyz: #HELP something, and then pretty-format the target and help. Then,
+# if there's a line with #SECTION something, that gets pretty-printed as a category.
 # More info on the usage of ANSI control characters for terminal formatting:
 # https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
+# The extended-help target uses '#EXHELP' as the delineator.
 
 .PHONY: help
-help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+help: #HELP Display essential help.
+	@awk 'BEGIN {FS = ":[^#]*#HELP"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\n"} /^[a-zA-Z_0-9-]+:.*#HELP / { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } ' $(MAKEFILE_LIST)
 
-##@ Development
+.PHONY: help-extended
+help-extended: #HELP Display extended help.
+	@awk 'BEGIN {FS = ":.*#(EX)?HELP"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*#(EX)?HELP / { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^#SECTION / { printf "\n\033[1m%s\033[0m\n", substr($$0, 10) } ' $(MAKEFILE_LIST)
+
+#SECTION Development
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Run golangci linter.
+lint: $(GOLANGCI_LINT) #HELP Run golangci linter.
 	$(GOLANGCI_LINT) run --build-tags $(GO_BUILD_TAGS) $(GOLANGCI_LINT_ARGS)
 
 .PHONY: tidy
-tidy: ## Update dependencies.
+tidy: #HELP Update dependencies.
 	$(Q)go mod tidy
 
 .PHONY: manifests
-manifests: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: $(CONTROLLER_GEN) #EXHELP Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: $(CONTROLLER_GEN) #EXHELP Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: verify
-verify: tidy fmt generate ## Verify the current code generation.
+verify: tidy fmt vet generate #HELP Verify all generated code is up-to-date.
 	git diff --exit-code
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
+fmt: #EXHELP Run go fmt against code.
 	go fmt ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: #EXHELP Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet test-unit e2e ## Run all tests.
+test: manifests generate fmt vet test-unit test-e2e #HELP Run all tests.
 
-.PHONY: test-e2e
+.PHONY: e2e
 FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 E2E_FLAGS ?= ""
-test-e2e: $(GINKGO) ## Run the e2e tests
+e2e: $(GINKGO) #EXHELP Run the e2e tests.
 	$(GINKGO) --tags $(GO_BUILD_TAGS) $(E2E_FLAGS) -trace -progress $(FOCUS) test/e2e
 
 .PHONY: test-op-dev-e2e
-test-op-dev-e2e: $(GINKGO) ## Run operator create, upgrade and delete tests
+test-op-dev-e2e: $(GINKGO) #HELP Run operator create, upgrade and delete tests.
 	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) $(GINKGO) --tags $(GO_BUILD_TAGS) $(E2E_FLAGS) -trace -progress $(FOCUS) test/operator-framework-e2e
 
 .PHONY: test-unit
 ENVTEST_VERSION = $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.x/')
 UNIT_TEST_DIRS=$(shell go list ./... | grep -v /test/)
-test-unit: $(SETUP_ENVTEST) ## Run the unit tests
+test-unit: $(SETUP_ENVTEST) #HELP Run the unit tests
 	eval $$($(SETUP_ENVTEST) use -p env $(ENVTEST_VERSION)) && go test -tags $(GO_BUILD_TAGS) -count=1 -short $(UNIT_TEST_DIRS) -coverprofile cover.out
 
-.PHONY: e2e
-e2e: KIND_CLUSTER_NAME=operator-controller-e2e
-e2e: KUSTOMIZE_BUILD_DIR=config/e2e
-e2e: GO_BUILD_FLAGS=-cover
-e2e: run kind-load-test-artifacts test-e2e e2e-coverage kind-cluster-cleanup ## Run e2e test suite on local kind cluster
+.PHONY: test-e2e
+test-e2e: KIND_CLUSTER_NAME=operator-controller-e2e
+test-e2e: KUSTOMIZE_BUILD_DIR=config/e2e
+test-e2e: GO_BUILD_FLAGS=-cover
+test-e2e: run kind-load-test-artifacts e2e e2e-coverage undeploy kind-clean #HELP Run e2e test suite on local kind cluster
 
 .PHONY: operator-developer-e2e
-operator-developer-e2e: KIND_CLUSTER_NAME=operator-controller-op-dev-e2e  ## Run operator-developer e2e on local kind cluster
-operator-developer-e2e: run $(OPM) $(OPERATOR_SDK) $(KUSTOMIZE) deploy-local-registry test-op-dev-e2e cleanup-local-registry kind-cluster-cleanup
+operator-developer-e2e: KIND_CLUSTER_NAME=operator-controller-op-dev-e2e  #EXHELP Run operator-developer e2e on local kind cluster
+operator-developer-e2e: run $(OPM) $(OPERATOR_SDK) $(KUSTOMIZE) deploy-local-registry test-op-dev-e2e cleanup-local-registry kind-clean
 
 .PHONY: e2e-coverage
 e2e-coverage:
 	COVERAGE_OUTPUT=./e2e-cover.out ./hack/e2e-coverage.sh
 
 .PHONY: kind-load
-kind-load: $(KIND) ## Loads the currently constructed image onto the cluster
+kind-load: $(KIND) #EXHELP Loads the currently constructed image onto the cluster.
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
 
+kind-deploy: export MANIFEST="./operator-controller.yaml"
+kind-deploy: manifests $(KUSTOMIZE) #EXHELP Install controller and dependencies onto the kind cluster.
+	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) > operator-controller.yaml
+	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh | bash -s
+
 .PHONY: kind-cluster
-kind-cluster: $(KIND) ## Standup a kind cluster
+kind-cluster: $(KIND) #EXHELP Standup a kind cluster.
 	-$(KIND) delete cluster --name ${KIND_CLUSTER_NAME}
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KIND) export kubeconfig --name ${KIND_CLUSTER_NAME}
 
-.PHONY: kind-cluster-cleanup
-kind-cluster-cleanup: $(KIND) ## Delete the kind cluster
+.PHONY: kind-clean
+kind-clean: $(KIND) #EXHELP Delete the kind cluster.
 	$(KIND) delete cluster --name ${KIND_CLUSTER_NAME}
 
 .PHONY: kind-load-test-artifacts
-kind-load-test-artifacts: $(KIND) ## Load the e2e testdata container images into a kind cluster
+kind-load-test-artifacts: $(KIND) #EXHELP Load the e2e testdata container images into a kind cluster.
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry-v1/prometheus-operator.v0.37.0 -t localhost/testdata/bundles/registry-v1/prometheus-operator:v0.37.0
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry-v1/prometheus-operator.v0.47.0 -t localhost/testdata/bundles/registry-v1/prometheus-operator:v0.47.0
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry-v1/prometheus-operator.v0.65.1 -t localhost/testdata/bundles/registry-v1/prometheus-operator:v0.65.1
@@ -151,11 +161,11 @@ kind-load-test-artifacts: $(KIND) ## Load the e2e testdata container images into
 	$(KIND) load docker-image localhost/testdata/catalogs/test-catalog:e2e --name $(KIND_CLUSTER_NAME)
 
 .PHONY: deploy-local-registry
-deploy-local-registry: ## Deploy local registry
+deploy-local-registry: #EXHELP Deploy local registry.
 	$(CONTAINER_RUNTIME) run -d -p 5001:5000 --restart=always --name local-registry registry:2
 
 .PHONY: cleanup-local-registry
-cleanup-local-registry: ## Stop and remove local registry
+cleanup-local-registry: #EXHELP Stop and remove local registry.
 	$(CONTAINER_RUNTIME) container stop local-registry
 	$(CONTAINER_RUNTIME) container rm -v local-registry
 
@@ -168,7 +178,7 @@ operator-sdk: $(OPERATOR_SDK)
 kustomize: $(KUSTOMIZE)
 	(cd $(OPERATOR_SDK_PROJECT_PATH) && $(KUSTOMIZE) $(KUSTOMIZE_ARGS))
 
-##@ Build
+#SECTION Build
 
 export VERSION           ?= $(shell git describe --tags --always --dirty)
 export CGO_ENABLED       ?= 0
@@ -184,65 +194,52 @@ BUILDCMD = go build $(GO_BUILD_FLAGS) -tags '$(GO_BUILD_TAGS)' -ldflags '$(GO_BU
 build-deps: manifests generate fmt vet
 
 .PHONY: build go-build-local
-build: build-deps go-build-local ## Build manager binary for current GOOS and GOARCH.
+build: build-deps go-build-local #HELP Build manager binary for current GOOS and GOARCH. Default target.
 go-build-local: BUILDBIN = bin
 go-build-local:
 	$(BUILDCMD)
 
 .PHONY: build-linux go-build-linux
-build-linux: build-deps go-build-linux ## Build manager binary for GOOS=linux and local GOARCH.
+build-linux: build-deps go-build-linux #EXHELP Build manager binary for GOOS=linux and local GOARCH.
 go-build-linux: BUILDBIN = bin/linux
 go-build-linux:
 	GOOS=linux $(BUILDCMD)
 
 .PHONY: run
-run: docker-build kind-cluster kind-load install ## Build the operator-controller then deploy it into a new kind cluster.
+run: docker-build kind-cluster kind-load kind-deploy #HELP Build the operator-controller then deploy it into a new kind cluster.
 
 .PHONY: docker-build
-docker-build: build-linux ## Build docker image for operator-controller with GOOS=linux and local GOARCH.
+docker-build: build-linux #EXHELP Build docker image for operator-controller with GOOS=linux and local GOARCH.
 	docker build -t ${IMG} -f Dockerfile ./bin/linux
 
-###########
-# Release #
-###########
+#SECTION Release
 
-##@ Release:
 export ENABLE_RELEASE_PIPELINE ?= false
 export GORELEASER_ARGS ?= --snapshot --clean
 
 .PHONY: release
-release: $(GORELEASER) ## Runs goreleaser for the operator-controller. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
+release: $(GORELEASER) #EXHELP Runs goreleaser for the operator-controller. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)
 
 .PHONY: quickstart
 quickstart: export MANIFEST="https://github.com/operator-framework/operator-controller/releases/download/$(VERSION)/operator-controller.yaml"
-quickstart: $(KUSTOMIZE) generate ## Generate the installation release manifests and scripts
+quickstart: $(KUSTOMIZE) manifests #EXHELP Generate the installation release manifests and scripts.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | sed "s/:devel/:$(VERSION)/g" > operator-controller.yaml
 	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh > install.sh
 
-##@ Deployment
+#SECTION Deployment
 
 ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-.PHONY: install
-install: export MANIFEST="./operator-controller.yaml"
-install: manifests $(KUSTOMIZE) generate ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) > operator-controller.yaml
-	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh | bash -s
-
-.PHONY: uninstall
-uninstall: manifests $(KUSTOMIZE) ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
 .PHONY: deploy
-deploy: manifests $(KUSTOMIZE) ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests $(KUSTOMIZE) #HELP Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl apply -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+undeploy: #HELP Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 


### PR DESCRIPTION
# Description

Update Makefile targets for consistency

Fixes #226

* Rename the `install` target to `kind-deploy`
* Remove `uninstall` target
* Rename the `kind-cluster-cleanup` target to `kind-clean`
* Remove the `generate` target from `kind-deploy`
* Swap `e2e`/`test-e2e` targets
* Update help descriptions
* Add `help-extended`,
* Change e2e workflow to use `test-e2e`

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
