### PR TITLE
Add extra tests for zero major version

### DIFF
--- a/internal/resolution/variablesources/installed_package_test.go
+++ b/internal/resolution/variablesources/installed_package_test.go
@@ -24,7 +24,27 @@ func TestInstalledPackageVariableSource(t *testing.T) {
 		Name: "stable",
 		Entries: []declcfg.ChannelEntry{
 			{
-				Name: "test-package.v1.0.0",
+				Name: "test-package.v0.0.1",
+			},
+			{
+				Name:     "test-package.v0.0.2",
+				Replaces: "test-package.v0.0.1",
+			},
+			{
+				Name:     "test-package.v0.1.0",
+				Replaces: "test-package.v0.0.2",
+			},
+			{
+				Name:     "test-package.v0.1.1",
+				Replaces: "test-package.v0.1.0",
+			},
+			{
+				Name:     "test-package.v0.2.0",
+				Replaces: "test-package.v0.1.1",
+			},
+			{
+				Name:     "test-package.v1.0.0",
+				Replaces: "test-package.v0.2.0",
 			},
 			{
 				Name:     "test-package.v2.0.0",
@@ -53,6 +73,51 @@ func TestInstalledPackageVariableSource(t *testing.T) {
 		},
 	}}
 	bundleList := []*catalogmetadata.Bundle{
+		{Bundle: declcfg.Bundle{
+			Name:    "test-package.v0.0.1",
+			Package: "test-package",
+			Image:   "registry.io/repo/test-package@v0.0.1",
+			Properties: []property.Property{
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.0.1"}`)},
+			}},
+			InChannels: []*catalogmetadata.Channel{&channel},
+		},
+		{Bundle: declcfg.Bundle{
+			Name:    "test-package.v0.0.2",
+			Package: "test-package",
+			Image:   "registry.io/repo/test-package@v0.0.2",
+			Properties: []property.Property{
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.0.2"}`)},
+			}},
+			InChannels: []*catalogmetadata.Channel{&channel},
+		},
+		{Bundle: declcfg.Bundle{
+			Name:    "test-package.v0.1.0",
+			Package: "test-package",
+			Image:   "registry.io/repo/test-package@v0.1.0",
+			Properties: []property.Property{
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.1.0"}`)},
+			}},
+			InChannels: []*catalogmetadata.Channel{&channel},
+		},
+		{Bundle: declcfg.Bundle{
+			Name:    "test-package.v0.1.1",
+			Package: "test-package",
+			Image:   "registry.io/repo/test-package@v0.1.1",
+			Properties: []property.Property{
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.1.1"}`)},
+			}},
+			InChannels: []*catalogmetadata.Channel{&channel},
+		},
+		{Bundle: declcfg.Bundle{
+			Name:    "test-package.v0.2.0",
+			Package: "test-package",
+			Image:   "registry.io/repo/test-package@v0.2.0",
+			Properties: []property.Property{
+				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.2.0"}`)},
+			}},
+			InChannels: []*catalogmetadata.Channel{&channel},
+		},
 		{Bundle: declcfg.Bundle{
 			Name:    "test-package.v1.0.0",
 			Package: "test-package",
@@ -118,33 +183,75 @@ func TestInstalledPackageVariableSource(t *testing.T) {
 		},
 	}
 
-	const bundleImage = "registry.io/repo/test-package@v2.0.0"
 	fakeCatalogClient := testutil.NewFakeCatalogClient(bundleList)
 
 	t.Run("with ForceSemverUpgradeConstraints feature gate enabled", func(t *testing.T) {
 		defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, true)()
 
-		ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
-		require.NoError(t, err)
+		t.Run("with non-zero major version", func(t *testing.T) {
+			const bundleImage = "registry.io/repo/test-package@v2.0.0"
+			ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
+			require.NoError(t, err)
 
-		variables, err := ipvs.GetVariables(context.TODO())
-		require.NoError(t, err)
-		require.Len(t, variables, 1)
-		packageVariable, ok := variables[0].(*olmvariables.InstalledPackageVariable)
-		assert.True(t, ok)
-		assert.Equal(t, deppy.IdentifierFromString("installed package test-package"), packageVariable.Identifier())
+			variables, err := ipvs.GetVariables(context.TODO())
+			require.NoError(t, err)
+			require.Len(t, variables, 1)
+			packageVariable, ok := variables[0].(*olmvariables.InstalledPackageVariable)
+			assert.True(t, ok)
+			assert.Equal(t, deppy.IdentifierFromString("installed package test-package"), packageVariable.Identifier())
 
-		// ensure bundles are in version order (high to low)
-		bundles := packageVariable.Bundles()
-		require.Len(t, bundles, 3)
-		assert.Equal(t, "test-package.v2.2.0", packageVariable.Bundles()[0].Name)
-		assert.Equal(t, "test-package.v2.1.0", packageVariable.Bundles()[1].Name)
-		assert.Equal(t, "test-package.v2.0.0", packageVariable.Bundles()[2].Name)
+			// ensure bundles are in version order (high to low)
+			bundles := packageVariable.Bundles()
+			require.Len(t, bundles, 3)
+			assert.Equal(t, "test-package.v2.2.0", packageVariable.Bundles()[0].Name)
+			assert.Equal(t, "test-package.v2.1.0", packageVariable.Bundles()[1].Name)
+			assert.Equal(t, "test-package.v2.0.0", packageVariable.Bundles()[2].Name)
+		})
+
+		t.Run("with zero major version", func(t *testing.T) {
+			t.Run("with zero minor version", func(t *testing.T) {
+				const bundleImage = "registry.io/repo/test-package@v0.0.1"
+				ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
+				require.NoError(t, err)
+
+				variables, err := ipvs.GetVariables(context.TODO())
+				require.NoError(t, err)
+				require.Len(t, variables, 1)
+				packageVariable, ok := variables[0].(*olmvariables.InstalledPackageVariable)
+				assert.True(t, ok)
+				assert.Equal(t, deppy.IdentifierFromString("installed package test-package"), packageVariable.Identifier())
+
+				// No upgrades are allowed in major version zero when minor version is also zero
+				bundles := packageVariable.Bundles()
+				require.Len(t, bundles, 1)
+				assert.Equal(t, "test-package.v0.0.1", packageVariable.Bundles()[0].Name)
+			})
+
+			t.Run("with non-zero minor version", func(t *testing.T) {
+				const bundleImage = "registry.io/repo/test-package@v0.1.0"
+				ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
+				require.NoError(t, err)
+
+				variables, err := ipvs.GetVariables(context.TODO())
+				require.NoError(t, err)
+				require.Len(t, variables, 1)
+				packageVariable, ok := variables[0].(*olmvariables.InstalledPackageVariable)
+				assert.True(t, ok)
+				assert.Equal(t, deppy.IdentifierFromString("installed package test-package"), packageVariable.Identifier())
+
+				// Patch version upgrades are allowed, but not minor upgrades
+				bundles := packageVariable.Bundles()
+				require.Len(t, bundles, 2)
+				assert.Equal(t, "test-package.v0.1.1", packageVariable.Bundles()[0].Name)
+				assert.Equal(t, "test-package.v0.1.0", packageVariable.Bundles()[1].Name)
+			})
+		})
 	})
 
 	t.Run("with ForceSemverUpgradeConstraints feature gate disabled", func(t *testing.T) {
 		defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)()
 
+		const bundleImage = "registry.io/repo/test-package@v2.0.0"
 		ipvs, err := variablesources.NewInstalledPackageVariableSource(&fakeCatalogClient, bundleImage)
 		require.NoError(t, err)
 


### PR DESCRIPTION
# Description

Zero major version is reserved for initial development according to [SemVer spec](https://semver.org/#spec-item-4) and anything may change at any time.

As the result of the above update behaviour is different for it.

This is a follow up for https://github.com/operator-framework/operator-controller/pull/444#discussion_r1364836753

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
