### PR TITLE
✨ Add `ValidatingAdmissionPolicy` to enforce package uniqueness across `ClusterExtension`

### DIFF
--- a/config/admission/admission.yaml
+++ b/config/admission/admission.yaml
@@ -1,0 +1,37 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "clusterextensions-package-uniqueness"
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: olm.operatorframework.io/v1alpha1
+    kind: ClusterExtension
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["olm.operatorframework.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["clusterextensions"]
+  matchConditions:
+    # Only apply the policy when the request operation is CREATE
+    # or when the package is being changed
+    - name: 'only-create-or-package-change'
+      expression: request.operation == 'CREATE' || oldObject.spec.packageName != object.spec.packageName
+  validations:
+    - expression: object.spec.packageName != params.spec.packageName
+      messageExpression: "'Package \"' + string(object.spec.packageName) + '\" is already installed via ClusterExtension \"' +  string(params.metadata.name) + '\"'"
+      reason: Invalid
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "clusterextensions-package-uniqueness-binding"
+spec:
+  policyName: "clusterextensions-package-uniqueness"
+  validationActions: [Deny]
+  paramRef:
+    parameterNotFoundAction: Allow
+    selector: {}

--- a/config/admission/kustomization.yaml
+++ b/config/admission/kustomization.yaml
@@ -1,2 +1,5 @@
+configurations:
+- kustomizeconfig.yaml
+
 resources:
 - admission.yaml

--- a/config/admission/kustomization.yaml
+++ b/config/admission/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- admission.yaml

--- a/config/admission/kustomizeconfig.yaml
+++ b/config/admission/kustomizeconfig.yaml
@@ -1,0 +1,9 @@
+# This file is for teaching kustomize how to substitute name in ValidatingAdmissionPolicyBinding
+# This might become obsolete depending on the outcome of https://github.com/kubernetes-sigs/kustomize/issues/5674
+nameReference:
+- kind: ValidatingAdmissionPolicy
+  group: admissionregistration.k8s.io
+  fieldSpecs:
+  - kind: ValidatingAdmissionPolicyBinding
+    group: admissionregistration.k8s.io
+    path: spec/policyName

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ namePrefix: operator-controller-
 
 resources:
 - ../crd
+- ../admission
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in


### PR DESCRIPTION
# Description

To enforce package uniqueness across `ClusterExtension`.

We currently have this enforcement on the operator-controller level, but with Deppy removal in #758 we want to shift it into API server.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
