### PR TITLE
🌱 Update e2e action to reduce flakes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
           # after failing tests.
           # With -k flag make will continue the build, but will return non-zero
           # exit code in case of any errors.
-          ARTIFACT_PATH=/tmp/artifacts make -k test-e2e
+          ARTIFACT_PATH=/tmp/artifacts make test-e2e
 
       - uses: cytopia/upload-artifact-retry-action@v0.1.7
         if: failure()


### PR DESCRIPTION

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
- Removes the `-k` option from the `make` command run to execute our e2e tests in CI. The `-k` flag would force `make` to continue running a target even when a dependency of the target has failed leading to flakes. Removing the flag means that the e2e tests will fail if any of the `test-e2e` target dependencies fail.
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
