### PR TITLE
:sparkles: (feat): add graph deprecation logic

### DIFF
--- a/api/v1alpha1/clusterextension_types.go
+++ b/api/v1alpha1/clusterextension_types.go
@@ -71,6 +71,12 @@ const (
 	// TODO(user): add more Types, here and into init()
 	TypeInstalled = "Installed"
 	TypeResolved  = "Resolved"
+	// TypeDeprecated is a rollup condition that is present when
+	// any of the deprecated conditions are present.
+	TypeDeprecated        = "Deprecated"
+	TypePackageDeprecated = "PackageDeprecated"
+	TypeChannelDeprecated = "ChannelDeprecated"
+	TypeBundleDeprecated  = "BundleDeprecated"
 
 	ReasonBundleLookupFailed        = "BundleLookupFailed"
 	ReasonInstallationFailed        = "InstallationFailed"
@@ -80,6 +86,7 @@ const (
 	ReasonResolutionFailed          = "ResolutionFailed"
 	ReasonResolutionUnknown         = "ResolutionUnknown"
 	ReasonSuccess                   = "Success"
+	ReasonDeprecated                = "Deprecated"
 )
 
 func init() {
@@ -87,6 +94,10 @@ func init() {
 	conditionsets.ConditionTypes = append(conditionsets.ConditionTypes,
 		TypeInstalled,
 		TypeResolved,
+		TypeDeprecated,
+		TypePackageDeprecated,
+		TypeChannelDeprecated,
+		TypeBundleDeprecated,
 	)
 	// TODO(user): add Reasons from above
 	conditionsets.ConditionReasons = append(conditionsets.ConditionReasons,
@@ -98,6 +109,7 @@ func init() {
 		ReasonInstallationStatusUnknown,
 		ReasonInvalidSpec,
 		ReasonSuccess,
+		ReasonDeprecated,
 	)
 }
 

--- a/cmd/resolutioncli/client.go
+++ b/cmd/resolutioncli/client.go
@@ -47,8 +47,9 @@ func (c *indexRefClient) Bundles(ctx context.Context) ([]*catalogmetadata.Bundle
 		}
 
 		var (
-			channels []*catalogmetadata.Channel
-			bundles  []*catalogmetadata.Bundle
+			channels     []*catalogmetadata.Channel
+			bundles      []*catalogmetadata.Bundle
+			deprecations []*catalogmetadata.Deprecation
 		)
 
 		for i := range cfg.Channels {
@@ -63,10 +64,16 @@ func (c *indexRefClient) Bundles(ctx context.Context) ([]*catalogmetadata.Bundle
 			})
 		}
 
+		for i := range cfg.Deprecations {
+			deprecations = append(deprecations, &catalogmetadata.Deprecation{
+				Deprecation: cfg.Deprecations[i],
+			})
+		}
+
 		// TODO: update fake catalog name string to be catalog name once we support multiple catalogs in CLI
 		catalogName := "offline-catalog"
 
-		bundles, err = client.PopulateExtraFields(catalogName, channels, bundles)
+		bundles, err = client.PopulateExtraFields(catalogName, channels, bundles, deprecations)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/catalogmetadata/client/client_test.go
+++ b/internal/catalogmetadata/client/client_test.go
@@ -126,6 +126,45 @@ func TestClient(t *testing.T) {
 				},
 				fetcher: &MockFetcher{},
 			},
+			{
+				name: "deprecated at the package, channel, and bundle level",
+				fakeCatalog: func() ([]client.Object, []*catalogmetadata.Bundle, map[string][]byte) {
+					objs, bundles, catalogContentMap := defaultFakeCatalog()
+
+					catalogContentMap["catalog-1"] = append(catalogContentMap["catalog-1"],
+						[]byte(`{"schema": "olm.deprecations", "package":"fake1", "entries":[{"message": "fake1 is deprecated", "reference": {"schema": "olm.package"}}, {"message":"channel stable is deprecated", "reference": {"schema": "olm.channel", "name": "stable"}}, {"message": "bundle fake1.v1.0.0 is deprecated", "reference":{"schema":"olm.bundle", "name":"fake1.v1.0.0"}}]}`)...)
+
+					for i := range bundles {
+						if bundles[i].Package == "fake1" && bundles[i].CatalogName == "catalog-1" && bundles[i].Name == "fake1.v1.0.0" {
+							bundles[i].Deprecations = append(bundles[i].Deprecations, declcfg.DeprecationEntry{
+								Reference: declcfg.PackageScopedReference{
+									Schema: "olm.package",
+								},
+								Message: "fake1 is deprecated",
+							})
+
+							bundles[i].Deprecations = append(bundles[i].Deprecations, declcfg.DeprecationEntry{
+								Reference: declcfg.PackageScopedReference{
+									Schema: "olm.channel",
+									Name:   "stable",
+								},
+								Message: "channel stable is deprecated",
+							})
+
+							bundles[i].Deprecations = append(bundles[i].Deprecations, declcfg.DeprecationEntry{
+								Reference: declcfg.PackageScopedReference{
+									Schema: "olm.bundle",
+									Name:   "fake1.v1.0.0",
+								},
+								Message: "bundle fake1.v1.0.0 is deprecated",
+							})
+						}
+					}
+
+					return objs, bundles, catalogContentMap
+				},
+				fetcher: &MockFetcher{},
+			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				ctx := context.Background()

--- a/internal/catalogmetadata/filter/bundle_predicates.go
+++ b/internal/catalogmetadata/filter/bundle_predicates.go
@@ -70,3 +70,9 @@ func Replaces(bundleName string) Predicate[catalogmetadata.Bundle] {
 		return false
 	}
 }
+
+func WithDeprecation(deprecated bool) Predicate[catalogmetadata.Bundle] {
+	return func(bundle *catalogmetadata.Bundle) bool {
+		return bundle.HasDeprecation() == deprecated
+	}
+}

--- a/internal/catalogmetadata/filter/bundle_predicates_test.go
+++ b/internal/catalogmetadata/filter/bundle_predicates_test.go
@@ -158,3 +158,19 @@ func TestReplaces(t *testing.T) {
 	assert.False(t, f(b2))
 	assert.False(t, f(b3))
 }
+
+func TestWithDeprecation(t *testing.T) {
+	b1 := &catalogmetadata.Bundle{
+		Deprecations: []declcfg.DeprecationEntry{
+			{
+				Reference: declcfg.PackageScopedReference{},
+			},
+		},
+	}
+
+	b2 := &catalogmetadata.Bundle{}
+
+	f := filter.WithDeprecation(true)
+	assert.True(t, f(b1))
+	assert.False(t, f(b2))
+}

--- a/internal/catalogmetadata/sort/sort.go
+++ b/internal/catalogmetadata/sort/sort.go
@@ -18,6 +18,25 @@ func ByVersion(b1, b2 *catalogmetadata.Bundle) bool {
 	return ver1.GT(*ver2)
 }
 
+// ByDeprecation is a sort "less" function that orders bundles
+// that are deprecated lower than ones without deprecations
+func ByDeprecated(b1, b2 *catalogmetadata.Bundle) bool {
+	b1Val := 1
+	b2Val := 1
+
+	if b1.IsDeprecated() {
+		b1Val = b1Val - 1
+	}
+
+	if b2.IsDeprecated() {
+		b2Val = b2Val - 1
+	}
+
+	// Check for "greater than" because we
+	// non deprecated on top
+	return b1Val > b2Val
+}
+
 // compareErrors returns 0 if both errors are either nil or not nil
 // -1 if err1 is nil and err2 is not nil
 // +1 if err1 is not nil and err2 is nil

--- a/internal/catalogmetadata/types_test.go
+++ b/internal/catalogmetadata/types_test.go
@@ -201,3 +201,31 @@ func TestBundleMediaType(t *testing.T) {
 		})
 	}
 }
