### PR TITLE
🐛 Prevent updates from one package to another

### DIFF
--- a/internal/resolution/variablesources/bundle_deployment_test.go
+++ b/internal/resolution/variablesources/bundle_deployment_test.go
@@ -136,7 +136,7 @@ var _ = Describe("BundleDeploymentVariableSource", func() {
 	})
 
 	It("should produce RequiredPackage variables", func() {
-		fakeOperator := fakeOperator("test-operator", "test-prometheus", operatorsv1alpha1.UpgradeConstraintPolicyEnforce)
+		fakeOperator := fakeOperator("test-operator", "prometheus", operatorsv1alpha1.UpgradeConstraintPolicyEnforce)
 		operators := []operatorsv1alpha1.Operator{fakeOperator}
 		bundleDeployments := []rukpakv1alpha1.BundleDeployment{
 			bundleDeployment("prometheus", "quay.io/operatorhubio/prometheus@sha256:3e281e587de3d03011440685fc4fb782672beab044c1ebadc42788ce05a21c35", &fakeOperator),
@@ -161,7 +161,7 @@ var _ = Describe("BundleDeploymentVariableSource", func() {
 		})))
 	})
 	It("should return an error if the bundleDeployment image doesn't match any operator resource", func() {
-		fakeOperator := fakeOperator("test-operator", "test-prometheus", operatorsv1alpha1.UpgradeConstraintPolicyEnforce)
+		fakeOperator := fakeOperator("test-operator", "prometheus", operatorsv1alpha1.UpgradeConstraintPolicyEnforce)
 		operators := []operatorsv1alpha1.Operator{fakeOperator}
 		bundleDeployments := []rukpakv1alpha1.BundleDeployment{
 			bundleDeployment("prometheus", "quay.io/operatorhubio/prometheus@sha256:nonexistent", &fakeOperator),
@@ -169,6 +169,6 @@ var _ = Describe("BundleDeploymentVariableSource", func() {
 
 		bdVariableSource := variablesources.NewBundleDeploymentVariableSource(operators, bundleDeployments, testBundleList, &MockRequiredPackageSource{})
 		_, err := bdVariableSource.GetVariables(context.Background())
-		Expect(err.Error()).To(Equal(`bundle with image "quay.io/operatorhubio/prometheus@sha256:nonexistent" not found in available catalogs but is currently installed via BundleDeployment "prometheus"`))
+		Expect(err.Error()).To(Equal(`bundle with image "quay.io/operatorhubio/prometheus@sha256:nonexistent" for package "prometheus" not found in available catalogs but is currently installed via BundleDeployment "prometheus"`))
 	})
 })

--- a/internal/resolution/variablesources/installed_package.go
+++ b/internal/resolution/variablesources/installed_package.go
@@ -64,9 +64,12 @@ func MakeInstalledPackageVariables(
 		bundleImage := sourceImage.Ref
 
 		// find corresponding bundle for the installed content
-		resultSet := catalogfilter.Filter(allBundles, catalogfilter.WithBundleImage(bundleImage))
+		resultSet := catalogfilter.Filter(allBundles, catalogfilter.And(
+			catalogfilter.WithPackageName(operator.Spec.PackageName),
+			catalogfilter.WithBundleImage(bundleImage),
+		))
 		if len(resultSet) == 0 {
-			return nil, fmt.Errorf("bundle with image %q not found in available catalogs but is currently installed via BundleDeployment %q", bundleImage, bundleDeployment.Name)
+			return nil, fmt.Errorf("bundle with image %q for package %q not found in available catalogs but is currently installed via BundleDeployment %q", bundleImage, operator.Spec.PackageName, bundleDeployment.Name)
 		}
 
 		sort.SliceStable(resultSet, func(i, j int) bool {

--- a/internal/resolution/variablesources/installed_package_test.go
+++ b/internal/resolution/variablesources/installed_package_test.go
@@ -390,6 +390,6 @@ func TestMakeInstalledPackageVariables(t *testing.T) {
 			},
 		)
 		assert.Nil(t, installedPackages)
-		assert.ErrorContains(t, err, `bundle with image "registry.io/repo/test-package@v9.0.0" not found in available catalogs but is currently installed via BundleDeployment "test-package-bd"`)
+		assert.ErrorContains(t, err, `bundle with image "registry.io/repo/test-package@v9.0.0" for package "test-package" not found in available catalogs but is currently installed via BundleDeployment "test-package-bd"`)
 	})
 }


### PR DESCRIPTION
# Description

This commit adds extra bundle filtering when looking for a currently installed bundle. This prevents updates
from one package to another in case when currently installed bundle shares bundle image with a bundle from another package.

Closes #466

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
