### PR TITLE
Remove go-apidiff GHA from merge_group runs

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,7 +1,6 @@
 name: go-apidiff
 on:
   pull_request:
-  merge_group:
 jobs:
   go-apidiff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

go-apidiff is meant to be informational and is optional, so it will not block PRs in the merge queue, even when it finds incompatible changes. Therefore it serves no real purpose in the merge queue CI.

There also seems to be an issue with running go-apidiff in the context of a merge_queue where it fails due to invalid commit references. See https://github.com/operator-framework/operator-controller/actions/runs/6014708335/job/16315430191

For these reasons, removing it from the merge queue CI

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
