### PR TITLE
Add bundle data snapshotting for resolution

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -110,11 +110,10 @@ func main() {
 	catalogClient := catalogclient.New(cl, cache.NewFilesystemCache(cachePath, &http.Client{Timeout: 10 * time.Second}))
 
 	if err = (&controllers.OperatorReconciler{
-		Client: cl,
-		Scheme: mgr.GetScheme(),
-		Resolver: solver.NewDeppySolver(
-			controllers.NewVariableSource(cl, catalogClient),
-		),
+		Client:        cl,
+		Scheme:        mgr.GetScheme(),
+		CatalogClient: catalogClient,
+		NewSolver:     solver.NewDeppySolver,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Operator")
 		os.Exit(1)

--- a/internal/controllers/operator_controller_test.go
+++ b/internal/controllers/operator_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/deppy/pkg/deppy/input"
 	"github.com/operator-framework/deppy/pkg/deppy/solver"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -37,9 +38,13 @@ var _ = Describe("Operator Controller Test", func() {
 		ctx = context.Background()
 		fakeCatalogClient = testutil.NewFakeCatalogClient(testBundleList)
 		reconciler = &controllers.OperatorReconciler{
-			Client:   cl,
-			Scheme:   sch,
-			Resolver: solver.NewDeppySolver(controllers.NewVariableSource(cl, &fakeCatalogClient)),
+			Client: cl,
+			Scheme: sch,
+			NewSolver: func(variableSource input.VariableSource) *solver.DeppySolver {
+				return solver.NewDeppySolver(
+					controllers.NewVariableSource(cl, &fakeCatalogClient),
+				)
+			},
 		}
 	})
 	When("the operator does not exist", func() {


### PR DESCRIPTION
# Description

We now snapshot bundle data in the client for the duration of single resolution.

This reduces reads (from network or cache) and unmarshalling since data in memory. And it also ensures that different variable sources involved in the resolution process have the same view of catalogs and bundles.

Closes #418

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
