### PR TITLE
Adds go module caching for bingo modules

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,6 +24,9 @@ jobs:
           go.sum
           .bingo/**.sum
 
+    - name: Install all tools
+      run: make install-tools
+
     - name: Run e2e tests
       run: |
         # By default make stops building on first non-zero exit code which

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,6 +20,9 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+        cache-dependency-path: |
+          go.sum
+          .bingo/**.sum
 
     - name: Run e2e tests
       run: |

--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -14,5 +14,8 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+        cache-dependency-path: |
+          go.sum
+          .bingo/**.sum
 
     - uses: joelanford/go-apidiff@main

--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -18,4 +18,9 @@ jobs:
           go.sum
           .bingo/**.sum
 
+    - name: Install all tools
+      run: make install-tools
+
     - uses: joelanford/go-apidiff@main
+      with:
+        skip-cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: "go.mod"
+        cache-dependency-path: |
+          go.sum
+          .bingo/**.sum
 
     - name: Docker Login
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,9 @@ jobs:
           go.sum
           .bingo/**.sum
 
+    - name: Install all tools
+      run: make install-tools
+
     - name: Docker Login
       if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v2

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -21,6 +21,9 @@ jobs:
             go.sum
             .bingo/**.sum
 
+      - name: Install all tools
+        run: make install-tools
+
       - name: Run verification checks
         run: make verify
   lint:
@@ -34,6 +37,9 @@ jobs:
           cache-dependency-path: |
             go.sum
             .bingo/**.sum
+
+      - name: Install all tools
+        run: make install-tools
 
       - name: Run golangci linting checks
         run: make lint GOLANGCI_LINT_ARGS="--out-format github-actions"

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
+
       - name: Run verification checks
         run: make verify
   lint:
@@ -27,6 +31,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+          cache-dependency-path: |
+            go.sum
+            .bingo/**.sum
 
       - name: Run golangci linting checks
         run: make lint GOLANGCI_LINT_ARGS="--out-format github-actions"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -22,6 +22,9 @@ jobs:
           go.sum
           .bingo/**.sum
 
+    - name: Install all tools
+      run: make install-tools
+
     - name: Run basic unit tests
       run: |
         make test-unit

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,6 +18,9 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+        cache-dependency-path: |
+          go.sum
+          .bingo/**.sum
 
     - name: Run basic unit tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ kind-load-test-artifacts: $(KIND) ## Load the e2e testdata container images into
 	$(KIND) load docker-image localhost/testdata/bundles/plain-v0/plain:v0.1.0 --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image localhost/testdata/catalogs/test-catalog:e2e --name $(KIND_CLUSTER_NAME)
 
+install-tools: $(BINGO) ## Installs all the tools
+	$(BINGO) get
+
 ##@ Build
 
 export VERSION           ?= $(shell git describe --tags --always --dirty)


### PR DESCRIPTION
# Description

We introduced [bingo](https://github.com/bwplotka/bingo) in OLMv1 repos for managing tools and it created a bunch of modules in the `.bingo` directory in each repo. It works well, but on every job we download these dependencies from internet instead of using cache. This happens becuase setup-go github action only looks into project root for `go.sum` and builds cache based on it.

`cache-dependency-path` needs to be added to all OLMv1 repos and it should speed up our builds (we've seen decrease in build time of ~3 minutes in https://github.com/operator-framework/olm-docs).

Relevant issue: #323

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)

