### PR TITLE
Remove randomness in package uniqueness ordering

### DIFF
--- a/internal/resolution/variablesources/crd_constraints_test.go
+++ b/internal/resolution/variablesources/crd_constraints_test.go
@@ -284,13 +284,13 @@ var _ = Describe("CRDUniquenessConstraintsVariableSource", func() {
 		}
 		// Note: As above, the 5 GVKs would appear here as GVK uniqueness constraints
 		// if GVK Uniqueness were being accounted for.
-		Expect(crdConstraintVariables).To(WithTransform(CollectGlobalConstraintVariableIDs, ConsistOf([]string{
-			"another-package package uniqueness",
-			"bar-package package uniqueness",
-			"test-package-2 package uniqueness",
+		Expect(crdConstraintVariables).To(WithTransform(CollectGlobalConstraintVariableIDs, Equal([]string{
 			"test-package package uniqueness",
 			"some-package package uniqueness",
 			"some-other-package package uniqueness",
+			"another-package package uniqueness",
+			"bar-package package uniqueness",
+			"test-package-2 package uniqueness",
 		})))
 	})
 


### PR DESCRIPTION
# Description

Partly addresses #459. I would still want to keep the issue open so we can get rid of `prettyUnsatMessage` function.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
