### PR TITLE
:bug: Revert "Move the e2e into the operator-controler-system ns"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ e2e: #EXHELP Run the e2e tests.
 	go test -v ./test/e2e/...
 
 E2E_REGISTRY_NAME := docker-registry
-E2E_REGISTRY_NAMESPACE := operator-controller-system
+E2E_REGISTRY_NAMESPACE := operator-controller-e2e
 
 export REG_PKG_NAME := registry-operator
 export REGISTRY_ROOT := $(E2E_REGISTRY_NAME).$(E2E_REGISTRY_NAMESPACE).svc:5000

--- a/testdata/catalogs/test-catalog/catalog.yaml
+++ b/testdata/catalogs/test-catalog/catalog.yaml
@@ -24,7 +24,7 @@ entries:
 schema: olm.bundle
 name: prometheus-operator.1.0.0
 package: prometheus
-image: docker-registry.operator-controller-system.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.0.0
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.0.0
 properties:
   - type: olm.package
     value:
@@ -34,7 +34,7 @@ properties:
 schema: olm.bundle
 name: prometheus-operator.1.0.1
 package: prometheus
-image: docker-registry.operator-controller-system.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.0.1
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.0.1
 properties:
   - type: olm.package
     value:
@@ -44,7 +44,7 @@ properties:
 schema: olm.bundle
 name: prometheus-operator.1.2.0
 package: prometheus
-image: docker-registry.operator-controller-system.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.2.0
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.2.0
 properties:
   - type: olm.package
     value:
@@ -54,7 +54,7 @@ properties:
 schema: olm.bundle
 name: prometheus-operator.2.0.0
 package: prometheus
-image: docker-registry.operator-controller-system.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v2.0.0
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v2.0.0
 properties:
   - type: olm.package
     value:
@@ -74,7 +74,7 @@ entries:
 schema: olm.bundle
 name: package-with-webhooks.1.0.0
 package: package-with-webhooks
-image: docker-registry.operator-controller-system.svc.cluster.local:5000/bundles/registry-v1/package-with-webhooks:v1.0.0
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/package-with-webhooks:v1.0.0
 properties:
   - type: olm.package
     value:


### PR DESCRIPTION
This ends up overwriting the security policy of the operator-controller-system namespace, which really isn't something we want to do in a valid e2e test.

Many of the e2e components need to run as root in order to do the things they need to do.

This reverts commit aa48e704bbbc4ae808fff5e3d762f95df3a0982a.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
