### PR TITLE
🌱 Part 3: Reduce number of variable sources. Installed packages

### DIFF
--- a/internal/resolution/variablesources/installed_package.go
+++ b/internal/resolution/variablesources/installed_package.go
@@ -1,71 +1,74 @@
 package variablesources
 
 import (
-	"context"
 	"fmt"
 	"sort"
 
 	mmsemver "github.com/Masterminds/semver/v3"
-	"github.com/operator-framework/deppy/pkg/deppy"
-	"github.com/operator-framework/deppy/pkg/deppy/input"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	catalogfilter "github.com/operator-framework/operator-controller/internal/catalogmetadata/filter"
 	catalogsort "github.com/operator-framework/operator-controller/internal/catalogmetadata/sort"
-	"github.com/operator-framework/operator-controller/internal/resolution/variables"
+	olmvariables "github.com/operator-framework/operator-controller/internal/resolution/variables"
 	"github.com/operator-framework/operator-controller/pkg/features"
 )
 
-var _ input.VariableSource = &InstalledPackageVariableSource{}
-
-type InstalledPackageVariableSource struct {
-	allBundles  []*catalogmetadata.Bundle
-	successors  successorsFunc
-	bundleImage string
-}
-
-func (r *InstalledPackageVariableSource) GetVariables(_ context.Context) ([]deppy.Variable, error) {
-	// find corresponding bundle for the installed content
-	resultSet := catalogfilter.Filter(r.allBundles, catalogfilter.WithBundleImage(r.bundleImage))
-	if len(resultSet) == 0 {
-		return nil, r.notFoundError()
-	}
-
-	// TODO: fast follow - we should check whether we are already supporting the channel attribute in the operator spec.
-	//       if so, we should take the value from spec of the operator CR in the owner ref of the bundle deployment.
-	//       If that channel is set, we need to update the filter above to filter by channel as well.
-	sort.SliceStable(resultSet, func(i, j int) bool {
-		return catalogsort.ByVersion(resultSet[i], resultSet[j])
-	})
-	installedBundle := resultSet[0]
-
-	upgradeEdges, err := r.successors(r.allBundles, installedBundle)
-	if err != nil {
-		return nil, err
-	}
-
-	// you can always upgrade to yourself, i.e. not upgrade
-	upgradeEdges = append(upgradeEdges, installedBundle)
-	return []deppy.Variable{
-		variables.NewInstalledPackageVariable(installedBundle.Package, upgradeEdges),
-	}, nil
-}
-
-func (r *InstalledPackageVariableSource) notFoundError() error {
-	return fmt.Errorf("bundleImage %q not found", r.bundleImage)
-}
-
-func NewInstalledPackageVariableSource(allBundles []*catalogmetadata.Bundle, bundleImage string) (*InstalledPackageVariableSource, error) {
-	successors := legacySemanticsSuccessors
+// MakeInstalledPackageVariables returns variables representing packages
+// already installed in the system.
+// Meaning that each BundleDeployment managed by operator-controller
+// has own variable.
+func MakeInstalledPackageVariables(
+	allBundles []*catalogmetadata.Bundle,
+	bundleDeployments []rukpakv1alpha1.BundleDeployment,
+) ([]*olmvariables.InstalledPackageVariable, error) {
+	var successors successorsFunc = legacySemanticsSuccessors
 	if features.OperatorControllerFeatureGate.Enabled(features.ForceSemverUpgradeConstraints) {
 		successors = semverSuccessors
 	}
 
-	return &InstalledPackageVariableSource{
-		allBundles:  allBundles,
-		bundleImage: bundleImage,
-		successors:  successors,
-	}, nil
+	result := make([]*olmvariables.InstalledPackageVariable, 0, len(bundleDeployments))
+	processed := sets.Set[string]{}
+	for _, bundleDeployment := range bundleDeployments {
+		if bundleDeployment.Spec.Template == nil {
+			continue
+		}
+		sourceImage := bundleDeployment.Spec.Template.Spec.Source.Image
+		if sourceImage == nil || sourceImage.Ref == "" {
+			continue
+		}
+
+		if processed.Has(sourceImage.Ref) {
+			continue
+		}
+		processed.Insert(sourceImage.Ref)
+
+		bundleImage := sourceImage.Ref
+
+		// find corresponding bundle for the installed content
+		resultSet := catalogfilter.Filter(allBundles, catalogfilter.WithBundleImage(bundleImage))
+		if len(resultSet) == 0 {
+			return nil, fmt.Errorf("bundleImage %q not found", bundleImage)
+		}
+
+		sort.SliceStable(resultSet, func(i, j int) bool {
+			return catalogsort.ByVersion(resultSet[i], resultSet[j])
+		})
+		installedBundle := resultSet[0]
+
+		upgradeEdges, err := successors(allBundles, installedBundle)
+		if err != nil {
+			return nil, err
+		}
+
+		// you can always upgrade to yourself, i.e. not upgrade
+		upgradeEdges = append(upgradeEdges, installedBundle)
+		result = append(result, olmvariables.NewInstalledPackageVariable(installedBundle.Package, upgradeEdges))
+	}
+
+	return result, nil
 }
 
 // successorsFunc must return successors of a currently installed bundle


### PR DESCRIPTION
# Description

Spliting https://github.com/operator-framework/operator-controller/pull/460 into smaller chunks. Related to https://github.com/operator-framework/operator-controller/issues/437

In this part I extract code related to creating installed package variables from `InstalledPackageVariableSource` and `BundleDeploymentVariableSource` into a separate function.

`InstalledPackageVariableSource` gets removed in this PR. `BundleDeploymentVariableSource` will be removed later in #501

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
