### PR TITLE
🐛 update catalog status field being used for stale cache identification

### DIFF
--- a/internal/catalogmetadata/cache/cache.go
+++ b/internal/catalogmetadata/cache/cache.go
@@ -84,7 +84,7 @@ func (fsc *filesystemCache) FetchCatalogContents(ctx context.Context, catalog *c
 
 	fsc.mutex.RLock()
 	if data, ok := fsc.cacheDataByCatalogName[catalog.Name]; ok {
-		if catalog.Status.ResolvedSource.Image.Ref == data.ResolvedRef {
+		if catalog.Status.ResolvedSource.Image.ResolvedRef == data.ResolvedRef {
 			fsc.mutex.RUnlock()
 			return os.Open(cacheFilePath)
 		}
@@ -143,7 +143,7 @@ func (fsc *filesystemCache) FetchCatalogContents(ctx context.Context, catalog *c
 	}
 
 	fsc.cacheDataByCatalogName[catalog.Name] = cacheData{
-		ResolvedRef: catalog.Status.ResolvedSource.Image.Ref,
+		ResolvedRef: catalog.Status.ResolvedSource.Image.ResolvedRef,
 	}
 
 	return file, nil

--- a/internal/catalogmetadata/cache/cache_test.go
+++ b/internal/catalogmetadata/cache/cache_test.go
@@ -72,7 +72,7 @@ func TestCache(t *testing.T) {
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
-								Ref: "fake/catalog@sha256:fakesha",
+								ResolvedRef: "fake/catalog@sha256:fakesha",
 							},
 						},
 					},
@@ -90,7 +90,7 @@ func TestCache(t *testing.T) {
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
-								Ref: "fake/catalog@sha256:fakesha",
+								ResolvedRef: "fake/catalog@sha256:fakesha",
 							},
 						},
 					},
@@ -110,7 +110,7 @@ func TestCache(t *testing.T) {
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
-								Ref: "fake/catalog@sha256:fakesha",
+								ResolvedRef: "fake/catalog@sha256:fakesha",
 							},
 						},
 					},
@@ -130,7 +130,7 @@ func TestCache(t *testing.T) {
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
-								Ref: "fake/catalog@sha256:fakesha",
+								ResolvedRef: "fake/catalog@sha256:fakesha",
 							},
 						},
 					},
@@ -149,7 +149,7 @@ func TestCache(t *testing.T) {
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
-								Ref: "fake/catalog@sha256:fakesha",
+								ResolvedRef: "fake/catalog@sha256:fakesha",
 							},
 						},
 					},

--- a/internal/catalogmetadata/cache/cache_test.go
+++ b/internal/catalogmetadata/cache/cache_test.go
@@ -223,7 +223,7 @@ func TestCache(t *testing.T) {
 
 				if tt.testCaching {
 					if !tt.shouldHitCache {
-						tt.catalog.Status.ResolvedSource.Image.Ref = "fake/catalog@sha256:shafake"
+						tt.catalog.Status.ResolvedSource.Image.ResolvedRef = "fake/catalog@sha256:shafake"
 					}
 					tt.tripper.content = append(tt.tripper.content, []byte(`{"schema": "olm.package", "name": "foobar"}`)...)
 					rc, err := c.FetchCatalogContents(ctx, tt.catalog)


### PR DESCRIPTION

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
- Updates the field used for identifying whether or not the cache of `Catalog` contents is stale
- resolves #528 

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
