### PR TITLE
🌱 Update CONTAINER_TOOL evaluation in makefile to warn instead of error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ CONTAINER_RUNTIME := docker
 else ifneq (, $(shell command -v podman 2>/dev/null))
 CONTAINER_RUNTIME := podman
 else
-$(error Could not find docker or podman in path!)
+$(warning Could not find docker or podman in path! This may result in targets requiring a container runtime failing!) 
 endif
 
 KUSTOMIZE_BUILD_DIR := config/default


### PR DESCRIPTION
when unable to find docker or podman as this evaluation results in an error in environments where docker or podman is not installed even when using targets that do not require a container runtime

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
- Updates the `CONTAINER_TOOL` evaluation logic to warn instead of error out when `docker` or `podman` are not detected in the path. This makes it so that in environments where neither is installed, running targets that don't require a container runtime can still be run. A caveat is that the targets needing a container runtime will still attempt to run and fail. I believe issuing a warning is a good middle ground to provide a clear reason why a target that requires a container runtime would fail, but am open to suggestions on better ways to approach this.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
