### PR TITLE
✨ Add test to verify registry+v1 webhooks limitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,8 @@ kind-load-test-artifacts: $(KIND) #EXHELP Load the e2e testdata container images
 	$(KIND) load docker-image localhost/testdata/bundles/registry-v1/prometheus-operator:v1.0.1 --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image localhost/testdata/bundles/registry-v1/prometheus-operator:v1.2.0 --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image localhost/testdata/bundles/registry-v1/prometheus-operator:v2.0.0 --name $(KIND_CLUSTER_NAME)
+	$(CONTAINER_RUNTIME) build testdata/bundles/registry-v1/package-with-webhooks.v1.0.0 -t  localhost/testdata/bundles/registry-v1/package-with-webhooks:v1.0.0
+	$(KIND) load docker-image localhost/testdata/bundles/registry-v1/package-with-webhooks:v1.0.0 --name $(KIND_CLUSTER_NAME)
 
 
 #SECTION Build

--- a/test/e2e/cluster_extension_registryV1_limitations_test.go
+++ b/test/e2e/cluster_extension_registryV1_limitations_test.go
@@ -1,0 +1,64 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+
+	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+)
+
+func TestClusterExtensionPackagesWithWebhooksAreNotAllowed(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := createTestCatalog(ctx, testCatalogName, os.Getenv(testCatalogRefEnvVar))
+	defer func(cat *catalogd.Catalog) {
+		require.NoError(t, c.Delete(context.Background(), cat))
+		require.Eventually(t, func() bool {
+			err := c.Get(context.Background(), types.NamespacedName{Name: cat.Name}, &catalogd.Catalog{})
+			return errors.IsNotFound(err)
+		}, pollDuration, pollInterval)
+	}(catalog)
+	require.NoError(t, err)
+
+	deleteClusterExtension := func(clusterExtension *ocv1alpha1.ClusterExtension) {
+		require.NoError(t, c.Delete(ctx, clusterExtension))
+		require.Eventually(t, func() bool {
+			err := c.Get(ctx, types.NamespacedName{Name: clusterExtension.Name}, &ocv1alpha1.ClusterExtension{})
+			return errors.IsNotFound(err)
+		}, pollDuration, pollInterval)
+	}
+
+	clusterExtension := &ocv1alpha1.ClusterExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "package-with-webhooks-",
+		},
+		Spec: ocv1alpha1.ClusterExtensionSpec{
+			PackageName:      "package-with-webhooks",
+			Version:          "1.0.0",
+			InstallNamespace: "default",
+		},
+	}
+	err = c.Create(ctx, clusterExtension)
+	defer deleteClusterExtension(clusterExtension)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NoError(ct, c.Get(ctx, types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
+
+		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeInstalled)
+		assert.NotNil(ct, cond)
+		assert.Equal(ct, metav1.ConditionFalse, cond.Status)
+		assert.Equal(ct, ocv1alpha1.ReasonInstallationFailed, cond.Reason)
+		assert.Contains(ct, cond.Message, "webhookDefinitions are not supported")
+		assert.Equal(ct, &ocv1alpha1.BundleMetadata{Name: "package-with-webhooks.1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+	}, pollDuration, pollInterval)
+}

--- a/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/Dockerfile
+++ b/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=package-with-webhooks
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=unknown
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/manifests/bundle-with-webhooks.clusterserviceversion.yaml
+++ b/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/manifests/bundle-with-webhooks.clusterserviceversion.yaml
@@ -1,0 +1,34 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: package-with-webhooks.v1.0.0
+  namespace: placeholder
+spec:
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1alpha1
+    - v1beta1
+    containerPort: 443
+    conversionCRDs:
+    - testcds.package-with-webhooks.io
+    deploymentName: test-operator-controller-manager
+    generateName: testcrds
+    sideEffects: None
+    targetPort: 9443
+    type: ConversionWebhook
+    webhookPath: /convert
+  description: Test package with webhooks
+  displayName: Package with webhooks
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iMjQ5MCIgaGVpZ2h0PSIyNTAwIiB2aWV3Qm94PSIwIDAgMjU2IDI1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWlkWU1pZCI+PHBhdGggZD0iTTEyOC4wMDEuNjY3QzU3LjMxMS42NjcgMCA1Ny45NzEgMCAxMjguNjY0YzAgNzAuNjkgNTcuMzExIDEyNy45OTggMTI4LjAwMSAxMjcuOTk4UzI1NiAxOTkuMzU0IDI1NiAxMjguNjY0QzI1NiA1Ny45NyAxOTguNjg5LjY2NyAxMjguMDAxLjY2N3ptMCAyMzkuNTZjLTIwLjExMiAwLTM2LjQxOS0xMy40MzUtMzYuNDE5LTMwLjAwNGg3Mi44MzhjMCAxNi41NjYtMTYuMzA2IDMwLjAwNC0zNi40MTkgMzAuMDA0em02MC4xNTMtMzkuOTRINjcuODQyVjE3OC40N2gxMjAuMzE0djIxLjgxNmgtLjAwMnptLS40MzItMzMuMDQ1SDY4LjE4NWMtLjM5OC0uNDU4LS44MDQtLjkxLTEuMTg4LTEuMzc1LTEyLjMxNS0xNC45NTQtMTUuMjE2LTIyLjc2LTE4LjAzMi0zMC43MTYtLjA0OC0uMjYyIDE0LjkzMyAzLjA2IDI1LjU1NiA1LjQ1IDAgMCA1LjQ2NiAxLjI2NSAxMy40NTggMi43MjItNy42NzMtOC45OTQtMTIuMjMtMjAuNDI4LTEyLjIzLTMyLjExNiAwLTI1LjY1OCAxOS42OC00OC4wNzkgMTIuNTgtNjYuMjAxIDYuOTEuNTYyIDE0LjMgMTQuNTgzIDE0LjggMzYuNTA1IDcuMzQ2LTEwLjE1MiAxMC40Mi0yOC42OSAxMC40Mi00MC4wNTYgMC0xMS43NjkgNy43NTUtMjUuNDQgMTUuNTEyLTI1LjkwNy02LjkxNSAxMS4zOTYgMS43OSAyMS4xNjUgOS41MyA0NS40IDIuOTAyIDkuMTAzIDIuNTMyIDI0LjQyMyA0Ljc3MiAzNC4xMzguNzQ0LTIwLjE3OCA0LjIxMy00OS42MiAxNy4wMTQtNTkuNzg0LTUuNjQ3IDEyLjguODM2IDI4LjgxOCA1LjI3IDM2LjUxOCA3LjE1NCAxMi40MjQgMTEuNDkgMjEuODM2IDExLjQ5IDM5LjYzOCAwIDExLjkzNi00LjQwNyAyMy4xNzMtMTEuODQgMzEuOTU4IDguNDUyLTEuNTg2IDE0LjI4OS0zLjAxNiAxNC4yODktMy4wMTZsMjcuNDUtNS4zNTVjLjAwMi0uMDAyLTMuOTg3IDE2LjQwMS0xOS4zMTQgMzIuMTk3eiIgZmlsbD0iI0RBNEUzMSIvPjwvc3ZnPg==
+      mediatype: image/svg+xml
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  version: 1.0.0

--- a/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/metadata/annotations.yaml
+++ b/testdata/bundles/registry-v1/package-with-webhooks.v1.0.0/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: package-with-webhooks
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown

--- a/testdata/catalogs/test-catalog/catalog.yaml
+++ b/testdata/catalogs/test-catalog/catalog.yaml
@@ -60,3 +60,23 @@ properties:
     value:
       packageName: prometheus
       version: 2.0.0
+---
+schema: olm.package
+name: package-with-webhooks
+defaultChannel: beta
+---
+schema: olm.channel
+name: beta
+package: package-with-webhooks
+entries:
+  - name: package-with-webhooks.1.0.0
+---
+schema: olm.bundle
+name: package-with-webhooks.1.0.0
+package: package-with-webhooks
+image: localhost/testdata/bundles/registry-v1/package-with-webhooks:v1.0.0
+properties:
+  - type: olm.package
+    value:
+      packageName: package-with-webhooks
+      version: 1.0.0


### PR DESCRIPTION
# Description

No bundles with webhooks are currently allowed and we must be clearly indicated in the conditions of `ClusterExtension`.

Closes #815

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