+
+func TestBundleHasDeprecation(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		bundle     *catalogmetadata.Bundle
+		deprecated bool
+	}{
+		{
+			name: "has deprecation entries",
+			bundle: &catalogmetadata.Bundle{
+				Deprecations: []declcfg.DeprecationEntry{
+					{
+						Reference: declcfg.PackageScopedReference{},
+					},
+				},
+			},
+			deprecated: true,
+		},
+		{
+			name:   "has no deprecation entries",
+			bundle: &catalogmetadata.Bundle{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.deprecated, tt.bundle.HasDeprecation())
+		})
+	}
+}

--- a/internal/resolution/variablesources/required_package.go
+++ b/internal/resolution/variablesources/required_package.go
@@ -56,6 +56,9 @@ func MakeRequiredPackageVariables(allBundles []*catalogmetadata.Bundle, clusterE
 		sort.SliceStable(resultSet, func(i, j int) bool {
 			return catalogsort.ByVersion(resultSet[i], resultSet[j])
 		})
+		sort.SliceStable(resultSet, func(i, j int) bool {
+			return catalogsort.ByDeprecated(resultSet[i], resultSet[j])
+		})
 
 		result = append(result, olmvariables.NewRequiredPackageVariable(packageName, resultSet))
 	}

--- a/internal/resolution/variablesources/required_package_test.go
+++ b/internal/resolution/variablesources/required_package_test.go
@@ -63,6 +63,63 @@ func TestMakeRequiredPackageVariables(t *testing.T) {
 			},
 			InChannels: []*catalogmetadata.Channel{&stableChannel},
 		},
