### PR TITLE
⚠ bump rukpak to v0.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/operator-framework/catalogd v0.10.0
 	github.com/operator-framework/deppy v0.1.0
 	github.com/operator-framework/operator-registry v1.32.0
-	github.com/operator-framework/rukpak v0.15.0
+	github.com/operator-framework/rukpak v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ github.com/operator-framework/deppy v0.1.0 h1:Kj6SgSSMsPTbiWObYe7P1JPsW6CWkuVc+3
 github.com/operator-framework/deppy v0.1.0/go.mod h1:3blHej0Hj0M17Ru2q3QrhN9OwB5/MMmFkWUmiInqs6A=
 github.com/operator-framework/operator-registry v1.32.0 h1:RNazXYt3vBf5FZ+JrNNjq4bNh3tDwlkwZJnC+kmCeKk=
 github.com/operator-framework/operator-registry v1.32.0/go.mod h1:89VshAf6+n0V12vdh43+WOi8i1+XpY+kg6Ao4JO0y6k=
-github.com/operator-framework/rukpak v0.15.0 h1:NRByKr3NgtuehLbw1TLEygszSQhruVUcg9/vgFou6hM=
-github.com/operator-framework/rukpak v0.15.0/go.mod h1:v3dlRs4NG8cMht5X5shsCDlljVwjl7LX8uWrh53rsUc=
+github.com/operator-framework/rukpak v0.16.0 h1:d6iI7lYJbR5fHqw3vnAudB5SevAQ2dnQI7C6iOZyXJU=
+github.com/operator-framework/rukpak v0.16.0/go.mod h1:k3Nbp5eGqTI+QvXgPuOWOSV24AJ6waPDPzD+AH5OyDA=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/internal/controllers/operator_controller_test.go
+++ b/internal/controllers/operator_controller_test.go
@@ -213,7 +213,7 @@ func TestOperatorBundleDeploymentOutOfDate(t *testing.T) {
 		},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
 			ProvisionerClassName: "core-rukpak-io-plain",
-			Template: &rukpakv1alpha1.BundleTemplate{
+			Template: rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "core-rukpak-io-registry",
 					Source: rukpakv1alpha1.BundleSource{
@@ -304,7 +304,7 @@ func TestOperatorBundleDeploymentUpToDate(t *testing.T) {
 		},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
 			ProvisionerClassName: "core-rukpak-io-plain",
-			Template: &rukpakv1alpha1.BundleTemplate{
+			Template: rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "core-rukpak-io-registry",
 					Source: rukpakv1alpha1.BundleSource{
@@ -566,7 +566,7 @@ func TestOperatorExpectedBundleDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: opKey.Name},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
 			ProvisionerClassName: "foo",
-			Template: &rukpakv1alpha1.BundleTemplate{
+			Template: rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "bar",
 					Source: rukpakv1alpha1.BundleSource{

--- a/internal/controllers/variable_source_test.go
+++ b/internal/controllers/variable_source_test.go
@@ -89,7 +89,7 @@ func TestVariableSource(t *testing.T) {
 		},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
 			ProvisionerClassName: "core-rukpak-io-plain",
-			Template: &rukpakv1alpha1.BundleTemplate{
+			Template: rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "core-rukpak-io-registry",
 					Source: rukpakv1alpha1.BundleSource{

--- a/internal/resolution/variablesources/fake_object_utils_test.go
+++ b/internal/resolution/variablesources/fake_object_utils_test.go
@@ -33,7 +33,7 @@ func fakeBundleDeployment(name, bundleImage string, owner *operatorsv1alpha1.Ope
 		},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
 			ProvisionerClassName: "core-rukpak-io-plain",
-			Template: &rukpakv1alpha1.BundleTemplate{
+			Template: rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "core-rukpak-io-plain",
 					Source: rukpakv1alpha1.BundleSource{

--- a/internal/resolution/variablesources/installed_package.go
+++ b/internal/resolution/variablesources/installed_package.go
@@ -48,9 +48,6 @@ func MakeInstalledPackageVariables(
 			continue
 		}
 
-		if bundleDeployment.Spec.Template == nil {
-			continue
-		}
 		sourceImage := bundleDeployment.Spec.Template.Spec.Source.Image
 		if sourceImage == nil || sourceImage.Ref == "" {
 			continue


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
Bumping rukpak dependency to v0.16.0. This includes changes to the way that rukpak names `Bundle` objects derived from `BundleDeployments` and the way that performs registry+v1 to plain conversion. This results in different names and labels for some objects, so it may be a breaking change for some users.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
