### PR TITLE
🌱 Change global var GetInstalledBundle to interface

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -181,13 +181,14 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterExtensionReconciler{
-		Client:             cl,
-		ReleaseNamespace:   systemNamespace,
-		BundleProvider:     catalogClient,
-		ActionClientGetter: acg,
-		Unpacker:           unpacker,
-		Storage:            localStorage,
-		Handler:            handler.HandlerFunc(handler.HandleClusterExtension),
+		Client:                cl,
+		ReleaseNamespace:      systemNamespace,
+		BundleProvider:        catalogClient,
+		ActionClientGetter:    acg,
+		Unpacker:              unpacker,
+		Storage:               localStorage,
+		Handler:               handler.HandlerFunc(handler.HandleClusterExtension),
+		InstalledBundleGetter: &controllers.DefaultInstalledBundleGetter{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterExtension")
 		os.Exit(1)

--- a/internal/controllers/clusterextension_registryv1_validation_test.go
+++ b/internal/controllers/clusterextension_registryv1_validation_test.go
@@ -107,12 +107,16 @@ func TestClusterExtensionRegistryV1DisallowDependencies(t *testing.T) {
 			mockUnpacker.On("Unpack", mock.Anything, mock.AnythingOfType("*v1alpha2.BundleDeployment")).Return(&source.Result{
 				State: source.StatePending,
 			}, nil)
+			// Create and configure the mock InstalledBundleGetter
+			mockInstalledBundleGetter := &MockInstalledBundleGetter{}
+			mockInstalledBundleGetter.SetBundle(tt.bundle)
 
 			reconciler := &controllers.ClusterExtensionReconciler{
-				Client:             cl,
-				BundleProvider:     &fakeCatalogClient,
-				ActionClientGetter: helmClientGetter,
-				Unpacker:           unpacker,
+				Client:                cl,
+				BundleProvider:        &fakeCatalogClient,
+				ActionClientGetter:    helmClientGetter,
+				Unpacker:              unpacker,
+				InstalledBundleGetter: mockInstalledBundleGetter,
 			}
 
 			installNamespace := fmt.Sprintf("test-ns-%s", rand.String(8))


### PR DESCRIPTION
# Description

Follow on to the helm-poc changes:

We'd like to not have a global variable for `GetInstalledBundle`, but instead an easier to test interface.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
