### PR TITLE
Fixes kind cluster cleanup in `e2e` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ e2e: run kind-load-test-artifacts test-e2e kind-cluster-cleanup ## Run e2e test 
 kind-load: $(KIND) ## Loads the currently constructed image onto the cluster
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
 
-kind-cluster: $(KIND) kind-cluster-cleanup ## Standup a kind cluster
+kind-cluster: $(KIND) ## Standup a kind cluster
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 	$(KIND) export kubeconfig --name ${KIND_CLUSTER_NAME}
 


### PR DESCRIPTION
# Description

Currently we have `kind-cluster-cleanup` as a dependency in `kind-cluster` target. Since `make` only builds a target once this means that `e2e` target performs cleanup before creating a new cluster and skips cleanup at the end leaving cluster hanging around.

With this change, `make e2e` will be failing on cluster creation, if a cluster with the same name already exists, but the failure message will clearly indicate the issue.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
