### PR TITLE
Enable merge_group events

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,6 +3,7 @@ name: e2e
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
     - main

--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,5 +1,7 @@
 name: go-apidiff
-on: [ pull_request ]
+on:
+  pull_request:
+  merge_group:
 jobs:
   go-apidiff:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
     - main
+  merge_group:
 
 jobs:
   goreleaser:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -3,6 +3,7 @@ name: sanity
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
     - main

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -3,6 +3,7 @@ name: unit-test
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
     - main


### PR DESCRIPTION
# Description

Enable receiving `merge_group` events in preparation for enabling the merge queue.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
