### PR TITLE
:bug: [Fix] Constant reconciles due to Catalog's poll interval

### DIFF
--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
@@ -409,6 +411,23 @@ func (r *ClusterExtensionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&ocv1alpha1.ClusterExtension{}).
 		Watches(&catalogd.Catalog{},
 			handler.EnqueueRequestsFromMapFunc(clusterExtensionRequestsForCatalog(mgr.GetClient(), mgr.GetLogger()))).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(ue event.UpdateEvent) bool {
+				oldObject, isOldCatalog := ue.ObjectOld.(*catalogd.Catalog)
+				newObject, isNewCatalog := ue.ObjectNew.(*catalogd.Catalog)
+
+				if !isOldCatalog || !isNewCatalog {
+					return true
+				}
+
+				if oldObject.Status.ResolvedSource != nil && newObject.Status.ResolvedSource != nil {
+					if oldObject.Status.ResolvedSource.Image != nil && newObject.Status.ResolvedSource.Image != nil {
+						return oldObject.Status.ResolvedSource.Image.ResolvedRef != newObject.Status.ResolvedSource.Image.ResolvedRef
+					}
+				}
+				return true
+			},
+		}).
 		Owns(&rukpakv1alpha2.BundleDeployment{}).
 		Complete(r)
 


### PR DESCRIPTION
# Description

Due to the polling feature in the Catalog, the `lastPolledInterval` in the Catalog's status gets updated. Because of this there is a reconcile triggered every time the catalog is polled, even though there is no change in the resolved image ref.

This causes unnecessary continuous reconciles in the CE reconciler. To overcome this, a Predicate is added to accept update events only when there is a change in Resolved image reference in catalog's status.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->



<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
