### PR TITLE
e2e: fix gomega assertion that breaks Eventually semantics

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -99,7 +99,7 @@ var _ = AfterSuite(func() {
 	Expect(c.Delete(ctx, operatorCatalog)).To(Succeed())
 	Eventually(func(g Gomega) {
 		err := c.Get(ctx, types.NamespacedName{Name: operatorCatalog.Name}, &catalogd.Catalog{})
-		Expect(errors.IsNotFound(err)).To(BeTrue())
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
 	}).Should(Succeed())
 
 	// speed up delete without waiting for gc


### PR DESCRIPTION
# Description

See: https://github.com/operator-framework/operator-controller/actions/runs/6187398899/job/16797170708?pr=410

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
