### PR TITLE
🌱 GitHub Actions: Setup kind cluster without ctlptl

### DIFF
--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -35,13 +35,10 @@ jobs:
         TILT_VERSION="0.33.3"
         curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v$TILT_VERSION/tilt.$TILT_VERSION.linux.x86_64.tar.gz | \
           tar -xzv -C /usr/local/bin tilt
-    - name: Install ctlptl
-      run: |
-        CTLPTL_VERSION="0.8.20"
-        curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | \
-          tar -xzv -C /usr/local/bin ctlptl
     - name: Set up kind
-      run: ctlptl create cluster kind --registry=ctlptl-registry
+      run: |
+        cd operator-controller
+        make kind-cluster
     - name: Test Tilt
       run: |
         cd operator-controller


### PR DESCRIPTION
# Description

We already have kind cluster setup scripted in `Makefile` which includes correct configuration.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
