### PR TITLE
Add annotations to `BundleDeployment`

### DIFF
--- a/internal/catalogmetadata/filter/bundle_predicates.go
+++ b/internal/catalogmetadata/filter/bundle_predicates.go
@@ -13,6 +13,12 @@ func WithPackageName(packageName string) Predicate[catalogmetadata.Bundle] {
 	}
 }
 
+func WithName(bundleName string) Predicate[catalogmetadata.Bundle] {
+	return func(bundle *catalogmetadata.Bundle) bool {
+		return bundle.Name == bundleName
+	}
+}
+
 func InMastermindsSemverRange(semverRange *mmsemver.Constraints) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
 		bVersion, err := bundle.Version()
@@ -49,12 +55,6 @@ func InChannel(channelName string) Predicate[catalogmetadata.Bundle] {
 			}
 		}
 		return false
-	}
-}
-
-func WithBundleImage(bundleImage string) Predicate[catalogmetadata.Bundle] {
-	return func(bundle *catalogmetadata.Bundle) bool {
-		return bundle.Image == bundleImage
 	}
 }
 

--- a/internal/catalogmetadata/filter/bundle_predicates_test.go
+++ b/internal/catalogmetadata/filter/bundle_predicates_test.go
@@ -26,6 +26,18 @@ func TestWithPackageName(t *testing.T) {
 	assert.False(t, f(b3))
 }
 
+func TestWithName(t *testing.T) {
+	b1 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Name: "package1.v1"}}
+	b2 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Name: "package2.v1"}}
+	b3 := &catalogmetadata.Bundle{}
+
+	f := filter.WithName("package1.v1")
+
+	assert.True(t, f(b1))
+	assert.False(t, f(b2))
+	assert.False(t, f(b3))
+}
+
 func TestInMastermindsSemverRange(t *testing.T) {
 	b1 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{
 		Properties: []property.Property{
@@ -108,18 +120,6 @@ func TestInChannel(t *testing.T) {
 	b3 := &catalogmetadata.Bundle{}
 
 	f := filter.InChannel("stable")
-
-	assert.True(t, f(b1))
-	assert.False(t, f(b2))
-	assert.False(t, f(b3))
-}
-
-func TestWithBundleImage(t *testing.T) {
-	b1 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Image: "fake-image-uri-1"}}
-	b2 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Image: "fake-image-uri-2"}}
-	b3 := &catalogmetadata.Bundle{}
-
-	f := filter.WithBundleImage("fake-image-uri-1")
 
 	assert.True(t, f(b1))
 	assert.False(t, f(b2))

--- a/internal/resolution/variablesources/bundles_and_dependencies_test.go
+++ b/internal/resolution/variablesources/bundles_and_dependencies_test.go
@@ -225,7 +225,7 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 		fakeCatalogClient = testutil.NewFakeCatalogClient(testBundleList)
 		bdvs = variablesources.NewBundlesAndDepsVariableSource(
 			&fakeCatalogClient,
-			&MockRequiredPackageSource{
+			&MockVariableSource{
 				ResultSet: []deppy.Variable{
 					// must match data in fakeCatalogClient
 					olmvariables.NewRequiredPackageVariable("test-package", []*catalogmetadata.Bundle{
@@ -257,7 +257,7 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 					}),
 				},
 			},
-			&MockRequiredPackageSource{
+			&MockVariableSource{
 				ResultSet: []deppy.Variable{
 					// must match data in fakeCatalogClient
 					olmvariables.NewRequiredPackageVariable("test-package-2", []*catalogmetadata.Bundle{
@@ -339,7 +339,7 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 
 		bdvs = variablesources.NewBundlesAndDepsVariableSource(
 			&emptyCatalogClient,
-			&MockRequiredPackageSource{
+			&MockVariableSource{
 				ResultSet: []deppy.Variable{
 					// must match data in fakeCatalogClient
 					olmvariables.NewRequiredPackageVariable("test-package", []*catalogmetadata.Bundle{
@@ -380,7 +380,7 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 	It("should return error if an inner variable source returns an error", func() {
 		bdvs = variablesources.NewBundlesAndDepsVariableSource(
 			&fakeCatalogClient,
-			&MockRequiredPackageSource{Error: errors.New("fake error")},
+			&MockVariableSource{Error: errors.New("fake error")},
 		)
 		_, err := bdvs.GetVariables(context.TODO())
 		Expect(err).To(HaveOccurred())
@@ -388,12 +388,12 @@ var _ = Describe("BundlesAndDepsVariableSource", func() {
 	})
 })
 
-type MockRequiredPackageSource struct {
+type MockVariableSource struct {
 	ResultSet []deppy.Variable
 	Error     error
 }
 
-func (m *MockRequiredPackageSource) GetVariables(_ context.Context) ([]deppy.Variable, error) {
+func (m *MockVariableSource) GetVariables(_ context.Context) ([]deppy.Variable, error) {
 	return m.ResultSet, m.Error
 }
 

--- a/internal/resolution/variablesources/installed_package_test.go
+++ b/internal/resolution/variablesources/installed_package_test.go
@@ -118,14 +118,15 @@ func TestInstalledPackageVariableSource(t *testing.T) {
 		},
 	}
 
-	const bundleImage = "registry.io/repo/test-package@v2.0.0"
 	fakeCatalogClient := testutil.NewFakeCatalogClient(bundleList)
 
 	t.Run("with ForceSemverUpgradeConstraints feature gate disabled", func(t *testing.T) {
 		defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)()
 
-		ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
-		require.NoError(t, err)
+		pkgName := "test-package"
+		bundleName := "test-package.v2.0.0"
+		bundleVersion := "2.0.0"
+		ipvs := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, pkgName, bundleName, bundleVersion)
 
 		variables, err := ipvs.GetVariables(context.TODO())
 		require.NoError(t, err)

--- a/internal/resolution/variablesources/operator_test.go
+++ b/internal/resolution/variablesources/operator_test.go
@@ -116,7 +116,7 @@ var _ = Describe("OperatorVariableSource", func() {
 	It("should produce RequiredPackage variables", func() {
 		cl := FakeClient(operator("prometheus"), operator("packageA"))
 		fakeCatalogClient := testutil.NewFakeCatalogClient(testBundleList)
-		opVariableSource := variablesources.NewOperatorVariableSource(cl, &fakeCatalogClient, &MockRequiredPackageSource{})
+		opVariableSource := variablesources.NewOperatorVariableSource(cl, &fakeCatalogClient, &MockVariableSource{})
 		variables, err := opVariableSource.GetVariables(context.Background())
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
# Description

This adds annotations to `BundleDeployment` objects created by operator-controller in response to `Operator` objects.

This makes it easier to filter bundles during resolution and makes us less dependant on image bundle format.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