+		"test-package.v4.0.0": {
+			Bundle: declcfg.Bundle{
+				Name:    "test-package.v4.0.0",
+				Package: "test-package",
+				Properties: []property.Property{
+					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "4.0.0"}`)},
+				},
+			},
+			InChannels: []*catalogmetadata.Channel{&stableChannel},
+			Deprecations: []declcfg.DeprecationEntry{
+				{
+					Reference: declcfg.PackageScopedReference{
+						Schema: declcfg.SchemaBundle,
+						Name:   "test-package.v4.0.0",
+					},
+					Message: "test-package.v4.0.0 has been deprecated",
+				},
+			},
+		},
+		"test-package.v4.1.0": {
+			Bundle: declcfg.Bundle{
+				Name:    "test-package.v4.1.0",
+				Package: "test-package",
+				Properties: []property.Property{
+					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "4.1.0"}`)},
+				},
+			},
+			InChannels: []*catalogmetadata.Channel{&stableChannel},
+			Deprecations: []declcfg.DeprecationEntry{
+				{
+					Reference: declcfg.PackageScopedReference{
+						Schema: declcfg.SchemaBundle,
+						Name:   "test-package.v4.1.0",
+					},
+					Message: "test-package.v4.1.0 has been deprecated",
+				},
+			},
+		},
+		"test-package.v5.0.0": {
+			Bundle: declcfg.Bundle{
+				Name:    "test-package.v5.0.0",
+				Package: "test-package",
+				Properties: []property.Property{
+					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "5.0.0"}`)},
+				},
+			},
+			InChannels: []*catalogmetadata.Channel{&stableChannel},
+			Deprecations: []declcfg.DeprecationEntry{
+				{
+					Reference: declcfg.PackageScopedReference{
+						Schema: declcfg.SchemaBundle,
+						Name:   "test-package.v5.0.0",
+					},
+					Message: "test-package.v5.0.0 has been deprecated",
+				},
+			},
+		},
 
 		// We need at least one bundle from different package
 		// to make sure that we are filtering it out.
@@ -111,6 +168,9 @@ func TestMakeRequiredPackageVariables(t *testing.T) {
 					bundleSet["test-package.v3.0.0"],
 					bundleSet["test-package.v2.0.0"],
 					bundleSet["test-package.v1.0.0"],
+					bundleSet["test-package.v5.0.0"],
+					bundleSet["test-package.v4.1.0"],
+					bundleSet["test-package.v4.0.0"],
 				}),
 			},
 		},

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -81,7 +81,7 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 	t.Log("By eventually reporting a successful resolution and bundle path")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		assert.Len(ct, clusterExtension.Status.Conditions, 2)
+		assert.Len(ct, clusterExtension.Status.Conditions, 6)
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
 		if !assert.NotNil(ct, cond) {
 			return
@@ -137,7 +137,7 @@ func TestClusterExtensionInstallPlain(t *testing.T) {
 	t.Log("By eventually reporting a successful resolution and bundle path")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		assert.Len(ct, clusterExtension.Status.Conditions, 2)
+		assert.Len(ct, clusterExtension.Status.Conditions, 6)
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
 		if !assert.NotNil(ct, cond) {
 			return


### PR DESCRIPTION
# Description
- Add new condition types and reasons to signal when an installed bundle for a `ClusterExtension` has deprecations associated with it
- Update the `catalogmetadata.Bundle` type to have fields to hold the deprecation information for a bundle
- Update the resolution logic to prefer bundles with deprecations less than bundles without
- Update the `ClusterExtension` reconciler logic to add the deprecation statuses if there are any associated with the installed bundle

# Motivation
- Implements [RFC: OLMv1 Graph Deprecation](https://docs.google.com/document/d/1CYGANKILfzfOoWtHvyg4luF7i-cC1NRa7_1N9xTLatw/edit?usp=sharing)
- fixes #525 
- fixes #526 
- fixes #527

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
