### PR TITLE
:sparkles: Add healthy status condition to ClusterExtension

### DIFF
--- a/api/v1alpha1/clusterextension_types.go
+++ b/api/v1alpha1/clusterextension_types.go
@@ -77,6 +77,7 @@ const (
 	// TODO(user): add more Types, here and into init()
 	TypeInstalled = "Installed"
 	TypeResolved  = "Resolved"
+	TypeHealthy   = "Healthy"
 	// TypeDeprecated is a rollup condition that is present when
 	// any of the deprecated conditions are present.
 	TypeDeprecated        = "Deprecated"
@@ -93,6 +94,9 @@ const (
 	ReasonResolutionUnknown         = "ResolutionUnknown"
 	ReasonSuccess                   = "Success"
 	ReasonDeprecated                = "Deprecated"
+	ReasonHealthy                   = "Healthy"
+	ReasonUnhealthy                 = "Unhealthy"
+	ReasonHealthStatusUnknown       = "HealthStatusUnknown"
 )
 
 func init() {
@@ -104,6 +108,7 @@ func init() {
 		TypePackageDeprecated,
 		TypeChannelDeprecated,
 		TypeBundleDeprecated,
+		TypeHealthy,
 	)
 	// TODO(user): add Reasons from above
 	conditionsets.ConditionReasons = append(conditionsets.ConditionReasons,
@@ -116,6 +121,9 @@ func init() {
 		ReasonInvalidSpec,
 		ReasonSuccess,
 		ReasonDeprecated,
+		ReasonHealthy,
+		ReasonUnhealthy,
+		ReasonHealthStatusUnknown,
 	)
 }
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
 )
 
 const (
@@ -81,7 +82,7 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 	t.Log("By eventually reporting a successful resolution and bundle path")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		assert.Len(ct, clusterExtension.Status.Conditions, 6)
+		assert.Len(ct, clusterExtension.Status.Conditions, len(conditionsets.ConditionTypes))
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
 		if !assert.NotNil(ct, cond) {
 			return
@@ -137,7 +138,7 @@ func TestClusterExtensionInstallPlain(t *testing.T) {
 	t.Log("By eventually reporting a successful resolution and bundle path")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		assert.Len(ct, clusterExtension.Status.Conditions, 6)
+		assert.Len(ct, clusterExtension.Status.Conditions, len(conditionsets.ConditionTypes))
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
 		if !assert.NotNil(ct, cond) {
 			return


### PR DESCRIPTION

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->
- Adds a `Healthy` status condition type to the `ClusterExtension` status conditions. This value is populated based on two things:
    - If installation status is failed or unknown, the `Healthy` status will be unknown
    - The healthy status condition of the associated `BundleDeployment`

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
