### PR TITLE
:seedling: bump catalogd to v0.11.0

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -70,3 +70,4 @@ $(SETUP_ENVTEST): $(BINGO_DIR)/setup-envtest.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/setup-envtest-v0.0.0-20230606045100-e54088c8c7da"
 	@cd $(BINGO_DIR) && GOWORK=off $(GO) build -mod=mod -modfile=setup-envtest.mod -o=$(GOBIN)/setup-envtest-v0.0.0-20230606045100-e54088c8c7da "sigs.k8s.io/controller-runtime/tools/setup-envtest"
+

--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -25,3 +25,4 @@ OPERATOR_SDK="${GOBIN}/operator-sdk-v1.31.0"
 OPM="${GOBIN}/opm-v1.28.0"
 
 SETUP_ENVTEST="${GOBIN}/setup-envtest-v0.0.0-20230606045100-e54088c8c7da"
+

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
-	github.com/operator-framework/catalogd v0.10.0
+	github.com/operator-framework/catalogd v0.11.0
 	github.com/operator-framework/deppy v0.3.0
 	github.com/operator-framework/operator-registry v1.34.0
 	github.com/operator-framework/rukpak v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=
 github.com/operator-framework/api v0.20.0/go.mod h1:rXPOhrQ6mMeXqCmpDgt1ALoar9ZlHL+Iy5qut9R99a4=
-github.com/operator-framework/catalogd v0.10.0 h1:T207IQfQCcd3f31bDPCgfJcwEvmaPGV8BotqIzIvnRo=
-github.com/operator-framework/catalogd v0.10.0/go.mod h1:xIeR5f/Spr5rHnLp0yOi0AYetWcHvBAx9n+K3S/va2A=
+github.com/operator-framework/catalogd v0.11.0 h1:b1ifk/TriPTo4KkdVTSWi6HY959h/ZD7sHuBKGEbLDA=
+github.com/operator-framework/catalogd v0.11.0/go.mod h1:AHz6B7NxC7cywF6P3XclmCim1bs0y0g2+LdycdIGAmE=
 github.com/operator-framework/deppy v0.3.0 h1:W8wpF0ehcTAdH2WfMyqMPI5Ja0Qv8M5FMO5cXgJvEQ8=
 github.com/operator-framework/deppy v0.3.0/go.mod h1:EHDxZz8fKGvuymCng3G/Ou7wuX14GaLr0cmf2u29Oog=
 github.com/operator-framework/operator-registry v1.34.0 h1:dNgWTqMfixBaBwalypo3oJqQvqNwKwJ3NS9RaBHJxzs=


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
- Bumps catalogd --> v0.11.0
- Bumps kind to v0.20.0 and ensures we are using a 1.28 node image for testing
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
