### PR TITLE
blang semver pkg alias

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,8 @@ linters-settings:
       alias: ctrl
     - pkg: github.com/operator-framework/rukpak/api/v1alpha1
       alias: rukpakv1alpha1
+    - pkg: github.com/blang/semver/v4
+      alias: bsemver
   goimports:
     local-prefixes: github.com/operator-framework/operator-controller
 

--- a/internal/controllers/validators/validators.go
+++ b/internal/controllers/validators/validators.go
@@ -3,7 +3,7 @@ package validators
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
@@ -18,7 +18,7 @@ func validateSemver(operator *operatorsv1alpha1.Operator) error {
 	if operator.Spec.Version == "" {
 		return nil
 	}
-	if _, err := semver.Parse(operator.Spec.Version); err != nil {
+	if _, err := bsemver.Parse(operator.Spec.Version); err != nil {
 		return fmt.Errorf("invalid .spec.version: %w", err)
 	}
 	return nil

--- a/internal/resolution/entities/bundle_entity.go
+++ b/internal/resolution/entities/bundle_entity.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
 	"github.com/operator-framework/operator-registry/alpha/property"
 )
@@ -32,7 +32,7 @@ const (
 
 type PackageRequired struct {
 	property.PackageRequired
-	SemverRange *semver.Range `json:"-"`
+	SemverRange *bsemver.Range `json:"-"`
 }
 
 type GVK property.GVK
@@ -67,7 +67,7 @@ type BundleEntity struct {
 	requiredPackages []PackageRequired
 	channel          *property.Channel
 	channelEntry     *ChannelEntry
-	semVersion       *semver.Version
+	semVersion       *bsemver.Version
 	bundlePath       string
 	mediaType        string
 	mu               sync.RWMutex
@@ -87,7 +87,7 @@ func (b *BundleEntity) PackageName() (string, error) {
 	return b.bundlePackage.PackageName, nil
 }
 
-func (b *BundleEntity) Version() (*semver.Version, error) {
+func (b *BundleEntity) Version() (*bsemver.Version, error) {
 	if err := b.loadPackage(); err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (b *BundleEntity) loadPackage() error {
 		}
 		b.bundlePackage = &bundlePackage
 		if b.semVersion == nil {
-			semVer, err := semver.Parse(b.bundlePackage.Version)
+			semVer, err := bsemver.Parse(b.bundlePackage.Version)
 			if err != nil {
 				return fmt.Errorf("could not parse semver (%s) for entity '%s': %w", b.bundlePackage.Version, b.ID, err)
 			}
@@ -232,7 +232,7 @@ func (b *BundleEntity) loadRequiredPackages() error {
 			return fmt.Errorf("error determining bundle required packages for entity '%s': %w", b.ID, err)
 		}
 		for _, requiredPackage := range requiredPackages {
-			semverRange, err := semver.ParseRange(requiredPackage.VersionRange)
+			semverRange, err := bsemver.ParseRange(requiredPackage.VersionRange)
 			if err != nil {
 				return fmt.Errorf("error determining bundle required package semver range for entity '%s': '%w'", b.ID, err)
 			}

--- a/internal/resolution/entities/bundle_entity_test.go
+++ b/internal/resolution/entities/bundle_entity_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
@@ -55,7 +55,7 @@ var _ = Describe("BundleEntity", func() {
 			bundleEntity := olmentity.NewBundleEntity(entity)
 			version, err := bundleEntity.Version()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*version).To(Equal(semver.MustParse("0.14.0")))
+			Expect(*version).To(Equal(bsemver.MustParse("0.14.0")))
 		})
 		It("should return an error if the property is not found", func() {
 			entity := input.NewEntity("operatorhub/prometheus/0.14.0", map[string]string{})

--- a/internal/resolution/util/predicates/predicates.go
+++ b/internal/resolution/util/predicates/predicates.go
@@ -1,7 +1,7 @@
 package predicates
 
 import (
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
 
 	olmentity "github.com/operator-framework/operator-controller/internal/resolution/entities"
@@ -18,7 +18,7 @@ func WithPackageName(packageName string) input.Predicate {
 	}
 }
 
-func InSemverRange(semverRange semver.Range) input.Predicate {
+func InSemverRange(semverRange bsemver.Range) input.Predicate {
 	return func(entity *input.Entity) bool {
 		bundleEntity := olmentity.NewBundleEntity(entity)
 		bundleVersion, err := bundleEntity.Version()

--- a/internal/resolution/util/predicates/predicates_test.go
+++ b/internal/resolution/util/predicates/predicates_test.go
@@ -3,7 +3,7 @@ package predicates_test
 import (
 	"testing"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
@@ -38,14 +38,14 @@ var _ = Describe("Predicates", func() {
 			entity := input.NewEntity("test", map[string]string{
 				property.TypePackage: `{"packageName": "mypackage", "version": "1.0.0"}`,
 			})
-			inRange := semver.MustParseRange(">=1.0.0")
-			notInRange := semver.MustParseRange(">=2.0.0")
+			inRange := bsemver.MustParseRange(">=1.0.0")
+			notInRange := bsemver.MustParseRange(">=2.0.0")
 			Expect(predicates.InSemverRange(inRange)(entity)).To(BeTrue())
 			Expect(predicates.InSemverRange(notInRange)(entity)).To(BeFalse())
 		})
 		It("should return false when the entity does not have a version", func() {
 			entity := input.NewEntity("test", map[string]string{})
-			inRange := semver.MustParseRange(">=1.0.0")
+			inRange := bsemver.MustParseRange(">=1.0.0")
 			Expect(predicates.InSemverRange(inRange)(entity)).To(BeFalse())
 		})
 	})

--- a/internal/resolution/variablesources/bundles_and_dependencies.go
+++ b/internal/resolution/variablesources/bundles_and_dependencies.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
 
@@ -87,7 +87,7 @@ func (b *BundlesAndDepsVariableSource) getEntityDependencies(ctx context.Context
 	// todo(perdasilva): disambiguate between not found and actual errors
 	requiredPackages, _ := bundleEntity.RequiredPackages()
 	for _, requiredPackage := range requiredPackages {
-		semverRange, err := semver.ParseRange(requiredPackage.VersionRange)
+		semverRange, err := bsemver.ParseRange(requiredPackage.VersionRange)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resolution/variablesources/required_package.go
+++ b/internal/resolution/variablesources/required_package.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/blang/semver/v4"
+	bsemver "github.com/blang/semver/v4"
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
 
@@ -21,7 +21,7 @@ type RequiredPackageVariableSourceOption func(*RequiredPackageVariableSource) er
 func InVersionRange(versionRange string) RequiredPackageVariableSourceOption {
 	return func(r *RequiredPackageVariableSource) error {
 		if versionRange != "" {
-			vr, err := semver.ParseRange(versionRange)
+			vr, err := bsemver.ParseRange(versionRange)
 			if err == nil {
 				r.versionRange = versionRange
 				r.predicates = append(r.predicates, predicates.InSemverRange(vr))


### PR DESCRIPTION
Create consistent alias for blang, enforce with golang-ci lint.

Addresses #344 in preparation for #346.