### PR TITLE
🌱 Enable `admissionregistration.k8s.io/v1beta1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,8 @@ kind-deploy: manifests $(KUSTOMIZE) #EXHELP Install controller and dependencies 
 .PHONY: kind-cluster
 kind-cluster: $(KIND) #EXHELP Standup a kind cluster.
 	-$(KIND) delete cluster --name ${KIND_CLUSTER_NAME}
-	$(KIND) create cluster --name ${KIND_CLUSTER_NAME} --image ${KIND_CLUSTER_IMAGE}
+	# kind-config.yaml can be deleted after upgrading to Kubernetes 1.30
+	$(KIND) create cluster --name ${KIND_CLUSTER_NAME} --image ${KIND_CLUSTER_IMAGE} --config ./kind-config.yaml
 	$(KIND) export kubeconfig --name ${KIND_CLUSTER_NAME}
 
 .PHONY: kind-clean

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,8 @@
+# Can be deleted after upgrading to Kubernetes 1.30
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  ValidatingAdmissionPolicy: true
+runtimeConfig:
+  admissionregistration.k8s.io/v1beta1: true
+


### PR DESCRIPTION
# Description

We will be using [validating admission policy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) API for a few things (like https://github.com/operator-framework/operator-controller/issues/736) and [enforcing package uniqueness](https://github.com/operator-framework/operator-controller/pull/758#issuecomment-2066688215) on `ClusterExtension`).

This PR enables `admissionregistration.k8s.io/v1beta1` in kind cluster used for E2E and local development.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
