### PR TITLE
Switch to catalogd's `CatalogMetadata` APIs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ rules:
 - apiGroups:
   - catalogd.operatorframework.io
   resources:
-  - bundlemetadata
+  - catalogmetadata
   verbs:
   - list
   - watch

--- a/internal/controllers/operator_controller.go
+++ b/internal/controllers/operator_controller.go
@@ -62,9 +62,9 @@ type OperatorReconciler struct {
 
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundledeployments,verbs=get;list;watch;create;update;patch
 
-//+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=bundlemetadata,verbs=list;watch
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=packages,verbs=list;watch
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogs,verbs=list;watch
+//+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogmetadata,verbs=list;watch
 
 func (r *OperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithName("operator-controller")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -95,8 +95,9 @@ var _ = AfterSuite(func() {
 	}).Should(Succeed())
 
 	// speed up delete without waiting for gc
-	Expect(c.DeleteAllOf(ctx, &catalogd.BundleMetadata{})).To(Succeed())
 	Expect(c.DeleteAllOf(ctx, &catalogd.Package{})).To(Succeed())
+	Expect(c.DeleteAllOf(ctx, &catalogd.BundleMetadata{})).To(Succeed())
+	Expect(c.DeleteAllOf(ctx, &catalogd.CatalogMetadata{})).To(Succeed())
 
 	Eventually(func(g Gomega) {
 		// ensure resource cleanup
@@ -106,6 +107,10 @@ var _ = AfterSuite(func() {
 
 		bmd := &catalogd.BundleMetadataList{}
 		g.Expect(c.List(ctx, bmd)).To(Succeed())
+		g.Expect(bmd.Items).To(BeEmpty())
+
+		cmd := &catalogd.CatalogMetadataList{}
+		g.Expect(c.List(ctx, cmd)).To(Succeed())
 		g.Expect(bmd.Items).To(BeEmpty())
 	}).Should(Succeed())
 })


### PR DESCRIPTION
# Description

Closes #342

This is a minimal set of changes required to switch from `BundleMetadata` API to `CatalogMetadata` and remove code duplication between resolution CLI and operator controller itself.

I expect more refactoring to be done as part of #347 where we will be removing entities/entity sources from operator controller and switching to `VariableSources`. E.g. we might want to create a wrapper for `declcfg` structs which makes it easier to traverse catalog (e.g. package might contain refs to channels and channels might contain refs to bundles). But this to be defined separately and out of scope for this PR.

The main goal of this PR is to make removal of entities and entity sources easier.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
