### PR TITLE
Revert "Removes GVKRequired struct (#400)"

### DIFF
--- a/internal/resolution/entities/bundle_entity.go
+++ b/internal/resolution/entities/bundle_entity.go
@@ -47,13 +47,23 @@ func (g GVK) String() string {
 	return fmt.Sprintf(`group:"%s" version:"%s" kind:"%s"`, g.Group, g.Version, g.Kind)
 }
 
+type GVKRequired property.GVKRequired
+
+func (g GVKRequired) String() string {
+	return fmt.Sprintf(`group:"%s" version:"%s" kind:"%s"`, g.Group, g.Version, g.Kind)
+}
+
+func (g GVKRequired) AsGVK() GVK {
+	return GVK(g)
+}
+
 type BundleEntity struct {
 	*input.Entity
 
 	// these properties are lazy loaded as they are requested
 	bundlePackage    *property.Package
 	providedGVKs     []GVK
-	requiredGVKs     []GVK
+	requiredGVKs     []GVKRequired
 	requiredPackages []PackageRequired
 	channel          *property.Channel
 	channelEntry     *ChannelEntry
@@ -91,7 +101,7 @@ func (b *BundleEntity) ProvidedGVKs() ([]GVK, error) {
 	return b.providedGVKs, nil
 }
 
-func (b *BundleEntity) RequiredGVKs() ([]GVK, error) {
+func (b *BundleEntity) RequiredGVKs() ([]GVKRequired, error) {
 	if err := b.loadRequiredGVKs(); err != nil {
 		return nil, err
 	}
@@ -204,7 +214,7 @@ func (b *BundleEntity) loadRequiredGVKs() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.requiredGVKs == nil {
-		requiredGVKs, err := loadFromEntity[[]GVK](b.Entity, property.TypeGVKRequired, optional)
+		requiredGVKs, err := loadFromEntity[[]GVKRequired](b.Entity, property.TypeGVKRequired, optional)
 		if err != nil {
 			return fmt.Errorf("error determining bundle required gvks for entity '%s': %w", b.ID, err)
 		}

--- a/internal/resolution/entities/bundle_entity_test.go
+++ b/internal/resolution/entities/bundle_entity_test.go
@@ -135,7 +135,7 @@ var _ = Describe("BundleEntity", func() {
 			bundleEntity := olmentity.NewBundleEntity(entity)
 			requiredGvks, err := bundleEntity.RequiredGVKs()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(requiredGvks).To(Equal([]olmentity.GVK{
+			Expect(requiredGvks).To(Equal([]olmentity.GVKRequired{
 				{Group: "foo.io", Kind: "Foo", Version: "v1"},
 				{Group: "bar.io", Kind: "Bar", Version: "v1alpha1"},
 			}))
@@ -326,6 +326,27 @@ var _ = Describe("BundleEntity", func() {
 		})
 	})
 
+	// Increase test coverage
+	Describe("GVKRequired properties", func() {
+		It("should return the GVKRequired properties", func() {
+			gvk := olmentity.GVKRequired{
+				Group:   "foo.io",
+				Kind:    "Foo",
+				Version: "v1",
+			}
+			Expect(gvk.AsGVK().Version).To(Equal("v1"))
+			Expect(gvk.AsGVK().Group).To(Equal("foo.io"))
+			Expect(gvk.AsGVK().Kind).To(Equal("Foo"))
+		})
+		It("should return the GVKRequired properties as a string", func() {
+			gvk := olmentity.GVKRequired{
+				Group:   "foo.io",
+				Kind:    "Foo",
+				Version: "v1",
+			}
+			Expect(gvk.String()).To(Equal(`group:"foo.io" version:"v1" kind:"Foo"`))
+		})
+	})
 	Describe("GVK properties", func() {
 		It("should return the gvk properties", func() {
 			gvk := olmentity.GVK{

--- a/internal/resolution/variablesources/bundles_and_dependencies.go
+++ b/internal/resolution/variablesources/bundles_and_dependencies.go
@@ -111,7 +111,7 @@ func (b *BundlesAndDepsVariableSource) getEntityDependencies(ctx context.Context
 	// todo(perdasilva): disambiguate between not found and actual errors
 	gvkDependencies, _ := bundleEntity.RequiredGVKs()
 	for i := 0; i < len(gvkDependencies); i++ {
-		providedGvk := gvkDependencies[i]
+		providedGvk := gvkDependencies[i].AsGVK()
 		gvkDependencyBundles, err := entitySource.Filter(ctx, predicates.ProvidesGVK(&providedGvk))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

This reverts commit 5cbc9a0d5e3bbeab3ce200a9fd1da66453f0247b from #400.

We accidentally merged #400. I should’ve marked it as a draft after [this thread](https://github.com/operator-framework/operator-controller/pull/400#discussion_r1318854976).

I think both operator-registry and operator-controller can get rid of it, but it is not a trivial thing to do on operator-registry side since it uses go type to map to a property type. It is not a difficult change either, but I don’t have time to look into it at the moment.

While operator-registry still has this this extra type, I think, operator-controller should also have it. There is no impact on functionality on operator-controller side without the second type, but it might be confusing that we have two types on operator-registry side and one in operator-controller.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
