### PR TITLE
Add k8s.io/apimachinery/pkg/util/sets

### DIFF
--- a/internal/resolution/variablesources/bundle_deployment.go
+++ b/internal/resolution/variablesources/bundle_deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/operator-framework/deppy/pkg/deppy"
 	"github.com/operator-framework/deppy/pkg/deppy/input"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,14 +37,14 @@ func (o *BundleDeploymentVariableSource) GetVariables(ctx context.Context) ([]de
 		return nil, err
 	}
 
-	processed := map[string]struct{}{}
+	processed := sets.Set[string]{}
 	for _, bundleDeployment := range bundleDeployments.Items {
 		sourceImage := bundleDeployment.Spec.Template.Spec.Source.Image
 		if sourceImage != nil && sourceImage.Ref != "" {
-			if _, ok := processed[sourceImage.Ref]; ok {
+			if processed.Has(sourceImage.Ref) {
 				continue
 			}
-			processed[sourceImage.Ref] = struct{}{}
+			processed.Insert(sourceImage.Ref)
 			ips, err := NewInstalledPackageVariableSource(o.catalogClient, bundleDeployment.Spec.Template.Spec.Source.Image.Ref)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
# Description

Switches from `map` of empty `struct`s to using sets package from apimachinery utils.

Note: there is also `internal/resolution/variablesources/crd_constraints.go` which uses map for empty structs, but there is #461 which modifies this file and makes use of sets package.

Fixes #454

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
