### PR TITLE
✨ Helper script for a podman kind cluster with an image registry

### DIFF
--- a/dev/podman/kind-with-registry-podman.sh
+++ b/dev/podman/kind-with-registry-podman.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -o errexit
+
+# 1. Create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5001'
+int_port='5000'
+if [ "$(podman inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  podman run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:${int_port}" --network bridge --name "${reg_name}" \
+    registry:2
+fi
+
+# 2. Create kind cluster with containerd registry config dir enabled
+# TODO: kind will eventually enable this by default and this patch will
+# be unnecessary.
+#
+# See:
+# https://github.com/kubernetes-sigs/kind/issues/2875
+# https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+# See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  "ValidatingAdmissionPolicy": true
+runtimeConfig:
+  "admissionregistration.k8s.io/v1beta1": true
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+EOF
+
+# 3. Add the registry config to the nodes
+#
+# This is necessary because localhost resolves to loopback addresses that are
+# network-namespace local.
+# In other words: localhost in the container is not localhost on the host.
+#
+# We want a consistent name that works from both ends, so we tell containerd to
+# alias localhost:${reg_port} to the registry container when pulling images
+REGISTRY_DIR="/etc/containerd/certs.d/localhost:${reg_port}"
+for node in $(kind get nodes); do
+  podman exec "${node}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | podman exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+[host."http://${reg_name}:${int_port}"]
+EOF
+done
+
+# 4. Connect the registry to the cluster network if not already connected
+# This allows kind to bootstrap the network but ensures they're on the same network
+if [ "$(podman inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  podman network connect "kind" "${reg_name}"
+fi
+
+# 5. Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF

--- a/dev/podman/setup-local-env-podman.md
+++ b/dev/podman/setup-local-env-podman.md
@@ -1,0 +1,54 @@
+## The following are Podman specific steps used to set up on a MacBook (Intel or Apple Silicon)
+
+### Verify installed tools (install if needed)
+
+```sh
+$ podman --version
+podman version 5.0.1
+$ kind version
+kind v0.23.0 go1.22.3 darwin/arm64
+
+(optional)
+$ tilt version
+v0.33.12, built 2024-03-28
+```
+
+### Start Kind with a local registry
+Use this [helper script](./kind-with-registry-podman.sh) to create a local single-node Kind cluster with an attached local image registry.
+
+#### Disable secure access on the local kind registry:
+
+`podman inspect kind-registry --format '{{.NetworkSettings.Ports}}'`
+
+With the port you find for 127.0.0.1 edit the Podman machine's config file:
+
+`podman machine ssh`
+
+`sudo vi /etc/containers/registries.conf.d/100-kind.conf`
+
+Should look like:
+
+```ini
+[[registry]]
+location = "localhost:5001"
+insecure = true
+```
+
+### export DOCKER_HOST
+
+`export DOCKER_HOST=unix:///var/run/docker.sock`
+
+
+### Optional - Start tilt with the tilt file in the parent directory
+
+`DOCKER_BUILDKIT=0 tilt up`
+
+### Optional troubleshooting
+
+In some cases it may be needed to do
+```
+sudo podman-mac-helper install
+```
+```
+podman machine stop/start
+```


### PR DESCRIPTION
# Description

Adding a helper script for a podman-based kind cluster with an image registry.
This should help local testing by speeding up initial setup, required for running Tilt.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
