### PR TITLE
🌱 Remove `prettyUnsatMessage` workaround

### DIFF
--- a/internal/controllers/operator_controller_test.go
+++ b/internal/controllers/operator_controller_test.go
@@ -1128,7 +1128,7 @@ func TestOperatorUpgrade(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 		assert.Equal(t, operatorsv1alpha1.ReasonResolutionFailed, cond.Reason)
 		assert.Contains(t, cond.Message, "constraints not satisfiable")
-		assert.Contains(t, cond.Message, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.2.0, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.0;")
+		assert.Regexp(t, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.2.0, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.0$", cond.Message)
 
 		// Valid update skipping one version
 		operator.Spec.Version = "1.2.0"
@@ -1221,7 +1221,7 @@ func TestOperatorUpgrade(t *testing.T) {
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
 		assert.Equal(t, operatorsv1alpha1.ReasonResolutionFailed, cond.Reason)
 		assert.Contains(t, cond.Message, "constraints not satisfiable")
-		assert.Contains(t, cond.Message, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.0;")
+		assert.Contains(t, cond.Message, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.0\n")
 
 		// Valid update skipping one version
 		operator.Spec.Version = "1.0.1"
@@ -1418,7 +1418,7 @@ func TestOperatorDowngrade(t *testing.T) {
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
 				assert.Equal(t, operatorsv1alpha1.ReasonResolutionFailed, cond.Reason)
 				assert.Contains(t, cond.Message, "constraints not satisfiable")
-				assert.Contains(t, cond.Message, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.2.0, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1;")
+				assert.Contains(t, cond.Message, "installed package prometheus requires at least one of fake-catalog-prometheus-operatorhub/prometheus/beta/1.2.0, fake-catalog-prometheus-operatorhub/prometheus/beta/1.0.1\n")
 			})
 		}
 	})

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Operator Install", func() {
 					g.Expect(cond).ToNot(BeNil())
 					g.Expect(cond.Reason).To(Equal(operatorv1alpha1.ReasonResolutionFailed))
 					g.Expect(cond.Message).To(ContainSubstring("constraints not satisfiable"))
-					g.Expect(cond.Message).To(ContainSubstring("installed package prometheus requires at least one of test-catalog-prometheus-prometheus-operator.1.2.0, test-catalog-prometheus-prometheus-operator.1.0.1, test-catalog-prometheus-prometheus-operator.1.0.0;"))
+					g.Expect(cond.Message).To(MatchRegexp("installed package prometheus requires at least one of test-catalog-prometheus-prometheus-operator.1.2.0, test-catalog-prometheus-prometheus-operator.1.0.1, test-catalog-prometheus-prometheus-operator.1.0.0$"))
 					g.Expect(operator.Status.ResolvedBundleResource).To(BeEmpty())
 				}).Should(Succeed())
 			})


### PR DESCRIPTION
# Description

It was a workaround a Deppy issue. We no longer need it since Deppy fixed the issue.

Related Deppy issues:
* https://github.com/operator-framework/deppy/issues/150 
* https://github.com/operator-framework/deppy/issues/142

Closes #459

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
