### PR TITLE
🐛 Fix: installed bundle provider no longer requires catalog

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -188,7 +188,7 @@ func main() {
 		Unpacker:              unpacker,
 		Storage:               localStorage,
 		Handler:               handler.HandlerFunc(handler.HandleClusterExtension),
-		InstalledBundleGetter: &controllers.DefaultInstalledBundleGetter{},
+		InstalledBundleGetter: &controllers.DefaultInstalledBundleGetter{ActionClientGetter: acg},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterExtension")
 		os.Exit(1)

--- a/internal/catalogmetadata/filter/bundle_predicates.go
+++ b/internal/catalogmetadata/filter/bundle_predicates.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
+	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 )
 
@@ -66,7 +67,7 @@ func WithBundleName(bundleName string) Predicate[catalogmetadata.Bundle] {
 	}
 }
 
-func LegacySuccessor(installedBundle *catalogmetadata.Bundle) Predicate[catalogmetadata.Bundle] {
+func LegacySuccessor(installedBundle *ocv1alpha1.BundleMetadata) Predicate[catalogmetadata.Bundle] {
 	isSuccessor := func(candidateBundleEntry declcfg.ChannelEntry) bool {
 		if candidateBundleEntry.Replaces == installedBundle.Name {
 			return true
@@ -77,9 +78,9 @@ func LegacySuccessor(installedBundle *catalogmetadata.Bundle) Predicate[catalogm
 			}
 		}
 		if candidateBundleEntry.SkipRange != "" {
-			installedBundleVersion, _ := installedBundle.Version()
-			skipRange, _ := bsemver.ParseRange(candidateBundleEntry.SkipRange)
-			if installedBundleVersion != nil && skipRange != nil && skipRange(*installedBundleVersion) {
+			installedBundleVersion, vErr := bsemver.Parse(installedBundle.Version)
+			skipRange, srErr := bsemver.ParseRange(candidateBundleEntry.SkipRange)
+			if vErr == nil && srErr == nil && skipRange(installedBundleVersion) {
 				return true
 			}
 		}

--- a/internal/catalogmetadata/filter/bundle_predicates_test.go
+++ b/internal/catalogmetadata/filter/bundle_predicates_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 
+	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata/filter"
 )
@@ -150,13 +151,9 @@ func TestLegacySuccessor(t *testing.T) {
 			},
 		},
 	}
-	installedBundle := &catalogmetadata.Bundle{
-		Bundle: declcfg.Bundle{
-			Name: "package1.v0.0.1",
-			Properties: []property.Property{
-				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName": "package1", "version": "0.0.1"}`)},
-			},
-		},
+	installedBundle := &ocv1alpha1.BundleMetadata{
+		Name:    "package1.v0.0.1",
+		Version: "0.0.1",
 	}
 
 	b2 := &catalogmetadata.Bundle{

--- a/internal/controllers/clusterextension_controller_test.go
+++ b/internal/controllers/clusterextension_controller_test.go
@@ -169,7 +169,7 @@ func TestClusterExtensionChannelVersionExists(t *testing.T) {
 	require.NoError(t, cl.Get(ctx, extKey, clusterExtension))
 
 	t.Log("By checking the status fields")
-	require.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+	require.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
 	require.Empty(t, clusterExtension.Status.InstalledBundle)
 
 	t.Log("By checking the expected conditions")
@@ -227,7 +227,7 @@ func TestClusterExtensionChannelExistsNoVersion(t *testing.T) {
 	require.NoError(t, cl.Get(ctx, extKey, clusterExtension))
 
 	t.Log("By checking the status fields")
-	require.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
+	require.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
 	require.Empty(t, clusterExtension.Status.InstalledBundle)
 
 	t.Log("By checking the expected conditions")
@@ -418,22 +418,6 @@ func verifyConditionsInvariants(t *testing.T, ext *ocv1alpha1.ClusterExtension) 
 }
 
 func TestClusterExtensionUpgrade(t *testing.T) {
-	bundle := &catalogmetadata.Bundle{
-		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/beta/1.0.0",
-			Package: "prometheus",
-			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-			Properties: []property.Property{
-				{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"1.0.0"}`)},
-				{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-			},
-		},
-		CatalogName: "fake-catalog",
-		InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-	}
-
-	cl, reconciler := newClientAndReconciler(t, bundle)
-
 	mockUnpacker := unpacker.(*MockUnpacker)
 	// Set up the Unpack method to return a result with StateUnpackPending
 	mockUnpacker.On("Unpack", mock.Anything, mock.AnythingOfType("*v1alpha2.BundleDeployment")).Return(&source.Result{
@@ -442,6 +426,13 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("semver upgrade constraints enforcement of upgrades within major version", func(t *testing.T) {
+		bundle := &ocv1alpha1.BundleMetadata{
+			Name:    "prometheus.v1.0.0",
+			Version: "1.0.0",
+		}
+
+		cl, reconciler := newClientAndReconciler(t, bundle)
+
 		defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, true)()
 		defer func() {
 			require.NoError(t, cl.DeleteAllOf(ctx, &ocv1alpha1.ClusterExtension{}))
@@ -475,7 +466,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		require.NoError(t, err)
 
 		// Checking the status fields
-		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 		// checking the expected conditions
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -489,21 +480,6 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		err = cl.Update(ctx, clusterExtension)
 		require.NoError(t, err)
 
-		bundle := &catalogmetadata.Bundle{
-			Bundle: declcfg.Bundle{
-				Name:    "operatorhub/prometheus/beta/1.0.0",
-				Package: "prometheus",
-				Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-				Properties: []property.Property{
-					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"1.0.0"}`)},
-					{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-				},
-			},
-			CatalogName: "fake-catalog",
-			InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-		}
-
-		cl, reconciler := newClientAndReconciler(t, bundle)
 		// Run reconcile again
 		res, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
 		require.Error(t, err)
@@ -539,7 +515,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		require.NoError(t, err)
 
 		// Checking the status fields
-		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.2.0", Version: "1.2.0"}, clusterExtension.Status.ResolvedBundle)
+		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.2.0", Version: "1.2.0"}, clusterExtension.Status.ResolvedBundle)
 
 		// checking the expected conditions
 		cond = apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -550,6 +526,13 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 	})
 
 	t.Run("legacy semantics upgrade constraints enforcement", func(t *testing.T) {
+		bundle := &ocv1alpha1.BundleMetadata{
+			Name:    "prometheus.v1.0.0",
+			Version: "1.0.0",
+		}
+
+		cl, reconciler := newClientAndReconciler(t, bundle)
+
 		defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)()
 		defer func() {
 			require.NoError(t, cl.DeleteAllOf(ctx, &ocv1alpha1.ClusterExtension{}))
@@ -583,7 +566,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		require.NoError(t, err)
 
 		// Checking the status fields
-		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 		// checking the expected conditions
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -596,22 +579,6 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		clusterExtension.Spec.Version = "1.2.0"
 		err = cl.Update(ctx, clusterExtension)
 		require.NoError(t, err)
-
-		bundle := &catalogmetadata.Bundle{
-			Bundle: declcfg.Bundle{
-				Name:    "operatorhub/prometheus/beta/1.0.0",
-				Package: "prometheus",
-				Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-				Properties: []property.Property{
-					{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"1.0.0"}`)},
-					{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-				},
-			},
-			CatalogName: "fake-catalog",
-			InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-		}
-
-		cl, reconciler := newClientAndReconciler(t, bundle)
 
 		// Run reconcile again
 		res, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
@@ -648,7 +615,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 		require.NoError(t, err)
 
 		// Checking the status fields
-		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.1", Version: "1.0.1"}, clusterExtension.Status.ResolvedBundle)
+		assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.1", Version: "1.0.1"}, clusterExtension.Status.ResolvedBundle)
 
 		// checking the expected conditions
 		cond = apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -673,6 +640,13 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
+				bundle := &ocv1alpha1.BundleMetadata{
+					Name:    "prometheus.v1.0.0",
+					Version: "1.0.0",
+				}
+
+				cl, reconciler := newClientAndReconciler(t, bundle)
+
 				defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, tt.flagState)()
 				defer func() {
 					require.NoError(t, cl.DeleteAllOf(ctx, &ocv1alpha1.ClusterExtension{}))
@@ -704,7 +678,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 				require.NoError(t, err)
 
 				// Checking the status fields
-				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 				// checking the expected conditions
 				cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -720,22 +694,6 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 				err = cl.Update(ctx, clusterExtension)
 				require.NoError(t, err)
 
-				bundle := &catalogmetadata.Bundle{
-					Bundle: declcfg.Bundle{
-						Name:    "operatorhub/prometheus/beta/1.0.0",
-						Package: "prometheus",
-						Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-						Properties: []property.Property{
-							{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"1.0.0"}`)},
-							{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-						},
-					},
-					CatalogName: "fake-catalog",
-					InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-				}
-
-				cl, reconciler := newClientAndReconciler(t, bundle)
-
 				// Run reconcile again
 				res, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
 				require.NoError(t, err)
@@ -746,7 +704,7 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 				require.NoError(t, err)
 
 				// Checking the status fields
-				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
+				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 				// checking the expected conditions
 				cond = apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -760,7 +718,6 @@ func TestClusterExtensionUpgrade(t *testing.T) {
 }
 
 func TestClusterExtensionDowngrade(t *testing.T) {
-	cl, reconciler := newClientAndReconciler(t, nil)
 	mockUnpacker := unpacker.(*MockUnpacker)
 	// Set up the Unpack method to return a result with StateUnpacked
 	mockUnpacker.On("Unpack", mock.Anything, mock.AnythingOfType("*v1alpha2.BundleDeployment")).Return(&source.Result{
@@ -783,6 +740,13 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
+				bundle := &ocv1alpha1.BundleMetadata{
+					Name:    "prometheus.v1.0.1",
+					Version: "1.0.1",
+				}
+
+				cl, reconciler := newClientAndReconciler(t, bundle)
+
 				defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, tt.flagState)()
 				defer func() {
 					require.NoError(t, cl.DeleteAllOf(ctx, &ocv1alpha1.ClusterExtension{}))
@@ -813,7 +777,7 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 				require.NoError(t, err)
 
 				// Checking the status fields
-				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.1", Version: "1.0.1"}, clusterExtension.Status.ResolvedBundle)
+				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.1", Version: "1.0.1"}, clusterExtension.Status.ResolvedBundle)
 
 				// checking the expected conditions
 				cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -826,22 +790,6 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 				clusterExtension.Spec.Version = "1.0.0"
 				err = cl.Update(ctx, clusterExtension)
 				require.NoError(t, err)
-
-				bundle := &catalogmetadata.Bundle{
-					Bundle: declcfg.Bundle{
-						Name:    "operatorhub/prometheus/beta/1.0.1",
-						Package: "prometheus",
-						Image:   "quay.io/operatorhubio/prometheus@fake1.0.1",
-						Properties: []property.Property{
-							{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"1.0.1"}`)},
-							{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-						},
-					},
-					CatalogName: "fake-catalog",
-					InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-				}
-
-				cl, reconciler := newClientAndReconciler(t, bundle)
 
 				// Run reconcile again
 				res, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
@@ -881,6 +829,12 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
+				bundle := &ocv1alpha1.BundleMetadata{
+					Name:    "prometheus.v2.0.0",
+					Version: "2.0.0",
+				}
+
+				cl, reconciler := newClientAndReconciler(t, bundle)
 				defer featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, tt.flagState)()
 				defer func() {
 					require.NoError(t, cl.DeleteAllOf(ctx, &ocv1alpha1.ClusterExtension{}))
@@ -912,7 +866,7 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 				require.NoError(t, err)
 
 				// Checking the status fields
-				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
+				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v2.0.0", Version: "2.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 				// checking the expected conditions
 				cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -926,22 +880,6 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 				err = cl.Update(ctx, clusterExtension)
 				require.NoError(t, err)
 
-				bundle := &catalogmetadata.Bundle{
-					Bundle: declcfg.Bundle{
-						Name:    "operatorhub/prometheus/beta/2.0.0",
-						Package: "prometheus",
-						Image:   "quay.io/operatorhubio/prometheus@fake2.0.0",
-						Properties: []property.Property{
-							{Type: property.TypePackage, Value: json.RawMessage(`{"packageName":"prometheus","version":"2.0.0"}`)},
-							{Type: property.TypeGVK, Value: json.RawMessage(`[]`)},
-						},
-					},
-					CatalogName: "fake-catalog",
-					InChannels:  []*catalogmetadata.Channel{&prometheusBetaChannel},
-				}
-
-				cl, reconciler := newClientAndReconciler(t, bundle)
-
 				// Run reconcile again
 				res, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
 				require.NoError(t, err)
@@ -952,7 +890,7 @@ func TestClusterExtensionDowngrade(t *testing.T) {
 				require.NoError(t, err)
 
 				// Checking the status fields
-				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "operatorhub/prometheus/beta/1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
+				assert.Equal(t, &ocv1alpha1.BundleMetadata{Name: "prometheus.v1.0.0", Version: "1.0.0"}, clusterExtension.Status.ResolvedBundle)
 
 				// checking the expected conditions
 				cond = apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
@@ -1422,19 +1360,19 @@ var (
 			Package: "prometheus",
 			Entries: []declcfg.ChannelEntry{
 				{
-					Name: "operatorhub/prometheus/beta/1.0.0",
+					Name: "prometheus.v1.0.0",
 				},
 				{
-					Name:     "operatorhub/prometheus/beta/1.0.1",
-					Replaces: "operatorhub/prometheus/beta/1.0.0",
+					Name:     "prometheus.v1.0.1",
+					Replaces: "prometheus.v1.0.0",
 				},
 				{
-					Name:     "operatorhub/prometheus/beta/1.2.0",
-					Replaces: "operatorhub/prometheus/beta/1.0.1",
+					Name:     "prometheus.v1.2.0",
+					Replaces: "prometheus.v1.0.1",
 				},
 				{
-					Name:     "operatorhub/prometheus/beta/2.0.0",
-					Replaces: "operatorhub/prometheus/beta/1.2.0",
+					Name:     "prometheus.v2.0.0",
+					Replaces: "prometheus.v1.2.0",
 				},
 			},
 		},
@@ -1444,7 +1382,7 @@ var (
 var testBundleList = []*catalogmetadata.Bundle{
 	{
 		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/alpha/0.37.0",
+			Name:    "prometheus.v0.37.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@sha256:3e281e587de3d03011440685fc4fb782672beab044c1ebadc42788ce05a21c35",
 			Properties: []property.Property{
@@ -1457,7 +1395,7 @@ var testBundleList = []*catalogmetadata.Bundle{
 	},
 	{
 		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/beta/1.0.0",
+			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
 			Properties: []property.Property{
@@ -1470,7 +1408,7 @@ var testBundleList = []*catalogmetadata.Bundle{
 	},
 	{
 		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/beta/1.0.1",
+			Name:    "prometheus.v1.0.1",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.1",
 			Properties: []property.Property{
@@ -1483,7 +1421,7 @@ var testBundleList = []*catalogmetadata.Bundle{
 	},
 	{
 		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/beta/1.2.0",
+			Name:    "prometheus.v1.2.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.2.0",
 			Properties: []property.Property{
@@ -1496,7 +1434,7 @@ var testBundleList = []*catalogmetadata.Bundle{
 	},
 	{
 		Bundle: declcfg.Bundle{
-			Name:    "operatorhub/prometheus/beta/2.0.0",
+			Name:    "prometheus.v2.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake2.0.0",
 			Properties: []property.Property{

--- a/internal/controllers/clusterextension_registryv1_validation_test.go
+++ b/internal/controllers/clusterextension_registryv1_validation_test.go
@@ -109,7 +109,6 @@ func TestClusterExtensionRegistryV1DisallowDependencies(t *testing.T) {
 			}, nil)
 			// Create and configure the mock InstalledBundleGetter
 			mockInstalledBundleGetter := &MockInstalledBundleGetter{}
-			mockInstalledBundleGetter.SetBundle(tt.bundle)
 
 			reconciler := &controllers.ClusterExtensionReconciler{
 				Client:                cl,

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/operator-framework/rukpak/pkg/storage"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
-	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	"github.com/operator-framework/operator-controller/internal/controllers"
 	"github.com/operator-framework/operator-controller/pkg/scheme"
 	testutil "github.com/operator-framework/operator-controller/test/util"
@@ -97,18 +96,18 @@ func newClient(t *testing.T) client.Client {
 }
 
 type MockInstalledBundleGetter struct {
-	bundle *catalogmetadata.Bundle
+	bundle *ocv1alpha1.BundleMetadata
 }
 
-func (m *MockInstalledBundleGetter) SetBundle(bundle *catalogmetadata.Bundle) {
+func (m *MockInstalledBundleGetter) SetBundle(bundle *ocv1alpha1.BundleMetadata) {
 	m.bundle = bundle
 }
 
-func (m *MockInstalledBundleGetter) GetInstalledBundle(ctx context.Context, acg helmclient.ActionClientGetter, allBundles []*catalogmetadata.Bundle, ext *ocv1alpha1.ClusterExtension) (*catalogmetadata.Bundle, error) {
+func (m *MockInstalledBundleGetter) GetInstalledBundle(ctx context.Context, ext *ocv1alpha1.ClusterExtension) (*ocv1alpha1.BundleMetadata, error) {
 	return m.bundle, nil
 }
 
-func newClientAndReconciler(t *testing.T, bundle *catalogmetadata.Bundle) (client.Client, *controllers.ClusterExtensionReconciler) {
+func newClientAndReconciler(t *testing.T, bundle *ocv1alpha1.BundleMetadata) (client.Client, *controllers.ClusterExtensionReconciler) {
 	cl := newClient(t)
 	fakeCatalogClient := testutil.NewFakeCatalogClient(testBundleList)
 


### PR DESCRIPTION
The installed bundle provider, which is necessary for safely handling package upgrades, was too strict. It required the currently installed bundle to exist in the catalog in order to "find" the installed bundle.

This is problematic in several  situations:
- If a user receives a catalog update that no longer contains their installed bundle (perhaps its was removed from the catalog for security or policy reasons)
- If a user is trying to transition to a different catalog that provides that package
- If a bundle was directly installed, and the user is trying to have a catalog-backed ClusterExtension adopt it.

This change simply returns the name and version of the installed bundle, and makes some minor changes in the successors functions to handle the simplified installed bundle metadata.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
