### PR TITLE
:sparkles: Add noopdelete option to extension api

### DIFF
--- a/api/v1alpha1/extension_types.go
+++ b/api/v1alpha1/extension_types.go
@@ -74,6 +74,12 @@ type ExtensionSpec struct {
 	// paused controls the management state of the extension. If the extension is paused, it will be ignored by the extension controller.
 	Paused bool `json:"paused,omitempty"`
 
+	//+kubebuilder:default:=false
+	//+kubebuilder:Optional
+	//
+	// NoopDelete controls what is done with the associated resources. If set to true they will not be deleted.
+	NoopDelete bool `json:"noopdelete,omitempty"`
+
 	//+kubebuilder:validation:MaxLength:=253
 	//+kubebuilder:validation:Pattern:=^[a-z0-9]+([\.-][a-z0-9]+)*$
 	//

--- a/config/crd/bases/olm.operatorframework.io_extensions.yaml
+++ b/config/crd/bases/olm.operatorframework.io_extensions.yaml
@@ -44,6 +44,11 @@ spec:
           spec:
             description: ExtensionSpec defines the desired state of Extension
             properties:
+              noopdelete:
+                default: false
+                description: NoopDelete controls what is done with the associated
+                  resources. If set to true they will not be deleted.
+                type: boolean
               paused:
                 description: paused controls the management state of the extension.
                   If the extension is paused, it will be ignored by the extension

--- a/internal/controllers/extension_controller.go
+++ b/internal/controllers/extension_controller.go
@@ -430,6 +430,7 @@ func (r *ExtensionReconciler) GenerateExpectedApp(o ocv1alpha1.Extension, bundle
 				"kapp": map[string]interface{}{},
 			},
 		},
+		"noopdelete": o.Spec.NoopDelete,
 	}
 
 	app := &unstructured.Unstructured{


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

Solves #723 

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
