### PR TITLE
Renames `NewClient` to `New` to avoid duplication when imported

### DIFF
--- a/internal/catalogmetadata/client/client.go
+++ b/internal/catalogmetadata/client/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 )
 
-func NewClient(cl client.Client) *Client {
+func New(cl client.Client) *Client {
 	return &Client{cl: cl}
 }
 

--- a/internal/catalogmetadata/client/client_test.go
+++ b/internal/catalogmetadata/client/client_test.go
@@ -111,7 +111,7 @@ func TestClient(t *testing.T) {
 				ctx := context.Background()
 				objs, expectedBundles := tt.fakeCatalog()
 
-				fakeCatalogClient := catalogClient.NewClient(
+				fakeCatalogClient := catalogClient.New(
 					fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
 				)
 


### PR DESCRIPTION
# Description

So we can call `client.New` instead of `client.NewClient`.

Follow up for https://github.com/operator-framework/operator-controller/pull/413/files#r1330665212

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
