### PR TITLE
:sparkles: Add field to Extension API to skip crd safety checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ generate: $(CONTROLLER_GEN) #EXHELP Generate code containing DeepCopy, DeepCopyI
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: verify
-verify: tidy fmt vet generate #HELP Verify all generated code is up-to-date.
+verify: tidy fmt vet generate manifests #HELP Verify all generated code is up-to-date.
 	git diff --exit-code
 
 .PHONY: fmt

--- a/api/v1alpha1/extension_types.go
+++ b/api/v1alpha1/extension_types.go
@@ -82,6 +82,11 @@ type ExtensionSpec struct {
 
 	// source of Extension to be installed
 	Source ExtensionSource `json:"source"`
+
+	//+kubebuilder:Optional
+	//
+	// skipCRDUpgradeSafetyCheck specifies whether or not the CRD upgrade safety checks should be skipped when attempting to install the extension
+	SkipCRDUpgradeSafetyCheck bool `json:"skipCRDUpgradeSafetyCheck,omitempty"`
 }
 
 // ExtensionStatus defines the observed state of Extension

--- a/config/crd/bases/olm.operatorframework.io_extensions.yaml
+++ b/config/crd/bases/olm.operatorframework.io_extensions.yaml
@@ -51,6 +51,11 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]+([\.-][a-z0-9]+)*$
                 type: string
+              skipCRDUpgradeSafetyCheck:
+                description: skipCRDUpgradeSafetyCheck specifies whether or not the
+                  CRD upgrade safety checks should be skipped when attempting to install
+                  the extension
+                type: boolean
               source:
                 description: source of Extension to be installed
                 properties:


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
Adds an optional `Extension.spec.skipCRDUpgradeSafetyChecks` field that when set to `true` will be used to disable the CRD upgrade safety checks when attempting to install an extension.

No logic included in this PR as the CRD Upgrade Safety preflight check hasn't been fully implemented in carvel-dev/kapp yet.

I figured it doesn't hurt to go ahead and add the field and have it do nothing for now, but I'm also happy for this PR to be put on hold until the underlying logic to enable/disable the check is able to be put in place.

fixes #658 

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
