### PR TITLE
🌱 Add UID to fake `Operator` objects in tests

### DIFF
--- a/internal/resolution/variablesources/bundle_deployment_test.go
+++ b/internal/resolution/variablesources/bundle_deployment_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/operator-framework/operator-controller/internal/resolution/variablesources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/pointer"
 
 	"github.com/operator-framework/deppy/pkg/deppy"
@@ -26,6 +27,10 @@ func fakeOperator(name, packageName string, upgradeConstraintPolicy operatorsv1a
 	return operatorsv1alpha1.Operator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			// We manually set a fake UID here because the code we test
+			// uses UID to determine Operator CR which
+			// owns `BundleDeployment`
+			UID: uuid.NewUUID(),
 		},
 		Spec: operatorsv1alpha1.OperatorSpec{
 			PackageName:             packageName,

--- a/internal/resolution/variablesources/installed_package_test.go
+++ b/internal/resolution/variablesources/installed_package_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
 
@@ -207,6 +208,10 @@ func TestMakeInstalledPackageVariables(t *testing.T) {
 		return operatorsv1alpha1.Operator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+				// We manually set a fake UID here because the code we test
+				// uses UID to determine Operator CR which
+				// owns `BundleDeployment`
+				UID: uuid.NewUUID(),
 			},
 			Spec: operatorsv1alpha1.OperatorSpec{
 				PackageName:             packageName,


### PR DESCRIPTION
# Description

The code we test relies on UID and having UID set will ensure greater correctness of our tests.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
