### PR TITLE
🌱 Prefix dependabot pip PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: "daily"
     commit-message:
       prefix: ":seedling:"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ":seedling:"


### PR DESCRIPTION
# Description

Python dependabot PRs such as #576 are not being prefixed. This PR adds a enw configuration for pip package-ecosystem.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
