### PR TITLE
🐛 Sanitize temporary filename for podman image load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,15 +154,7 @@ e2e-coverage:
 
 .PHONY: kind-load
 kind-load: $(KIND) #EXHELP Loads the currently constructed image onto the cluster.
-ifeq ($(CONTAINER_RUNTIME),podman)
-	@echo "Using Podman"
-	podman save $(IMG) -o $(IMG).tar
-	$(KIND) load image-archive $(IMG).tar --name $(KIND_CLUSTER_NAME)
-	rm $(IMG).tar
-else
-	@echo "Using Docker"
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
-endif
+	$(CONTAINER_RUNTIME) save $(IMG) | $(KIND) load image-archive /dev/stdin --name $(KIND_CLUSTER_NAME)
 
 kind-deploy: export MANIFEST="./operator-controller.yaml"
 kind-deploy: manifests $(KUSTOMIZE) #EXHELP Install controller and dependencies onto the kind cluster.


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
The podman-specific kind-load commands in the Makefile currently write the image archive to a temporary file named $IM but that by default includes slashes and a colon. My changes replace any slashes or colons with hyphens to prevent any errors trying to write that file.

Also, the naming doesn't really matter, we can just make it be a hard-coded "tmp.tar" or something.

Also, also, I saw the closed PR from earlier today and the discussion about not getting too into the weeds on podman/docker-specific configuration in the Makefile, but the current setup will cause that file-write error for anyone who does use CONTAINER_RUNTIME=podman with our default env variables, so I figured that was worth a quick fix.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
