### PR TITLE
⚠️ (Partially) fix upgrade behaviour in `Extension`

### DIFF
--- a/internal/catalogmetadata/filter/bundle_predicates.go
+++ b/internal/catalogmetadata/filter/bundle_predicates.go
@@ -33,19 +33,6 @@ func InMastermindsSemverRange(semverRange *mmsemver.Constraints) Predicate[catal
 	}
 }
 
-func HigherBundleVersion(currentVersion *bsemver.Version) Predicate[catalogmetadata.Bundle] {
-	return func(bundle *catalogmetadata.Bundle) bool {
-		if currentVersion == nil {
-			return false
-		}
-		bundleVersion, err := bundle.Version()
-		if err != nil {
-			return false
-		}
-		return bundleVersion.GTE(*currentVersion)
-	}
-}
-
 func InBlangSemverRange(semverRange bsemver.Range) Predicate[catalogmetadata.Bundle] {
 	return func(bundle *catalogmetadata.Bundle) bool {
 		bundleVersion, err := bundle.Version()

--- a/internal/catalogmetadata/filter/bundle_predicates_test.go
+++ b/internal/catalogmetadata/filter/bundle_predicates_test.go
@@ -2,7 +2,6 @@ package filter_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	mmsemver "github.com/Masterminds/semver/v3"
@@ -62,67 +61,6 @@ func TestInMastermindsSemverRange(t *testing.T) {
 	assert.True(t, f(b1))
 	assert.False(t, f(b2))
 	assert.False(t, f(b3))
-}
-
-func TestHigherBundleVersion(t *testing.T) {
-	testCases := []struct {
-		name             string
-		requestedVersion string
-		comparedVersion  string
-		wantResult       bool
-	}{
-		{
-			name:             "includes equal version",
-			requestedVersion: "1.0.0",
-			comparedVersion:  "1.0.0",
-			wantResult:       true,
-		},
-		{
-			name:             "filters out older version",
-			requestedVersion: "1.0.0",
-			comparedVersion:  "0.0.1",
-			wantResult:       false,
-		},
-		{
-			name:             "includes higher version",
-			requestedVersion: "1.0.0",
-			comparedVersion:  "2.0.0",
-			wantResult:       true,
-		},
-		{
-			name:             "filters out broken version",
-			requestedVersion: "1.0.0",
-			comparedVersion:  "broken",
-			wantResult:       false,
-		},
-		{
-			name:             "filter returns false with nil version",
-			requestedVersion: "",
-			comparedVersion:  "1.0.0",
-			wantResult:       false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			bundle := &catalogmetadata.Bundle{Bundle: declcfg.Bundle{
-				Properties: []property.Property{
-					{
-						Type:  property.TypePackage,
-						Value: json.RawMessage(fmt.Sprintf(`{"packageName": "package1", "version": "%s"}`, tc.comparedVersion)),
-					},
-				},
-			}}
-			var version *bsemver.Version
-			if tc.requestedVersion != "" {
-				parsedVersion := bsemver.MustParse(tc.requestedVersion)
-				// to test with nil requested version
-				version = &parsedVersion
-			}
-			f := filter.HigherBundleVersion(version)
-			assert.Equal(t, tc.wantResult, f(bundle))
-		})
-	}
 }
 
 func TestInBlangSemverRange(t *testing.T) {

--- a/internal/controllers/extension_controller.go
+++ b/internal/controllers/extension_controller.go
@@ -512,7 +512,14 @@ func (r *ExtensionReconciler) resolve(ctx context.Context, extension ocv1alpha1.
 		}
 		if installedVersionSemver != nil {
 			installedVersion = installedVersionSemver.String()
-			predicates = append(predicates, catalogfilter.HigherBundleVersion(installedVersionSemver))
+
+			// Based on installed version create a caret range comparison constraint
+			// to allow only minor and patch version as successors.
+			wantedVersionRangeConstraint, err := mmsemver.NewConstraint(fmt.Sprintf("^%s", installedVersion))
+			if err != nil {
+				return nil, err
+			}
+			predicates = append(predicates, catalogfilter.InMastermindsSemverRange(wantedVersionRangeConstraint))
 		}
 	}
 

--- a/internal/controllers/extension_controller_test.go
+++ b/internal/controllers/extension_controller_test.go
@@ -204,7 +204,7 @@ func TestExtensionResolve(t *testing.T) {
 			extNN := types.NamespacedName{Name: ext.GetName(), Namespace: ext.GetNamespace()}
 
 			res, reconcileErr := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extNN})
-			assert.Equal(t, reconcileErr, tc.wantErr)
+			assert.Equal(t, tc.wantErr, reconcileErr)
 			if tc.wantErr != nil {
 				err := c.Get(ctx, extNN, ext)
 				assert.NoError(t, err)


### PR DESCRIPTION
# Description

With the current code there are a few issues:

1. `catalogfilter.HigherBundleVersion` is not really required as we already have more generic `catalogfilter.InMastermindsSemverRange`.
1. I think `catalogfilter.HigherBundleVersion` allows upgrades from one major version to another major version, etc. This is not the same behaviour as in `ClusterExtension`
1. We do not seem to support legacy `replaces` here.

This PR solves the first two, but the third still needs to be addressed.

How it currently works in `ClusterExtension`: https://github.com/operator-framework/operator-controller/blob/52cb7eb1a650731f2e16253a7f0f0ba25ea3af70/docs/drafts/upgrade-support.md

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
