### PR TITLE
🌱 Add kapp-controller to Makefile to be installed with "run" command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export IMAGE_REPO ?= quay.io/operator-framework/operator-controller
 export IMAGE_TAG ?= devel
 export CERT_MGR_VERSION ?= v1.9.0
 export CATALOGD_VERSION ?= $(shell go list -mod=mod -m -f "{{.Version}}" github.com/operator-framework/catalogd)
+export KAPP_VERSION ?= v0.50.0# TODO replace with above or below line to pull version from go.mod
 export RUKPAK_VERSION=$(shell go list -mod=mod -m -f "{{.Version}}" github.com/operator-framework/rukpak)
 export WAIT_TIMEOUT ?= 60s
 IMG?=$(IMAGE_REPO):$(IMAGE_TAG)
@@ -157,7 +158,7 @@ kind-load: $(KIND) #EXHELP Loads the currently constructed image onto the cluste
 kind-deploy: export MANIFEST="./operator-controller.yaml"
 kind-deploy: manifests $(KUSTOMIZE) #EXHELP Install controller and dependencies onto the kind cluster.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) > operator-controller.yaml
-	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh | bash -s
+	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$KAPP_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh | bash -s
 
 .PHONY: kind-cluster
 kind-cluster: $(KIND) #EXHELP Standup a kind cluster.
@@ -230,7 +231,7 @@ release: $(GORELEASER) #EXHELP Runs goreleaser for the operator-controller. By d
 quickstart: export MANIFEST="https://github.com/operator-framework/operator-controller/releases/download/$(VERSION)/operator-controller.yaml"
 quickstart: $(KUSTOMIZE) manifests #EXHELP Generate the installation release manifests and scripts.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | sed "s/:devel/:$(VERSION)/g" > operator-controller.yaml
-	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh > install.sh
+	envsubst '$$CATALOGD_VERSION,$$CERT_MGR_VERSION,$$KAPP_VERSION,$$RUKPAK_VERSION,$$MANIFEST' < scripts/install.tpl.sh > install.sh
 
 #SECTION Deployment
 

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -12,8 +12,9 @@ fi
 catalogd_version=$CATALOGD_VERSION
 cert_mgr_version=$CERT_MGR_VERSION
 rukpak_version=$RUKPAK_VERSION
+kapp_version=$KAPP_VERSION
 
-if [[ -z "$catalogd_version" || -z "$cert_mgr_version" || -z "$rukpak_version" ]]; then
+if [[ -z "$catalogd_version" || -z "$cert_mgr_version" || -z "$rukpak_version" || -z "$kapp_version" ]]; then
     err="Error: Missing component version(s) for: "
     if [[ -z "$catalogd_version" ]]; then
         err+="catalogd "
@@ -23,6 +24,9 @@ if [[ -z "$catalogd_version" || -z "$cert_mgr_version" || -z "$rukpak_version" ]
     fi 
     if [[ -z "$rukpak_version" ]]; then
         err+="rukpak "
+    fi 
+    if [[ -z "$kapp_version" ]]; then
+        err+="kapp "
     fi 
     echo "$err"
     exit 1
@@ -38,6 +42,9 @@ function kubectl_wait() {
 
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
+
+kubectl apply -f "https://github.com/carvel-dev/kapp-controller/releases/download/${kapp_version}/release.yml"
+kubectl_wait "kapp-controller" "deployment.apps/kapp-controller" 60s
 
 kubectl apply -f "https://github.com/operator-framework/rukpak/releases/download/${rukpak_version}/rukpak.yaml"
 kubectl_wait "rukpak-system" "deployment/core" "60s"


### PR DESCRIPTION
Adds [kapp-controller ](https://github.com/carvel-dev/kapp-controller) to the install script and pins version to `v0.50.0`. Left a comment to note that once we add `kapp` to `go.mod` we can retrieve the version from there, so we have the version in just one place.

Closes #609 