### PR TITLE
Adds default channel to the CreateFBC helper

### DIFF
--- a/test/operator-framework-e2e/create_fbc_helper.go
+++ b/test/operator-framework-e2e/create_fbc_helper.go
@@ -19,7 +19,7 @@ const (
 
 // Forms the FBC declartive config and creates the FBC by calling functions for forming the package, channel and bundles.
 func CreateFBC(operatorName, channelName string, bundleRefsVersions map[string]string) *declcfg.DeclarativeConfig {
-	dPackage := formPackage(operatorName)
+	dPackage := formPackage(operatorName, channelName)
 	bundleVersions := make([]string, 0)
 	for _, bundleVersion := range bundleRefsVersions {
 		bundleVersions = append(bundleVersions, bundleVersion)
@@ -37,10 +37,11 @@ func CreateFBC(operatorName, channelName string, bundleRefsVersions map[string]s
 }
 
 // Forms package schema for the FBC
-func formPackage(pkgName string) declcfg.Package {
+func formPackage(pkgName, defaultChannelName string) declcfg.Package {
 	packageFormed := declcfg.Package{
-		Schema: declcfg.SchemaPackage,
-		Name:   pkgName,
+		Schema:         declcfg.SchemaPackage,
+		Name:           pkgName,
+		DefaultChannel: defaultChannelName,
 	}
 	return packageFormed
 }


### PR DESCRIPTION
# Description

Helper is not setting the default channel for a package which is a required field.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
