### PR TITLE
:seedling:  refactor catalogmetadata types used for resolution

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -115,10 +115,10 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterExtensionReconciler{
-		Client:         cl,
-		BundleProvider: catalogClient,
-		Scheme:         mgr.GetScheme(),
-		Resolver:       resolver,
+		Client:          cl,
+		CatalogProvider: catalogClient,
+		Scheme:          mgr.GetScheme(),
+		Resolver:        resolver,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterExtension")
 		os.Exit(1)

--- a/cmd/resolutioncli/client.go
+++ b/cmd/resolutioncli/client.go
@@ -34,7 +34,7 @@ type indexRefClient struct {
 	packagesCache []*catalogmetadata.Package
 }
 
-var _ controllers.CatalogProvider = &indexRefClient{}
+var _ controllers.CatalogProvider = (*indexRefClient)(nil)
 
 func newIndexRefClient(indexRef string) *indexRefClient {
 	return &indexRefClient{

--- a/cmd/resolutioncli/client.go
+++ b/cmd/resolutioncli/client.go
@@ -20,15 +20,21 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
+	"github.com/operator-framework/operator-controller/internal/controllers"
 )
 
 type indexRefClient struct {
-	renderer     action.Render
-	bundlesCache []*catalogmetadata.Bundle
+	renderer      action.Render
+	bundlesCache  []*catalogmetadata.Bundle
+	channelsCache []*catalogmetadata.Channel
+	packagesCache []*catalogmetadata.Package
 }
+
+var _ controllers.CatalogProvider = &indexRefClient{}
 
 func newIndexRefClient(indexRef string) *indexRefClient {
 	return &indexRefClient{
@@ -39,47 +45,81 @@ func newIndexRefClient(indexRef string) *indexRefClient {
 	}
 }
 
-func (c *indexRefClient) Bundles(ctx context.Context) ([]*catalogmetadata.Bundle, error) {
-	if c.bundlesCache == nil {
+func (c *indexRefClient) CatalogContents(ctx context.Context) (*client.Contents, error) {
+	if c.bundlesCache == nil || c.channelsCache == nil || c.packagesCache == nil {
 		cfg, err := c.renderer.Run(ctx)
 		if err != nil {
 			return nil, err
 		}
 
 		var (
-			channels     []*catalogmetadata.Channel
-			bundles      []*catalogmetadata.Bundle
-			deprecations []*catalogmetadata.Deprecation
+			channels []*catalogmetadata.Channel
+			bundles  []*catalogmetadata.Bundle
+			packages []*catalogmetadata.Package
 		)
+
+		// TODO: update fake catalog name string to be catalog name once we support multiple catalogs in CLI
+		catalogName := "offline-catalog"
+
+		for i := range cfg.Packages {
+			packages = append(packages, &catalogmetadata.Package{
+				Package: cfg.Packages[i],
+				Catalog: catalogName,
+			})
+		}
 
 		for i := range cfg.Channels {
 			channels = append(channels, &catalogmetadata.Channel{
 				Channel: cfg.Channels[i],
+				Catalog: catalogName,
 			})
 		}
 
 		for i := range cfg.Bundles {
 			bundles = append(bundles, &catalogmetadata.Bundle{
-				Bundle: cfg.Bundles[i],
+				Bundle:  cfg.Bundles[i],
+				Catalog: catalogName,
 			})
 		}
 
-		for i := range cfg.Deprecations {
-			deprecations = append(deprecations, &catalogmetadata.Deprecation{
-				Deprecation: cfg.Deprecations[i],
-			})
-		}
-
-		// TODO: update fake catalog name string to be catalog name once we support multiple catalogs in CLI
-		catalogName := "offline-catalog"
-
-		bundles, err = client.PopulateExtraFields(catalogName, channels, bundles, deprecations)
-		if err != nil {
-			return nil, err
+		for _, deprecation := range cfg.Deprecations {
+			for _, entry := range deprecation.Entries {
+				switch entry.Reference.Schema {
+				case declcfg.SchemaPackage:
+					for _, pkg := range packages {
+						if pkg.Name == deprecation.Package {
+							pkg.Deprecation = &declcfg.DeprecationEntry{
+								Reference: entry.Reference,
+								Message:   entry.Message,
+							}
+						}
+					}
+				case declcfg.SchemaChannel:
+					for _, channel := range channels {
+						if channel.Package == deprecation.Package && channel.Name == entry.Reference.Name {
+							channel.Deprecation = &declcfg.DeprecationEntry{
+								Reference: entry.Reference,
+								Message:   entry.Message,
+							}
+						}
+					}
+				case declcfg.SchemaBundle:
+					for _, bundle := range bundles {
+						if bundle.Package == deprecation.Package && bundle.Name == entry.Reference.Name {
+							bundle.Deprecation = &declcfg.DeprecationEntry{
+								Reference: entry.Reference,
+								Message:   entry.Message,
+							}
+						}
+					}
+				}
+			}
 		}
 
 		c.bundlesCache = bundles
+		c.channelsCache = channels
+		c.packagesCache = packages
 	}
 
-	return c.bundlesCache, nil
+	return &client.Contents{}, nil
 }

--- a/cmd/resolutioncli/main.go
+++ b/cmd/resolutioncli/main.go
@@ -150,7 +150,7 @@ func run(ctx context.Context, packageName, packageChannel, packageVersionRange, 
 
 	cl := clientBuilder.Build()
 	catalogClient := newIndexRefClient(indexRef)
-	allBundles, err := catalogClient.Bundles(ctx)
+	contents, err := catalogClient.CatalogContents(ctx)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func run(ctx context.Context, packageName, packageChannel, packageVersionRange, 
 	if err := cl.List(ctx, &bundleDeploymentList); err != nil {
 		return err
 	}
-	variables, err := controllers.GenerateVariables(allBundles, clusterExtensionList.Items, bundleDeploymentList.Items)
+	variables, err := controllers.GenerateVariables(contents, clusterExtensionList.Items, bundleDeploymentList.Items)
 	if err != nil {
 		return err
 	}

--- a/internal/catalogmetadata/filter/bundle_predicates.go
+++ b/internal/catalogmetadata/filter/bundle_predicates.go
@@ -41,26 +41,30 @@ func InBlangSemverRange(semverRange bsemver.Range) Predicate[catalogmetadata.Bun
 	}
 }
 
-func InChannel(channelName string) Predicate[catalogmetadata.Bundle] {
+func InChannel(channelName string, channels []*catalogmetadata.Channel) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
-		for _, ch := range bundle.InChannels {
+		for _, ch := range channels {
 			if ch.Name == channelName {
-				return true
+				for _, entry := range ch.Entries {
+					if entry.Name == bundle.Name {
+						return true
+					}
+				}
 			}
 		}
 		return false
 	}
 }
 
-func WithBundleImage(bundleImage string) Predicate[catalogmetadata.Bundle] {
+func WithImage(image string) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
-		return bundle.Image == bundleImage
+		return bundle.Image == image
 	}
 }
 
-func Replaces(bundleName string) Predicate[catalogmetadata.Bundle] {
+func Replaces(bundleName string, channels []*catalogmetadata.Channel) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
-		for _, ch := range bundle.InChannels {
+		for _, ch := range channels {
 			for _, chEntry := range ch.Entries {
 				if bundle.Name == chEntry.Name && chEntry.Replaces == bundleName {
 					return true
@@ -71,8 +75,8 @@ func Replaces(bundleName string) Predicate[catalogmetadata.Bundle] {
 	}
 }
 
-func WithDeprecation(deprecated bool) Predicate[catalogmetadata.Bundle] {
+func WithDeprecated(deprecated bool) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
-		return bundle.HasDeprecation() == deprecated
+		return bundle.IsDeprecated() == deprecated
 	}
 }

--- a/internal/catalogmetadata/filter/bundle_predicates_test.go
+++ b/internal/catalogmetadata/filter/bundle_predicates_test.go
@@ -97,80 +97,28 @@ func TestInBlangSemverRange(t *testing.T) {
 	assert.False(t, f(b3))
 }
 
-func TestInChannel(t *testing.T) {
-	b1 := &catalogmetadata.Bundle{InChannels: []*catalogmetadata.Channel{
-		{Channel: declcfg.Channel{Name: "alpha"}},
-		{Channel: declcfg.Channel{Name: "stable"}},
-	}}
-	b2 := &catalogmetadata.Bundle{InChannels: []*catalogmetadata.Channel{
-		{Channel: declcfg.Channel{Name: "alpha"}},
-	}}
-	b3 := &catalogmetadata.Bundle{}
-
-	f := filter.InChannel("stable")
-
-	assert.True(t, f(b1))
-	assert.False(t, f(b2))
-	assert.False(t, f(b3))
-}
-
-func TestWithBundleImage(t *testing.T) {
+func TestWithImage(t *testing.T) {
 	b1 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Image: "fake-image-uri-1"}}
 	b2 := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{Image: "fake-image-uri-2"}}
 	b3 := &catalogmetadata.Bundle{}
 
-	f := filter.WithBundleImage("fake-image-uri-1")
+	f := filter.WithImage("fake-image-uri-1")
 
 	assert.True(t, f(b1))
 	assert.False(t, f(b2))
 	assert.False(t, f(b3))
 }
 
-func TestReplaces(t *testing.T) {
-	fakeChannel := &catalogmetadata.Channel{
-		Channel: declcfg.Channel{
-			Entries: []declcfg.ChannelEntry{
-				{
-					Name:     "package1.v0.0.2",
-					Replaces: "package1.v0.0.1",
-				},
-				{
-					Name:     "package1.v0.0.3",
-					Replaces: "package1.v0.0.2",
-				},
-			},
-		},
-	}
-
+func TestWithDeprecated(t *testing.T) {
 	b1 := &catalogmetadata.Bundle{
-		Bundle:     declcfg.Bundle{Name: "package1.v0.0.2"},
-		InChannels: []*catalogmetadata.Channel{fakeChannel},
-	}
-	b2 := &catalogmetadata.Bundle{
-		Bundle:     declcfg.Bundle{Name: "package1.v0.0.3"},
-		InChannels: []*catalogmetadata.Channel{fakeChannel},
-	}
-	b3 := &catalogmetadata.Bundle{}
-
-	f := filter.Replaces("package1.v0.0.1")
-
-	assert.True(t, f(b1))
-	assert.False(t, f(b2))
-	assert.False(t, f(b3))
-}
-
-func TestWithDeprecation(t *testing.T) {
-	b1 := &catalogmetadata.Bundle{
-		Deprecations: []declcfg.DeprecationEntry{
-			{
-				Reference: declcfg.PackageScopedReference{},
-			},
+		Deprecation: &declcfg.DeprecationEntry{
+			Reference: declcfg.PackageScopedReference{},
 		},
 	}
 
 	b2 := &catalogmetadata.Bundle{}
 
-	f := filter.WithDeprecation(true)
+	f := filter.WithDeprecated(true)
 	assert.True(t, f(b1))
 	assert.False(t, f(b2))
 }

--- a/internal/catalogmetadata/sort/sort_test.go
+++ b/internal/catalogmetadata/sort/sort_test.go
@@ -85,23 +85,21 @@ func TestByVersion(t *testing.T) {
 
 func TestByDeprecated(t *testing.T) {
 	b1 := &catalogmetadata.Bundle{
-		CatalogName: "foo",
+		Catalog: "foo",
 		Bundle: declcfg.Bundle{
 			Name: "bar",
 		},
 	}
 
 	b2 := &catalogmetadata.Bundle{
-		CatalogName: "foo",
+		Catalog: "foo",
 		Bundle: declcfg.Bundle{
 			Name: "baz",
 		},
-		Deprecations: []declcfg.DeprecationEntry{
-			{
-				Reference: declcfg.PackageScopedReference{
-					Schema: "olm.bundle",
-					Name:   "baz",
-				},
+		Deprecation: &declcfg.DeprecationEntry{
+			Reference: declcfg.PackageScopedReference{
+				Schema: "olm.bundle",
+				Name:   "baz",
 			},
 		},
 	}
@@ -115,13 +113,7 @@ func TestByDeprecated(t *testing.T) {
 	assert.Equal(t, b1, toSort[0])
 	assert.Equal(t, b2, toSort[1])
 
-	// Channel deprecation association != bundle deprecated
-	b2.Deprecations[0] = declcfg.DeprecationEntry{
-		Reference: declcfg.PackageScopedReference{
-			Schema: "olm.channel",
-			Name:   "badchannel",
-		},
-	}
+	b2.Deprecation = nil
 
 	toSort = []*catalogmetadata.Bundle{b2, b1}
 	sort.SliceStable(toSort, func(i, j int) bool {
@@ -131,32 +123,4 @@ func TestByDeprecated(t *testing.T) {
 	require.Len(t, toSort, 2)
 	assert.Equal(t, b2, toSort[0])
 	assert.Equal(t, b1, toSort[1])
-
-	b1.Deprecations = []declcfg.DeprecationEntry{
-		{
-			Reference: declcfg.PackageScopedReference{
-				Schema: "olm.package",
-			},
-		},
-	}
-	b2.Deprecations = append(b2.Deprecations, declcfg.DeprecationEntry{
-		Reference: declcfg.PackageScopedReference{
-			Schema: "olm.package",
-		},
-	}, declcfg.DeprecationEntry{
-		Reference: declcfg.PackageScopedReference{
-			Schema: "olm.bundle",
-			Name:   "baz",
-		},
-	})
-
-	toSort = []*catalogmetadata.Bundle{b2, b1}
-	sort.SliceStable(toSort, func(i, j int) bool {
-		return catalogsort.ByDeprecated(toSort[i], toSort[j])
-	})
-	// Both are deprecated at package level, b2 is deprecated
-	// explicitly, b2 should be preferred less
-	require.Len(t, toSort, 2)
-	assert.Equal(t, b1, toSort[0])
-	assert.Equal(t, b2, toSort[1])
 }

--- a/internal/catalogmetadata/types.go
+++ b/internal/catalogmetadata/types.go
@@ -3,7 +3,6 @@ package catalogmetadata
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	bsemver "github.com/blang/semver/v4"
 
@@ -23,14 +22,27 @@ type Schemas interface {
 
 type Package struct {
 	declcfg.Package
+	Deprecation *declcfg.DeprecationEntry
+	Catalog     string
+}
+
+func (p *Package) IsDeprecated() bool {
+	return p.Deprecation != nil
 }
 
 type Channel struct {
 	declcfg.Channel
+	Deprecation *declcfg.DeprecationEntry
+	Catalog     string
+}
+
+func (c *Channel) IsDeprecated() bool {
+	return c.Deprecation != nil
 }
 
 type Deprecation struct {
 	declcfg.Deprecation
+	Catalog string
 }
 
 type PackageRequired struct {
@@ -40,119 +52,59 @@ type PackageRequired struct {
 
 type Bundle struct {
 	declcfg.Bundle
-	CatalogName  string
-	InChannels   []*Channel
-	Deprecations []declcfg.DeprecationEntry
-
-	mu sync.RWMutex
-	// these properties are lazy loaded as they are requested
-	propertiesMap    map[string][]*property.Property
-	bundlePackage    *property.Package
-	semVersion       *bsemver.Version
-	requiredPackages []PackageRequired
-	mediaType        *string
+	Deprecation *declcfg.DeprecationEntry
+	Catalog     string
 }
 
 func (b *Bundle) Version() (*bsemver.Version, error) {
-	if err := b.loadPackage(); err != nil {
+	pkg, err := loadOneFromProps[property.Package](b, property.TypePackage, true)
+	if err != nil {
 		return nil, err
 	}
-	return b.semVersion, nil
+	semVer, err := bsemver.Parse(pkg.Version)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse semver %q for bundle '%s': %s", pkg.Version, b.Name, err)
+	}
+	return &semVer, nil
 }
 
 func (b *Bundle) RequiredPackages() ([]PackageRequired, error) {
-	if err := b.loadRequiredPackages(); err != nil {
-		return nil, err
+	requiredPackages, err := loadFromProps[PackageRequired](b, property.TypePackageRequired, false)
+	if err != nil {
+		return nil, fmt.Errorf("error determining bundle required packages for bundle %q: %s", b.Name, err)
 	}
-	return b.requiredPackages, nil
+	for i := range requiredPackages {
+		semverRange, err := bsemver.ParseRange(requiredPackages[i].VersionRange)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error parsing bundle required package semver range for bundle %q (required package %q): %s",
+				b.Name,
+				requiredPackages[i].PackageName,
+				err,
+			)
+		}
+		requiredPackages[i].SemverRange = semverRange
+	}
+	return requiredPackages, nil
 }
 
 func (b *Bundle) MediaType() (string, error) {
-	if err := b.loadMediaType(); err != nil {
-		return "", err
+	mediaType, err := loadOneFromProps[string](b, PropertyBundleMediaType, false)
+	if err != nil {
+		return "", fmt.Errorf("error determining bundle mediatype for bundle %q: %s", b.Name, err)
 	}
 
-	return *b.mediaType, nil
-}
-
-func (b *Bundle) loadPackage() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.bundlePackage == nil {
-		bundlePackage, err := loadOneFromProps[property.Package](b, property.TypePackage, true)
-		if err != nil {
-			return err
-		}
-		b.bundlePackage = &bundlePackage
-	}
-	if b.semVersion == nil {
-		semVer, err := bsemver.Parse(b.bundlePackage.Version)
-		if err != nil {
-			return fmt.Errorf("could not parse semver %q for bundle '%s': %s", b.bundlePackage.Version, b.Name, err)
-		}
-		b.semVersion = &semVer
-	}
-	return nil
-}
-
-func (b *Bundle) loadRequiredPackages() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.requiredPackages == nil {
-		requiredPackages, err := loadFromProps[PackageRequired](b, property.TypePackageRequired, false)
-		if err != nil {
-			return fmt.Errorf("error determining bundle required packages for bundle %q: %s", b.Name, err)
-		}
-		for i := range requiredPackages {
-			semverRange, err := bsemver.ParseRange(requiredPackages[i].VersionRange)
-			if err != nil {
-				return fmt.Errorf(
-					"error parsing bundle required package semver range for bundle %q (required package %q): %s",
-					b.Name,
-					requiredPackages[i].PackageName,
-					err,
-				)
-			}
-			requiredPackages[i].SemverRange = semverRange
-		}
-		b.requiredPackages = requiredPackages
-	}
-	return nil
-}
-
-func (b *Bundle) loadMediaType() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.mediaType == nil {
-		mediaType, err := loadOneFromProps[string](b, PropertyBundleMediaType, false)
-		if err != nil {
-			return fmt.Errorf("error determining bundle mediatype for bundle %q: %s", b.Name, err)
-		}
-		b.mediaType = &mediaType
-	}
-	return nil
+	return mediaType, nil
 }
 
 func (b *Bundle) propertiesByType(propType string) []*property.Property {
-	if b.propertiesMap == nil {
-		b.propertiesMap = make(map[string][]*property.Property)
-		for i := range b.Properties {
-			prop := b.Properties[i]
-			b.propertiesMap[prop.Type] = append(b.propertiesMap[prop.Type], &prop)
-		}
+	propertiesMap := make(map[string][]*property.Property)
+	for i := range b.Properties {
+		prop := b.Properties[i]
+		propertiesMap[prop.Type] = append(propertiesMap[prop.Type], &prop)
 	}
 
-	return b.propertiesMap[propType]
-}
-
-// HasDeprecation returns true if the bundle
-// has any deprecations associated with it.
-// This may return true even in cases where the bundle
-// may be associated with an olm.channel deprecation
-// but the bundle is not considered "deprecated" because
-// the bundle is selected via a non-deprecated channel.
-func (b *Bundle) HasDeprecation() bool {
-	return len(b.Deprecations) > 0
+	return propertiesMap[propType]
 }
 
 // IsDeprecated returns true if the bundle
@@ -165,13 +117,7 @@ func (b *Bundle) HasDeprecation() bool {
 // Package deprecation does not carry the same meaning as an individual
 // bundle deprecation, so package deprecation is not considered.
 func (b *Bundle) IsDeprecated() bool {
-	for _, dep := range b.Deprecations {
-		if dep.Reference.Schema == declcfg.SchemaBundle && dep.Reference.Name == b.Name {
-			return true
-		}
-	}
-
-	return false
+	return b.Deprecation != nil
 }
 
 func loadOneFromProps[T any](bundle *Bundle, propType string, required bool) (T, error) {

--- a/internal/catalogmetadata/types_test.go
+++ b/internal/catalogmetadata/types_test.go
@@ -202,34 +202,6 @@ func TestBundleMediaType(t *testing.T) {
 	}
 }
 
-func TestBundleHasDeprecation(t *testing.T) {
-	for _, tt := range []struct {
-		name       string
-		bundle     *catalogmetadata.Bundle
-		deprecated bool
-	}{
-		{
-			name: "has deprecation entries",
-			bundle: &catalogmetadata.Bundle{
-				Deprecations: []declcfg.DeprecationEntry{
-					{
-						Reference: declcfg.PackageScopedReference{},
-					},
-				},
-			},
-			deprecated: true,
-		},
-		{
-			name:   "has no deprecation entries",
-			bundle: &catalogmetadata.Bundle{},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.deprecated, tt.bundle.HasDeprecation())
-		})
-	}
-}
-
 func TestBundleIsDeprecated(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
@@ -237,19 +209,13 @@ func TestBundleIsDeprecated(t *testing.T) {
 		deprecated bool
 	}{
 		{
-			name: "has package and channel deprecations, not deprecated",
+			name:       "has bundle deprecation entry, deprecated",
+			deprecated: true,
 			bundle: &catalogmetadata.Bundle{
-				Deprecations: []declcfg.DeprecationEntry{
-					{
-						Reference: declcfg.PackageScopedReference{
-							Schema: "olm.package",
-						},
-					},
-					{
-						Reference: declcfg.PackageScopedReference{
-							Schema: "olm.channel",
-							Name:   "foo",
-						},
+				Deprecation: &declcfg.DeprecationEntry{
+					Reference: declcfg.PackageScopedReference{
+						Schema: "olm.bundle",
+						Name:   "foo",
 					},
 				},
 			},
@@ -257,23 +223,6 @@ func TestBundleIsDeprecated(t *testing.T) {
 		{
 			name:   "has no deprecation entries, not deprecated",
 			bundle: &catalogmetadata.Bundle{},
-		},
-		{
-			name: "has bundle deprecation entry, deprecated",
-			bundle: &catalogmetadata.Bundle{
-				Bundle: declcfg.Bundle{
-					Name: "foo",
-				},
-				Deprecations: []declcfg.DeprecationEntry{
-					{
-						Reference: declcfg.PackageScopedReference{
-							Schema: "olm.bundle",
-							Name:   "foo",
-						},
-					},
-				},
-			},
-			deprecated: true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -49,12 +49,12 @@ func newClientAndReconciler(t *testing.T) (client.Client, *controllers.ClusterEx
 	require.NoError(t, err)
 
 	cl := newClient(t)
-	fakeCatalogClient := testutil.NewFakeCatalogClient(testBundleList)
+	fakeCatalogClient := testutil.NewFakeCatalogClient(testBundleList, testChannelList, testPackageList)
 	reconciler := &controllers.ClusterExtensionReconciler{
-		Client:         cl,
-		BundleProvider: &fakeCatalogClient,
-		Scheme:         sch,
-		Resolver:       resolver,
+		Client:          cl,
+		CatalogProvider: &fakeCatalogClient,
+		Scheme:          sch,
+		Resolver:        resolver,
 	}
 	return cl, reconciler
 }

--- a/internal/controllers/variables.go
+++ b/internal/controllers/variables.go
@@ -21,22 +21,22 @@ import (
 	rukpakv1alpha2 "github.com/operator-framework/rukpak/api/v1alpha2"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
-	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
+	"github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
 	"github.com/operator-framework/operator-controller/internal/resolution/variablesources"
 )
 
-func GenerateVariables(allBundles []*catalogmetadata.Bundle, clusterExtensions []ocv1alpha1.ClusterExtension, bundleDeployments []rukpakv1alpha2.BundleDeployment) ([]deppy.Variable, error) {
-	requiredPackages, err := variablesources.MakeRequiredPackageVariables(allBundles, clusterExtensions)
+func GenerateVariables(catalogContent *client.Contents, clusterExtensions []ocv1alpha1.ClusterExtension, bundleDeployments []rukpakv1alpha2.BundleDeployment) ([]deppy.Variable, error) {
+	requiredPackages, err := variablesources.MakeRequiredPackageVariables(catalogContent.Bundles, catalogContent.Channels, clusterExtensions)
 	if err != nil {
 		return nil, err
 	}
 
-	installedPackages, err := variablesources.MakeInstalledPackageVariables(allBundles, clusterExtensions, bundleDeployments)
+	installedPackages, err := variablesources.MakeInstalledPackageVariables(catalogContent.Bundles, catalogContent.Channels, clusterExtensions, bundleDeployments)
 	if err != nil {
 		return nil, err
 	}
 
-	bundles, err := variablesources.MakeBundleVariables(allBundles, requiredPackages, installedPackages)
+	bundles, err := variablesources.MakeBundleVariables(catalogContent.Bundles, requiredPackages, installedPackages)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/variables_test.go
+++ b/internal/controllers/variables_test.go
@@ -22,6 +22,7 @@ import (
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
+	"github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
 	"github.com/operator-framework/operator-controller/internal/controllers"
 	olmvariables "github.com/operator-framework/operator-controller/internal/resolution/variables"
 )
@@ -32,7 +33,8 @@ func TestVariableSource(t *testing.T) {
 	utilruntime.Must(rukpakv1alpha2.AddToScheme(sch))
 
 	stableChannel := catalogmetadata.Channel{Channel: declcfg.Channel{
-		Name: "stable",
+		Name:    "stable",
+		Package: "packageA",
 		Entries: []declcfg.ChannelEntry{
 			{
 				Name: "packageA.v2.0.0",
@@ -49,8 +51,7 @@ func TestVariableSource(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"packageA","version":"2.0.0"}`)},
 				},
 			},
-			CatalogName: "fake-catalog",
-			InChannels:  []*catalogmetadata.Channel{&stableChannel},
+			Catalog: "fake-catalog",
 		},
 	}
 	allBundles := make([]*catalogmetadata.Bundle, 0, len(bundleSet))
@@ -94,7 +95,7 @@ func TestVariableSource(t *testing.T) {
 		},
 	}
 
-	vars, err := controllers.GenerateVariables(allBundles, []ocv1alpha1.ClusterExtension{clusterExtension}, []rukpakv1alpha2.BundleDeployment{bd})
+	vars, err := controllers.GenerateVariables(&client.Contents{Bundles: allBundles, Channels: []*catalogmetadata.Channel{&stableChannel}}, []ocv1alpha1.ClusterExtension{clusterExtension}, []rukpakv1alpha2.BundleDeployment{bd})
 	require.NoError(t, err)
 
 	expectedVars := []deppy.Variable{

--- a/internal/resolution/variables/bundle.go
+++ b/internal/resolution/variables/bundle.go
@@ -62,6 +62,6 @@ func NewBundleUniquenessVariable(id deppy.Identifier, atMostIDs ...deppy.Identif
 // BundleVariableID returns an ID for a given bundle.
 func BundleVariableID(bundle *catalogmetadata.Bundle) deppy.Identifier {
 	return deppy.Identifier(
-		fmt.Sprintf("%s-%s-%s", bundle.CatalogName, bundle.Package, bundle.Name),
+		fmt.Sprintf("%s-%s-%s", bundle.Catalog, bundle.Package, bundle.Name),
 	)
 }

--- a/internal/resolution/variables/bundle_test.go
+++ b/internal/resolution/variables/bundle_test.go
@@ -15,26 +15,17 @@ import (
 
 func TestBundleVariable(t *testing.T) {
 	bundle := &catalogmetadata.Bundle{
-		InChannels: []*catalogmetadata.Channel{
-			{Channel: declcfg.Channel{Name: "stable"}},
-		},
 		Bundle: declcfg.Bundle{Name: "bundle-1", Properties: []property.Property{
 			{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "1.0.0"}`)},
 		}},
 	}
 	dependencies := []*catalogmetadata.Bundle{
 		{
-			InChannels: []*catalogmetadata.Channel{
-				{Channel: declcfg.Channel{Name: "stable"}},
-			},
 			Bundle: declcfg.Bundle{Name: "bundle-2", Properties: []property.Property{
 				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.0.0"}`)},
 			}},
 		},
 		{
-			InChannels: []*catalogmetadata.Channel{
-				{Channel: declcfg.Channel{Name: "stable"}},
-			},
 			Bundle: declcfg.Bundle{Name: "bundle-3", Properties: []property.Property{
 				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "3.0.0"}`)},
 			}},

--- a/internal/resolution/variablesources/bundle.go
+++ b/internal/resolution/variablesources/bundle.go
@@ -45,7 +45,7 @@ func MakeBundleVariables(
 		// get bundle dependencies
 		dependencies, err := filterBundleDependencies(allBundles, head)
 		if err != nil {
-			return nil, fmt.Errorf("could not determine dependencies for bundle %q from package %q in catalog %q: %s", head.Name, head.Package, head.CatalogName, err)
+			return nil, fmt.Errorf("could not determine dependencies for bundle %q from package %q in catalog %q: %s", head.Name, head.Package, head.Catalog, err)
 		}
 
 		// add bundle dependencies to queue for processing

--- a/internal/resolution/variablesources/bundle_test.go
+++ b/internal/resolution/variablesources/bundle_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 	const fakeCatalogName = "fake-catalog"
-	fakeChannel := catalogmetadata.Channel{Channel: declcfg.Channel{Name: "stable"}}
 	bundleSet := map[string]*catalogmetadata.Bundle{
 		// Test package which we will be using as input into
 		// the testable function
@@ -34,8 +33,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackageRequired, Value: json.RawMessage(`{"packageName": "first-level-dependency", "versionRange": ">=1.0.0 <2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 
 		// First level dependency of test-package. Will be explicitly
@@ -52,8 +50,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackageRequired, Value: json.RawMessage(`{"packageName": "second-level-dependency", "versionRange": ">=1.0.0 <2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 
 		// Second level dependency that matches requirements of the first level dependency.
@@ -65,8 +62,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "second-level-dependency", "version": "1.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 
 		// Second level dependency that matches requirements of the first level dependency.
@@ -78,8 +74,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "second-level-dependency", "version": "1.0.1"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 
 		// Second level dependency that does not match requirements of the first level dependency.
@@ -91,8 +86,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "second-level-dependency", "version": "2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 
 		// Package that is in a our fake catalog, but is not involved
@@ -106,8 +100,7 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "uninvolved-package", "version": "1.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 	}
 
@@ -162,7 +155,6 @@ func TestMakeBundleVariables_ValidDepedencies(t *testing.T) {
 
 func TestMakeBundleVariables_NonExistentDepedencies(t *testing.T) {
 	const fakeCatalogName = "fake-catalog"
-	fakeChannel := catalogmetadata.Channel{Channel: declcfg.Channel{Name: "stable"}}
 	bundleSet := map[string]*catalogmetadata.Bundle{
 		"test-package.v1.0.0": {
 			Bundle: declcfg.Bundle{
@@ -173,8 +165,7 @@ func TestMakeBundleVariables_NonExistentDepedencies(t *testing.T) {
 					{Type: property.TypePackageRequired, Value: json.RawMessage(`{"packageName": "first-level-dependency", "versionRange": ">=1.0.0 <2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&fakeChannel},
+			Catalog: fakeCatalogName,
 		},
 	}
 

--- a/internal/resolution/variablesources/bundle_uniqueness_test.go
+++ b/internal/resolution/variablesources/bundle_uniqueness_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestMakeBundleUniquenessVariables(t *testing.T) {
 	const fakeCatalogName = "fake-catalog"
-	channel := catalogmetadata.Channel{Channel: declcfg.Channel{Name: "stable"}}
 	bundleSet := map[string]*catalogmetadata.Bundle{
 		"test-package.v1.0.0": {
 			Bundle: declcfg.Bundle{
@@ -31,8 +30,7 @@ func TestMakeBundleUniquenessVariables(t *testing.T) {
 					{Type: property.TypePackageRequired, Value: json.RawMessage(`{"packageName": "some-package", "versionRange": ">=1.0.0 <2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&channel},
+			Catalog: fakeCatalogName,
 		},
 		"test-package.v1.0.1": {
 			Bundle: declcfg.Bundle{
@@ -43,8 +41,7 @@ func TestMakeBundleUniquenessVariables(t *testing.T) {
 					{Type: property.TypePackageRequired, Value: json.RawMessage(`{"packageName": "some-package", "versionRange": ">=1.0.0 <2.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&channel},
+			Catalog: fakeCatalogName,
 		},
 
 		"some-package.v1.0.0": {
@@ -55,8 +52,7 @@ func TestMakeBundleUniquenessVariables(t *testing.T) {
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "some-package", "version": "1.0.0"}`)},
 				},
 			},
-			CatalogName: fakeCatalogName,
-			InChannels:  []*catalogmetadata.Channel{&channel},
+			Catalog: fakeCatalogName,
 		},
 	}
 

--- a/internal/resolution/variablesources/installed_package_test.go
+++ b/internal/resolution/variablesources/installed_package_test.go
@@ -29,10 +29,47 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 	someOtherPackageChannel := catalogmetadata.Channel{Channel: declcfg.Channel{
 		Name:    "stable",
 		Package: "some-other-package",
+		Entries: []declcfg.ChannelEntry{
+			{
+				Name: "some-other-package.v2.3.0",
+			},
+		},
 	}}
 	testPackageChannel := catalogmetadata.Channel{Channel: declcfg.Channel{
 		Name:    "stable",
 		Package: testPackageName,
+		Entries: []declcfg.ChannelEntry{
+			{
+				Name: "test-package.v0.0.1",
+			},
+			{
+				Name: "test-package.v0.0.2",
+			},
+			{
+				Name: "test-package.v0.1.0",
+			},
+			{
+				Name: "test-package.v0.1.1",
+			},
+			{
+				Name: "test-package.v0.1.2",
+			},
+			{
+				Name: "test-package.v0.2.0",
+			},
+			{
+				Name: "test-package.v2.0.0",
+			},
+			{
+				Name: "test-package.v2.1.0",
+			},
+			{
+				Name: "test-package.v2.2.0",
+			},
+			{
+				Name: "test-package.v3.0.0",
+			},
+		},
 	}}
 	bundleSet := map[string]*catalogmetadata.Bundle{
 		// Major version zero is for initial development and
@@ -49,7 +86,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.0.1"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v0.0.2": {
 			Bundle: declcfg.Bundle{
@@ -60,7 +96,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.0.2"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v0.1.0": {
 			Bundle: declcfg.Bundle{
@@ -71,7 +106,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.1.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v0.1.1": {
 			Bundle: declcfg.Bundle{
@@ -82,7 +116,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.1.1"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v0.1.2": {
 			Bundle: declcfg.Bundle{
@@ -93,7 +126,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.1.2"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v0.2.0": {
 			Bundle: declcfg.Bundle{
@@ -104,7 +136,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "0.2.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v2.0.0": {
 			Bundle: declcfg.Bundle{
@@ -115,7 +146,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.0.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v2.1.0": {
 			Bundle: declcfg.Bundle{
@@ -126,7 +156,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.1.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v2.2.0": {
 			Bundle: declcfg.Bundle{
@@ -137,7 +166,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.2.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		// We need a bundle with a different major version to ensure
 		// that we do not allow upgrades from one major version to another
@@ -150,7 +178,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "3.0.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		// We need a bundle from different package to ensure that
 		// we filter out bundles certain bundle image
@@ -163,7 +190,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "some-other-package", "version": "2.3.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&someOtherPackageChannel},
 		},
 	}
 	allBundles := make([]*catalogmetadata.Bundle, 0, len(bundleSet))
@@ -242,7 +268,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 						{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "9.0.0"}`)},
 					},
 				},
-				InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 			},
 			expectedError: `bundle with image "registry.io/repo/test-package@v9.0.0" for package "test-package" not found in available catalogs but is currently installed via BundleDeployment "test-package-bd"`,
 		},
@@ -256,6 +281,7 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsEnabled(t
 
 			installedPackages, err := variablesources.MakeInstalledPackageVariables(
 				allBundles,
+				[]*catalogmetadata.Channel{&testPackageChannel, &someOtherPackageChannel},
 				[]ocv1alpha1.ClusterExtension{fakeOwnerClusterExtension},
 				bundleDeployments,
 			)
@@ -318,7 +344,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.0.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v2.1.0": {
 			Bundle: declcfg.Bundle{
@@ -329,7 +354,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.1.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		"test-package.v2.2.0": {
 			Bundle: declcfg.Bundle{
@@ -340,7 +364,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "2.2.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 		},
 		// We need a bundle from different package to ensure that
 		// we filter out bundles certain bundle image
@@ -353,7 +376,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "some-other-package", "version": "2.3.0"}`)},
 				},
 			},
-			InChannels: []*catalogmetadata.Channel{&someOtherPackageChannel},
 		},
 	}
 	allBundles := make([]*catalogmetadata.Bundle, 0, len(bundleSet))
@@ -405,7 +427,6 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 						{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "test-package", "version": "9.0.0"}`)},
 					},
 				},
-				InChannels: []*catalogmetadata.Channel{&testPackageChannel},
 			},
 			expectedError: `bundle with image "registry.io/repo/test-package@v9.0.0" for package "test-package" not found in available catalogs but is currently installed via BundleDeployment "test-package-bd"`,
 		},
@@ -419,6 +440,7 @@ func TestMakeInstalledPackageVariablesWithForceSemverUpgradeConstraintsDisabled(
 
 			installedPackages, err := variablesources.MakeInstalledPackageVariables(
 				allBundles,
+				[]*catalogmetadata.Channel{&testPackageChannel, &someOtherPackageChannel},
 				[]ocv1alpha1.ClusterExtension{fakeOwnerClusterExtension},
 				bundleDeployments,
 			)

--- a/test/util/fake_catalog_client.go
+++ b/test/util/fake_catalog_client.go
@@ -4,16 +4,21 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
+	"github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
 )
 
 type FakeCatalogClient struct {
-	bundles []*catalogmetadata.Bundle
-	err     error
+	bundles  []*catalogmetadata.Bundle
+	channels []*catalogmetadata.Channel
+	packages []*catalogmetadata.Package
+	err      error
 }
 
-func NewFakeCatalogClient(b []*catalogmetadata.Bundle) FakeCatalogClient {
+func NewFakeCatalogClient(b []*catalogmetadata.Bundle, c []*catalogmetadata.Channel, p []*catalogmetadata.Package) FakeCatalogClient {
 	return FakeCatalogClient{
-		bundles: b,
+		bundles:  b,
+		channels: c,
+		packages: p,
 	}
 }
 
@@ -23,9 +28,9 @@ func NewFakeCatalogClientWithError(e error) FakeCatalogClient {
 	}
 }
 
-func (c *FakeCatalogClient) Bundles(_ context.Context) ([]*catalogmetadata.Bundle, error) {
+func (c *FakeCatalogClient) CatalogContents(_ context.Context) (*client.Contents, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
-	return c.bundles, nil
+	return &client.Contents{Bundles: c.bundles, Channels: c.channels, Packages: c.packages}, nil
 }


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->
- Refactors the types in the `internal/catalogmetadata` package to reduce the complexity of requiring all the OLM-isms to be conveyed through the single `Bundle` type. Updates all resolution logic and unit tests as needed.

- resolves #176 (?)
- Any other issues folks think this resolves?

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
