### PR TITLE
:sparkles: Update status update functions

### DIFF
--- a/api/v1alpha1/clusterextension_types.go
+++ b/api/v1alpha1/clusterextension_types.go
@@ -106,7 +106,14 @@ const (
 	ReasonDeprecated            = "Deprecated"
 	ReasonUpgradeFailed         = "UpgradeFailed"
 	ReasonHasValidBundleUnknown = "HasValidBundleUnknown"
-	ReasonUnpackPending         = "UnpackPending"
+
+	ReasonUnpackPending = "UnpackPending"
+	ReasonUnpackSuccess = "UnpackSuccess"
+	ReasonUnpackFailed  = "UnpackFailed"
+	ReasonUnpacking     = "Unpacking"
+
+	ReasonErrorGettingReleaseState = "ErrorGettingReleaseState"
+	ReasonCreateDynamicWatchFailed = "CreateDynamicWatchFailed"
 )
 
 func init() {
@@ -134,6 +141,11 @@ func init() {
 		ReasonInstallationStatusUnknown,
 		ReasonHasValidBundleUnknown,
 		ReasonUnpackPending,
+		ReasonUnpackSuccess,
+		ReasonUnpacking,
+		ReasonUnpackFailed,
+		ReasonErrorGettingReleaseState,
+		ReasonCreateDynamicWatchFailed,
 	)
 }
 

--- a/internal/controllers/common_controller.go
+++ b/internal/controllers/common_controller.go
@@ -22,9 +22,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	rukpakv1alpha2 "github.com/operator-framework/rukpak/api/v1alpha2"
-	"github.com/operator-framework/rukpak/pkg/source"
-
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 )
@@ -36,84 +33,84 @@ type BundleProvider interface {
 }
 
 // setResolvedStatusConditionSuccess sets the resolved status condition to success.
