### PR TITLE
Optimises `Bundle.MediaType()` (#408 follow up)

### DIFF
--- a/internal/catalogmetadata/types.go
+++ b/internal/catalogmetadata/types.go
@@ -45,7 +45,7 @@ type Bundle struct {
 	bundlePackage    *property.Package
 	semVersion       *bsemver.Version
 	requiredPackages []PackageRequired
-	mediaType        string
+	mediaType        *string
 }
 
 func (b *Bundle) Version() (*bsemver.Version, error) {
@@ -67,7 +67,7 @@ func (b *Bundle) MediaType() (string, error) {
 		return "", err
 	}
 
-	return b.mediaType, nil
+	return *b.mediaType, nil
 }
 
 func (b *Bundle) loadPackage() error {
@@ -118,12 +118,12 @@ func (b *Bundle) loadRequiredPackages() error {
 func (b *Bundle) loadMediaType() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.mediaType == "" {
+	if b.mediaType == nil {
 		mediaType, err := loadFromProps[string](b, PropertyBundleMediaType, false)
 		if err != nil {
 			return fmt.Errorf("error determining bundle mediatype for bundle %q: %s", b.Name, err)
 		}
-		b.mediaType = mediaType
+		b.mediaType = &mediaType
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

It is a followup to https://github.com/operator-framework/operator-controller/pull/408#discussion_r1325665653

Media type is an optional field and can be an empty string after looading. This change avoids unmarshalling every time we call MediaType() method by comparing to `nil`.

If value is `nil` - we need to load. If anything else (even an empty string) we already lazy-loaded the value.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
