### PR TITLE
Removes unnecessary `HaveLen` assertions

### DIFF
--- a/internal/resolution/variable_sources/bundlesanddependencies/bundles_and_dependencies_test.go
+++ b/internal/resolution/variable_sources/bundlesanddependencies/bundles_and_dependencies_test.go
@@ -199,7 +199,6 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 				bundleVariables = append(bundleVariables, v)
 			}
 		}
-		Expect(bundleVariables).To(HaveLen(12))
 		Expect(bundleVariables).To(WithTransform(CollectBundleVariableIDs, Equal([]string{"bundle-2", "bundle-1", "bundle-15", "bundle-16", "bundle-17", "bundle-9", "bundle-8", "bundle-7", "bundle-5", "bundle-4", "bundle-11", "bundle-10"})))
 
 		// check dependencies for one of the bundles

--- a/internal/resolution/variable_sources/crdconstraints/crd_constraints_test.go
+++ b/internal/resolution/variable_sources/crdconstraints/crd_constraints_test.go
@@ -247,8 +247,7 @@ var _ = Describe("CRDUniquenessConstraintsVariableSource", func() {
 				crdConstraintVariables = append(crdConstraintVariables, v)
 			}
 		}
-		Expect(crdConstraintVariables).To(HaveLen(11))
-		Expect(crdConstraintVariables).To(WithTransform(CollectGlobalConstraintVariableIDs, ContainElements([]string{
+		Expect(crdConstraintVariables).To(WithTransform(CollectGlobalConstraintVariableIDs, ConsistOf([]string{
 			"another-package package uniqueness",
 			"bar-package package uniqueness",
 			"test-package-2 package uniqueness",


### PR DESCRIPTION
# Description

Follow up for #264:
* https://github.com/operator-framework/operator-controller/pull/264/files#r1235508524
* https://github.com/operator-framework/operator-controller/pull/264/files#r1235492338


## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
