### PR TITLE
Makes codecov-action optional

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,5 +34,4 @@ jobs:
       with:
         files: e2e-cover.out
         flags: e2e
-        fail_ci_if_error: true
         functionalities: fixes

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -26,5 +26,4 @@ jobs:
       with:
         files: cover.out
         flags: unit
-        fail_ci_if_error: true
         functionalities: fixes


### PR DESCRIPTION
# Description

We do not want to fail the job if codecov fails
to upload the report due to rate limiting.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
