### PR TITLE
🌱 Use server side apply to update test resource

### DIFF
--- a/test/e2e/cluster_extension_admission_test.go
+++ b/test/e2e/cluster_extension_admission_test.go
@@ -9,12 +9,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
 
 func TestClusterExtensionPackageUniqueness(t *testing.T) {
 	ctx := context.Background()
+	fieldOwner := client.FieldOwner("operator-controller-e2e")
 
 	deleteClusterExtension := func(clusterExtension *ocv1alpha1.ClusterExtension) {
 		require.NoError(t, c.Delete(ctx, clusterExtension))
@@ -64,12 +66,33 @@ func TestClusterExtensionPackageUniqueness(t *testing.T) {
 	defer deleteClusterExtension(clusterExtension2)
 
 	t.Log("update second resource with package which already exists on the cluster")
-	clusterExtension2.Spec.PackageName = firstResourcePackageName
-	err = c.Update(ctx, clusterExtension2)
+	intent := &ocv1alpha1.ClusterExtension{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ocv1alpha1.GroupVersion.String(),
+			Kind:       "ClusterExtension",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterExtension2.Name,
+		},
+		Spec: ocv1alpha1.ClusterExtensionSpec{
+			PackageName: firstResourcePackageName,
+		},
+	}
+	err = c.Patch(ctx, intent, client.Apply, client.ForceOwnership, fieldOwner)
 	require.ErrorContains(t, err, fmt.Sprintf("Package %q is already installed via ClusterExtension %q", firstResourcePackageName, firstResourceName))
 
 	t.Log("update second resource with package which does not exist on the cluster")
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: clusterExtension2.Name}, clusterExtension2))
-	clusterExtension2.Spec.PackageName = "package3"
-	require.NoError(t, c.Update(ctx, clusterExtension2))
+	intent = &ocv1alpha1.ClusterExtension{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ocv1alpha1.GroupVersion.String(),
+			Kind:       "ClusterExtension",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterExtension2.Name,
+		},
+		Spec: ocv1alpha1.ClusterExtensionSpec{
+			PackageName: "package3",
+		},
+	}
+	require.NoError(t, c.Patch(ctx, intent, client.Apply, client.ForceOwnership, fieldOwner))
 }


### PR DESCRIPTION
# Description

Deals with a flake such as this:

```
go test -tags upstream -v ./test/e2e/...
=== RUN   TestClusterExtensionPackageUniqueness
    cluster_extension_admission_test.go:30: create first resource
    cluster_extension_admission_test.go:42: create second resource with the same package as the first resource
    cluster_extension_admission_test.go:54: create second resource with different package
    cluster_extension_admission_test.go:66: update second resource with package which already exists on the cluster
    cluster_extension_admission_test.go:69: 
        	Error Trace:	/home/runner/work/operator-controller/operator-controller/test/e2e/cluster_extension_admission_test.go:69
        	Error:      	Error "Operation cannot be fulfilled on clusterextensions.olm.operatorframework.io \"test-extension-74hdj\": the object has been modified; please apply your changes to the latest version and try again" does not contain "Package \"package1\" is already installed via ClusterExtension \"test-extension-first\""
        	Test:       	TestClusterExtensionPackageUniqueness
--- FAIL: TestClusterExtensionPackageUniqueness (2.03s)
```

Was introduced in https://github.com/operator-framework/operator-controller/pull/785.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
