### PR TITLE
Update E2E test data to fix `operator-developer-e2e`

### DIFF
--- a/test/operator-framework-e2e/operator_framework_test.go
+++ b/test/operator-framework-e2e/operator_framework_test.go
@@ -132,10 +132,10 @@ var _ = Describe("Operator Framework E2E for plain+v0 bundles", func() {
 			baseFolderPath: "../../testdata/bundles/plain-v0",
 			bundles: []BundleContent{
 				{
-					bundleVersion: "0.1.0",
+					bundleVersion: "1.1.0",
 				},
 				{
-					bundleVersion: "0.2.0",
+					bundleVersion: "1.2.0",
 				},
 			},
 		}
@@ -146,8 +146,8 @@ var _ = Describe("Operator Framework E2E for plain+v0 bundles", func() {
 			desiredChannelName: "beta",
 		}
 		operatorAction = &OperatorActionInfo{
-			installVersion: "0.1.0",
-			upgradeVersion: "0.2.0",
+			installVersion: "1.1.0",
+			upgradeVersion: "1.2.0",
 		}
 		for i, b := range bundleInfo.bundles {
 			bundleInfo.bundles[i].bInputDir = catalogDInfo.operatorName + ".v" + b.bundleVersion
@@ -267,10 +267,10 @@ var _ = Describe("Operator Framework E2E for registry+v1 bundles", func() {
 			baseFolderPath: "../../testdata/bundles/registry-v1",
 			bundles: []BundleContent{
 				{
-					bundleVersion: "0.1.0",
+					bundleVersion: "1.1.0",
 				},
 				{
-					bundleVersion: "0.2.0",
+					bundleVersion: "1.2.0",
 				},
 			},
 		}
@@ -280,8 +280,8 @@ var _ = Describe("Operator Framework E2E for registry+v1 bundles", func() {
 			operatorName:   "registry-operator",
 		}
 		operatorAction = &OperatorActionInfo{
-			installVersion: "0.1.0",
-			upgradeVersion: "0.2.0",
+			installVersion: "1.1.0",
+			upgradeVersion: "1.2.0",
 		}
 		for i, b := range bundleInfo.bundles {
 			bundleInfo.bundles[i].bInputDir = sdkInfo.projectName + ".v" + b.bundleVersion


### PR DESCRIPTION
Zero major version is reserved for initial development according to SemVer spec[^1] and anything may change at any time.
Updates for this version behaves differently:

* When version is `0.1.0` we allow versions which are >= `0.1.0` and < `0.2.0` (patch updates)
* When version is `0.0.1` we allow versions which are >= `0.0.1` and < `0.0.2` (no updates)

To be able to update in the second case (e.g. from `0.0.1` to `0.0.2`) users will have to set `.spec.upgradeConstraintPolicy` to `Ignore` once support for this implemented.

We have unit tests for the above behaviour, but E2E test data was not updated.

[^1]: https://semver.org/#spec-item-4

Fixes #481

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
