### PR TITLE
🐛 More needed for podman workaround in kind-load (take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,13 @@ e2e-coverage:
 kind-load: $(KIND) #EXHELP Loads the currently constructed image onto the cluster.
 ifeq ($(CONTAINER_RUNTIME),podman)
 	@echo "Using Podman"
-	podman save $(IMG) -o $(IMG).tar
-	$(KIND) load image-archive $(IMG).tar --name $(KIND_CLUSTER_NAME)
-	rm $(IMG).tar
+	@DEPLOY_TEMPLATE_IMG_NAME=quay.io/operator-framework/operator-controller:devel; \
+	TMP_FILE=temp_image.tar; \
+	podman tag $(IMG) $$DEPLOY_TEMPLATE_IMG_NAME; \
+	echo "Saving image to temporary file $$TMP_FILE"; \
+	podman save $$DEPLOY_TEMPLATE_IMG_NAME -o $$TMP_FILE; \
+	$(KIND) load image-archive $$TMP_FILE --name $(KIND_CLUSTER_NAME); \
+	rm $$TMP_FILE
 else
 	@echo "Using Docker"
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)


### PR DESCRIPTION
The commit adding the podman workaround for the kind-load target seems to need a bit more work:

It needs to have the tag name set before image-archive is saved

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
