### PR TITLE
Define default logs container for operator-controller pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,6 +16,8 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: manager
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: deployment


### PR DESCRIPTION
# Description

Add an annotation to the controller-manager manifest so that `kubectl logs <controllerManagerPod>` automatically defaults to the manager pod (not the kube-rbac-proxy pod)
