### PR TITLE
Remove all references to the old catalogd Package and BundleMetadata APIs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,13 +19,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - catalogd.operatorframework.io
-  resources:
-  - packages
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - core.rukpak.io
   resources:
   - bundledeployments

--- a/internal/controllers/operator_controller.go
+++ b/internal/controllers/operator_controller.go
@@ -62,7 +62,6 @@ type OperatorReconciler struct {
 
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundledeployments,verbs=get;list;watch;create;update;patch
 
-//+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=packages,verbs=list;watch
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogs,verbs=list;watch
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogmetadata,verbs=list;watch
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -127,7 +128,7 @@ var _ = Describe("Operator Install", func() {
 
 			Eventually(func(g Gomega) {
 				// target package should not be present on cluster
-				err := c.Get(ctx, types.NamespacedName{Name: pkgName}, &catalogd.Package{})
+				err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s-%s", operatorCatalog.Name, declcfg.SchemaPackage, pkgName)}, &catalogd.CatalogMetadata{})
 				g.Expect(errors.IsNotFound(err)).To(BeTrue())
 			}).Should(Succeed())
 

--- a/test/operator-framework-e2e/operator_framework_test.go
+++ b/test/operator-framework-e2e/operator_framework_test.go
@@ -825,14 +825,8 @@ func createCatalogCheckResources(operatorCatalog *catalogd.Catalog, catalogDInfo
 		g.Expect(err).ToNot(HaveOccurred())
 	}, 2*time.Minute, 1).Should(Succeed())
 
-	// checking if the packages are created
-	Eventually(func(g Gomega) {
-		err = validatePackageCreation(operatorCatalog, catalogDInfo.operatorName)
-		g.Expect(err).ToNot(HaveOccurred())
-	}, 2*time.Minute, 1).Should(Succeed())
-
-	// checking if the bundle metadatas are created
-	By("Eventually checking if bundle metadata is created")
+	// checking if the catalog metadatas are created
+	By("Eventually checking if catalog metadata is created")
 	Eventually(func(g Gomega) {
 		validateCatalogMetadataCreation(g, operatorCatalog, catalogDInfo.operatorName, bundleVersions)
 	}).Should(Succeed())
@@ -864,26 +858,6 @@ func checkOperatorOperationsSuccess(operator *operatorv1alpha1.Operator, pkgName
 		err := checkManifestPresence(bundlePath, pkgName, opVersion, nameSpace)
 		g.Expect(err).ToNot(HaveOccurred())
 	}).Should(Succeed())
-}
-
-// Checks if the packages are created from the catalog and returns error if not.
-// The expected pkgName is taken as input and is compared against the packages collected whose catalog name
-// matches the catalog under consideration.
-func validatePackageCreation(operatorCatalog *catalogd.Catalog, pkgName string) error {
-	var pkgCollected string
-	pList := &catalogd.PackageList{}
-	if err := c.List(ctx, pList); err != nil {
-		return fmt.Errorf("Error retrieving the packages after %v catalog instance creation: %v", operatorCatalog.Name, err)
-	}
-	for _, pack := range pList.Items {
-		if pack.Spec.Catalog.Name == operatorCatalog.Name {
-			pkgCollected = pack.Spec.Name
-		}
-	}
-	if pkgCollected != pkgName {
-		return fmt.Errorf("Package %v for the catalog %v is not created", pkgName, operatorCatalog.Name)
-	}
-	return nil
 }
 
 // Checks if the CatalogMetadata was created from the catalog and returns error if not.


### PR DESCRIPTION
# Description

This follows up on #343 to remove the final bits of references to the catalogd `Package` and `BundleMetadata` APIs. This is important if we want Operator Controller to be able to bump to a version of Catalogd that removes those APIs.

See https://github.com/operator-framework/catalogd/pull/149

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
