### PR TITLE
 🐛 [Fix] fix hasKappAPIs method

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -175,6 +175,10 @@ func hasKappApis(config *rest.Config) (bool, error) {
 		return false, fmt.Errorf("listing resource APIs: %v", err)
 	}
 
+	if apiResourceList == nil {
+		return false, nil
+	}
+
 	for _, resource := range apiResourceList.APIResources {
 		if resource.Kind == "App" {
 			return true, nil


### PR DESCRIPTION
The method was listing resources falling under the `kappctrl.k14s.io` string. It would return nil when kapp-ctrl is not installed, resulting in a panic.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
