### PR TITLE
add feature gates infrastructure

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/operator-framework/deppy/pkg/deppy/solver"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -36,6 +37,7 @@ import (
 	"github.com/operator-framework/operator-controller/internal/controllers"
 	"github.com/operator-framework/operator-controller/internal/resolution/entitysources"
 	"github.com/operator-framework/operator-controller/internal/resolution/variable_sources/olm"
+	"github.com/operator-framework/operator-controller/pkg/features"
 )
 
 var (
@@ -66,7 +68,10 @@ func main() {
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	features.OperatorControllerFeatureGate.AddFlag(pflag.CommandLine)
+	pflag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.StacktraceLevel(zapcore.DPanicLevel)))
 

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/operator-framework/deppy v0.0.0-20230602120738-cbf2c66b141b
 	github.com/operator-framework/operator-registry v1.26.3
 	github.com/operator-framework/rukpak v0.12.0
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.24.0
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/component-base v0.26.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.4
 )
@@ -53,7 +55,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
@@ -71,7 +72,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
-	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,21 @@
+package features
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+// Add new feature gates constants (strings)
+// Ex: SomeFeature featuregate.Feature = "SomeFeature"
+)
+
+var operatorControllerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	// Add new feature gate definitions
+	// Ex: SomeFeature: {...}
+}
+
+var OperatorControllerFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+func init() {
+	OperatorControllerFeatureGate.Add(operatorControllerFeatureGates)
+}


### PR DESCRIPTION
# Description
- Adds a `features` package containing skeleton code for easily adding new feature gates to operator-controller
- Updates the flag parsing in `cmd/main.go` to use pflag to allow for easily adding and processing the `--feature-gates` flag
    - Feature gates can be enabled/disabled by setting them with the `--feature-gates` flag like so: `--feature-gates="SomeFeature=true"

- Resolves #255 
## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