-func setResolvedStatusConditionSuccess(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setResolvedStatusConditionSuccess(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeResolved,
 		Status:             metav1.ConditionTrue,
 		Reason:             ocv1alpha1.ReasonSuccess,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setInstalledStatusConditionUnknown sets the installed status condition to unknown.
-func setInstalledStatusConditionUnknown(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setInstalledStatusConditionUnknown(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeInstalled,
 		Status:             metav1.ConditionUnknown,
 		Reason:             ocv1alpha1.ReasonInstallationStatusUnknown,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setHasValidBundleUnknown sets the valid bundle condition to unknown.
-func setHasValidBundleUnknown(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setHasValidBundleUnknown(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeHasValidBundle,
 		Status:             metav1.ConditionUnknown,
 		Reason:             ocv1alpha1.ReasonHasValidBundleUnknown,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setHasValidBundleFalse sets the ivalid bundle condition to false
-func setHasValidBundleFailed(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setHasValidBundleFailed(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeHasValidBundle,
 		Status:             metav1.ConditionFalse,
 		Reason:             ocv1alpha1.ReasonBundleLoadFailed,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setResolvedStatusConditionFailed sets the resolved status condition to failed.
-func setResolvedStatusConditionFailed(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setResolvedStatusConditionFailed(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeResolved,
 		Status:             metav1.ConditionFalse,
 		Reason:             ocv1alpha1.ReasonResolutionFailed,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setInstalledStatusConditionSuccess sets the installed status condition to success.
-func setInstalledStatusConditionSuccess(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setInstalledStatusConditionSuccess(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeInstalled,
 		Status:             metav1.ConditionTrue,
 		Reason:             ocv1alpha1.ReasonSuccess,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setInstalledStatusConditionFailed sets the installed status condition to failed.
-func setInstalledStatusConditionFailed(conditions *[]metav1.Condition, message string, generation int64) {
-	apimeta.SetStatusCondition(conditions, metav1.Condition{
+func setInstalledStatusConditionFailed(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 		Type:               ocv1alpha1.TypeInstalled,
 		Status:             metav1.ConditionFalse,
 		Reason:             ocv1alpha1.ReasonInstallationFailed,
 		Message:            message,
-		ObservedGeneration: generation,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // setDeprecationStatusesUnknown sets the deprecation status conditions to unknown.
-func setDeprecationStatusesUnknown(conditions *[]metav1.Condition, message string, generation int64) {
+func setDeprecationStatusesUnknown(ext *ocv1alpha1.ClusterExtension, message string) {
 	conditionTypes := []string{
 		ocv1alpha1.TypeDeprecated,
 		ocv1alpha1.TypePackageDeprecated,
@@ -122,55 +119,57 @@ func setDeprecationStatusesUnknown(conditions *[]metav1.Condition, message strin
 	}
 
 	for _, conditionType := range conditionTypes {
-		apimeta.SetStatusCondition(conditions, metav1.Condition{
+		apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
 			Type:               conditionType,
 			Reason:             ocv1alpha1.ReasonDeprecated,
 			Status:             metav1.ConditionUnknown,
 			Message:            message,
-			ObservedGeneration: generation,
+			ObservedGeneration: ext.GetGeneration(),
 		})
 	}
 }
 
-func updateStatusUnpackFailing(status *ocv1alpha1.ClusterExtensionStatus, err error) error {
-	status.InstalledBundle = nil
-	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
-		Type:    rukpakv1alpha2.TypeUnpacked,
-		Status:  metav1.ConditionFalse,
-		Reason:  rukpakv1alpha2.ReasonUnpackFailed,
-		Message: err.Error(),
-	})
-	return err
-}
-
-// TODO: verify if we need to update the installBundle status or leave it as is.
-func updateStatusUnpackPending(status *ocv1alpha1.ClusterExtensionStatus, result *source.Result, generation int64) {
-	status.InstalledBundle = nil
-	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
-		Type:               rukpakv1alpha2.TypeUnpacked,
+func setStatusUnpackFailed(ext *ocv1alpha1.ClusterExtension, message string) {
+	ext.Status.InstalledBundle = nil
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
+		Type:               ocv1alpha1.TypeUnpacked,
 		Status:             metav1.ConditionFalse,
-		Reason:             rukpakv1alpha2.ReasonUnpackPending,
-		Message:            result.Message,
-		ObservedGeneration: generation,
+		Reason:             ocv1alpha1.ReasonUnpackFailed,
+		Message:            message,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
 // TODO: verify if we need to update the installBundle status or leave it as is.
-func updateStatusUnpacking(status *ocv1alpha1.ClusterExtensionStatus, result *source.Result) {
-	status.InstalledBundle = nil
-	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
-		Type:    rukpakv1alpha2.TypeUnpacked,
-		Status:  metav1.ConditionFalse,
-		Reason:  rukpakv1alpha2.ReasonUnpacking,
-		Message: result.Message,
+func setStatusUnpackPending(ext *ocv1alpha1.ClusterExtension, message string) {
+	ext.Status.InstalledBundle = nil
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
+		Type:               ocv1alpha1.TypeUnpacked,
+		Status:             metav1.ConditionFalse,
+		Reason:             ocv1alpha1.ReasonUnpackPending,
+		Message:            message,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }
 
-func updateStatusUnpacked(status *ocv1alpha1.ClusterExtensionStatus, result *source.Result) {
-	apimeta.SetStatusCondition(&status.Conditions, metav1.Condition{
-		Type:    rukpakv1alpha2.TypeUnpacked,
-		Status:  metav1.ConditionTrue,
-		Reason:  rukpakv1alpha2.ReasonUnpackSuccessful,
-		Message: result.Message,
+// TODO: verify if we need to update the installBundle status or leave it as is.
+func setStatusUnpacking(ext *ocv1alpha1.ClusterExtension, message string) {
+	ext.Status.InstalledBundle = nil
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
+		Type:               ocv1alpha1.TypeUnpacked,
+		Status:             metav1.ConditionFalse,
+		Reason:             ocv1alpha1.ReasonUnpacking,
+		Message:            message,
+		ObservedGeneration: ext.GetGeneration(),
+	})
+}
+
+func setStatusUnpacked(ext *ocv1alpha1.ClusterExtension, message string) {
+	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
+		Type:               ocv1alpha1.TypeUnpacked,
+		Status:             metav1.ConditionTrue,
+		Reason:             ocv1alpha1.ReasonUnpackSuccess,
+		Message:            message,
+		ObservedGeneration: ext.GetGeneration(),
 	})
 }

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
-	rukpakv1alpha2 "github.com/operator-framework/rukpak/api/v1alpha2"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 )
@@ -97,12 +96,12 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 	t.Log("By eventually reporting a successful unpacked")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, rukpakv1alpha2.TypeUnpacked)
+		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeUnpacked)
 		if !assert.NotNil(ct, cond) {
 			return
 		}
 		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
-		assert.Equal(ct, rukpakv1alpha2.ReasonUnpackSuccessful, cond.Reason)
+		assert.Equal(ct, ocv1alpha1.ReasonUnpackSuccess, cond.Reason)
 		assert.Contains(ct, cond.Message, "Successfully unpacked")
 	}, pollDuration, pollInterval)
 


### PR DESCRIPTION
Remove references to rukpak k8s API where possible.

With the removal of Extension, the status update functions no longer need to be generic. Simplify the function signatures

This also makes the update functions consistent signature/behavior.
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
