### PR TITLE
Make codecov wait for both jobs to upload coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    after_n_builds: 2


### PR DESCRIPTION
# Description

Currently we have 2 jobs that report code coverage to codecov. This setting makes codecov to wait for both before sending notifications such as comments and pull request checks.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
