### PR TITLE
:sparkles: Add version flag for operator-controller manager binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,10 +207,13 @@ CGO_ENABLED := 0
 endif
 export CGO_ENABLED
 
+export GIT_REPO := $(shell go list -m)
+export VERSION_PATH := ${GIT_REPO}/internal/version
 export GO_BUILD_ASMFLAGS := all=-trimpath=$(PWD)
-export GO_BUILD_LDFLAGS := -s -w -X $(shell go list -m)/version.Version=$(VERSION)
 export GO_BUILD_GCFLAGS := all=-trimpath=$(PWD)
 export GO_BUILD_FLAGS :=
+export GO_BUILD_LDFLAGS := -s -w \
+    -X '$(VERSION_PATH).version=$(VERSION)' \
 
 BUILDCMD = go build $(GO_BUILD_FLAGS) -ldflags '$(GO_BUILD_LDFLAGS)' -gcflags '$(GO_BUILD_GCFLAGS)' -asmflags '$(GO_BUILD_ASMFLAGS)' -o $(BUILDBIN)/manager ./cmd/manager
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,44 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+var (
+	gitCommit  = "unknown"
+	commitDate = "unknown"
+	repoState  = "unknown"
+	version    = "unknown"
+
+	stateMap = map[string]string{
+		"true":  "dirty",
+		"false": "clean",
+	}
+)
+
+func String() string {
+	return fmt.Sprintf("version: %q, commit: %q, date: %q, state: %q", version, gitCommit, commitDate, repoState)
+}
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			gitCommit = setting.Value
+		case "vcs.time":
+			commitDate = setting.Value
+		case "vcs.modified":
+			if v, ok := stateMap[setting.Value]; ok {
+				repoState = v
+			}
+		}
+	}
+	if version == "unknown" {
+		version = info.Main.Version
+	}
+}


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

- resolves #328 
- this just adds git commit version for now. Do we want to also show the release version?

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
