### PR TITLE
:seedling: Rename Catalog objects to ClusterCatalog

### DIFF
--- a/config/samples/catalogd_operatorcatalog.yaml
+++ b/config/samples/catalogd_operatorcatalog.yaml
@@ -1,5 +1,5 @@
 apiVersion: catalogd.operatorframework.io/v1alpha1
-kind: Catalog
+kind: ClusterCatalog
 metadata:
   name: operatorhubio
 spec:

--- a/docs/Tasks/adding-a-catalog.md
+++ b/docs/Tasks/adding-a-catalog.md
@@ -113,7 +113,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
             Reason:                UnpackSuccessful
             Status:                True
             Type:                  Unpacked
-          Content URL:             http://catalogd-catalogserver.catalogd-system.svc/catalogs/operatorhubio/all.json
+          Content URL:             http://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
           Observed Generation:     2
           Phase:                   Unpacked
           Resolved Source:

--- a/docs/Tasks/adding-a-catalog.md
+++ b/docs/Tasks/adding-a-catalog.md
@@ -22,7 +22,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
 
     ``` yaml title="catalog_cr.yaml"
     apiVersion: catalogd.operatorframework.io/v1alpha1
-    kind: Catalog
+    kind: ClusterCatalog
     metadata:
       name: operatorhubio
     spec:
@@ -44,7 +44,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
 
     ``` yaml title="Example `operatorhubio.yaml` CR"
     apiVersion: catalogd.operatorframework.io/v1alpha1
-    kind: Catalog
+    kind: ClusterCatalog
     metadata:
       name: operatorhub
     spec:

--- a/docs/Tasks/explore-available-packages.md
+++ b/docs/Tasks/explore-available-packages.md
@@ -11,7 +11,7 @@ Then you can query the catalog by using `curl` commands and the `jq` CLI tool to
 1. Port forward the catalog server service:
 
     ``` terminal
-    $ kubectl -n catalogd-system port-forward svc/catalogd-catalogserver 8080:80
+    $ kubectl -n olmv1-system port-forward svc/catalogd-catalogserver 8080:80
     ```
 
 2. Return a list of all the extensions in a catalog:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/operator-framework/api v0.25.0
-	github.com/operator-framework/catalogd v0.12.0
+	github.com/operator-framework/catalogd v0.14.0
 	github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9
 	github.com/operator-framework/operator-registry v1.43.1
 	github.com/operator-framework/rukpak v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,6 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/operator-framework/api v0.25.0 h1:pSQwFSoPmZaTIERadawxtCwicehLkC7i9n3w3+70SVI=
 github.com/operator-framework/api v0.25.0/go.mod h1:PvyCQb0x53ytIqdTECH5e+iqv+am3uZ0qGsZWmL35gQ=
-github.com/operator-framework/catalogd v0.12.0 h1:Cww+CyowkfTFugB9ZjUDpKvumh2vPe/TjCUpMHDmVBM=
-github.com/operator-framework/catalogd v0.12.0/go.mod h1:4lryGtBTVOdqlKR0MaVYnlsSOc7HiagVRVo3J4uIo7E=
 github.com/operator-framework/catalogd v0.14.0 h1:M/kDqhH1hBB9amUk7/dAV4WZuJIa5ARboeY6GMjhx0E=
 github.com/operator-framework/catalogd v0.14.0/go.mod h1:84M4gm0JPrwOLVbEOoCns/xjlg4ljenVMPYUO/Cs+Wc=
 github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9 h1:f7/TMBpuIZEQ3JbD9UyP1L1ZCSLLWdR2aPN+A+dOHFY=

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,8 @@ github.com/operator-framework/api v0.25.0 h1:pSQwFSoPmZaTIERadawxtCwicehLkC7i9n3
 github.com/operator-framework/api v0.25.0/go.mod h1:PvyCQb0x53ytIqdTECH5e+iqv+am3uZ0qGsZWmL35gQ=
 github.com/operator-framework/catalogd v0.12.0 h1:Cww+CyowkfTFugB9ZjUDpKvumh2vPe/TjCUpMHDmVBM=
 github.com/operator-framework/catalogd v0.12.0/go.mod h1:4lryGtBTVOdqlKR0MaVYnlsSOc7HiagVRVo3J4uIo7E=
+github.com/operator-framework/catalogd v0.14.0 h1:M/kDqhH1hBB9amUk7/dAV4WZuJIa5ARboeY6GMjhx0E=
+github.com/operator-framework/catalogd v0.14.0/go.mod h1:84M4gm0JPrwOLVbEOoCns/xjlg4ljenVMPYUO/Cs+Wc=
 github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9 h1:f7/TMBpuIZEQ3JbD9UyP1L1ZCSLLWdR2aPN+A+dOHFY=
 github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9/go.mod h1:ly6Bd9rSzmt37Wy6WtZHmA+IY9zG958MryJFLcVpCXw=
 github.com/operator-framework/operator-lib v0.14.0 h1:er+BgZymZD1im2wytLJiPLZpGALAX6N0gXaHx3PKbO4=

--- a/internal/catalogmetadata/cache/cache.go
+++ b/internal/catalogmetadata/cache/cache.go
@@ -66,7 +66,7 @@ type filesystemCache struct {
 // resources that have been successfully reconciled, unpacked, and are being served.
 // These requirements help ensure that we can rely on status conditions to determine
 // when to issue a request to update the cached Catalog contents.
-func (fsc *filesystemCache) FetchCatalogContents(ctx context.Context, catalog *catalogd.Catalog) (io.ReadCloser, error) {
+func (fsc *filesystemCache) FetchCatalogContents(ctx context.Context, catalog *catalogd.ClusterCatalog) (io.ReadCloser, error) {
 	if catalog == nil {
 		return nil, fmt.Errorf("error: provided catalog must be non-nil")
 	}

--- a/internal/catalogmetadata/cache/cache_test.go
+++ b/internal/catalogmetadata/cache/cache_test.go
@@ -54,7 +54,7 @@ func TestCache(t *testing.T) {
 	t.Run("FetchCatalogContents", func(t *testing.T) {
 		type test struct {
 			name           string
-			catalog        *catalogd.Catalog
+			catalog        *catalogd.ClusterCatalog
 			contents       []byte
 			wantErr        bool
 			tripper        *MockTripper
@@ -64,11 +64,11 @@ func TestCache(t *testing.T) {
 		for _, tt := range []test{
 			{
 				name: "valid non-cached fetch",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
@@ -82,11 +82,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "valid cached fetch",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
@@ -102,11 +102,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "cached update fetch with changes",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
@@ -122,11 +122,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "fetch error",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
@@ -141,11 +141,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "fetch internal server error response",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Type: catalogd.SourceTypeImage,
 							Image: &catalogd.ResolvedImageSource{
@@ -167,11 +167,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "nil catalog.status.resolvedSource",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: nil,
 					},
 				},
@@ -181,11 +181,11 @@ func TestCache(t *testing.T) {
 			},
 			{
 				name: "nil catalog.status.resolvedSource.image",
-				catalog: &catalogd.Catalog{
+				catalog: &catalogd.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-catalog",
 					},
-					Status: catalogd.CatalogStatus{
+					Status: catalogd.ClusterCatalogStatus{
 						ResolvedSource: &catalogd.ResolvedCatalogSource{
 							Image: nil,
 						},

--- a/internal/catalogmetadata/client/client.go
+++ b/internal/catalogmetadata/client/client.go
@@ -23,7 +23,7 @@ type Fetcher interface {
 	// server for the catalog provided. It returns an io.ReadCloser
 	// containing the FBC contents that the caller is expected to close.
 	// returns an error if any occur.
-	FetchCatalogContents(ctx context.Context, catalog *catalogd.Catalog) (io.ReadCloser, error)
+	FetchCatalogContents(ctx context.Context, catalog *catalogd.ClusterCatalog) (io.ReadCloser, error)
 }
 
 func New(cl client.Client, fetcher Fetcher) *Client {
@@ -46,7 +46,7 @@ type Client struct {
 func (c *Client) Bundles(ctx context.Context) ([]*catalogmetadata.Bundle, error) {
 	var allBundles []*catalogmetadata.Bundle
 
-	var catalogList catalogd.CatalogList
+	var catalogList catalogd.ClusterCatalogList
 	if err := c.cl.List(ctx, &catalogList); err != nil {
 		return nil, err
 	}

--- a/internal/catalogmetadata/client/client_test.go
+++ b/internal/catalogmetadata/client/client_test.go
@@ -105,7 +105,7 @@ func TestClient(t *testing.T) {
 				name: "skip catalog missing Unpacked status condition",
 				fakeCatalog: func() ([]client.Object, []*catalogmetadata.Bundle, map[string][]byte) {
 					objs, bundles, catalogContentMap := defaultFakeCatalog()
-					objs = append(objs, &catalogd.Catalog{
+					objs = append(objs, &catalogd.ClusterCatalog{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "foobar",
 						},
@@ -220,11 +220,11 @@ func defaultFakeCatalog() ([]client.Object, []*catalogmetadata.Bundle, map[strin
 	}`
 
 	objs := []client.Object{
-		&catalogd.Catalog{
+		&catalogd.ClusterCatalog{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "catalog-1",
 			},
-			Status: catalogd.CatalogStatus{
+			Status: catalogd.ClusterCatalogStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:   catalogd.TypeUnpacked,
@@ -234,11 +234,11 @@ func defaultFakeCatalog() ([]client.Object, []*catalogmetadata.Bundle, map[strin
 				},
 			},
 		},
-		&catalogd.Catalog{
+		&catalogd.ClusterCatalog{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "catalog-2",
 			},
-			Status: catalogd.CatalogStatus{
+			Status: catalogd.ClusterCatalogStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:   catalogd.TypeUnpacked,
@@ -338,7 +338,7 @@ type MockFetcher struct {
 	shouldError bool
 }
 
-func (mc *MockFetcher) FetchCatalogContents(_ context.Context, catalog *catalogd.Catalog) (io.ReadCloser, error) {
+func (mc *MockFetcher) FetchCatalogContents(_ context.Context, catalog *catalogd.ClusterCatalog) (io.ReadCloser, error) {
 	if mc.shouldError {
 		return nil, errors.New("mock cache error")
 	}

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -555,12 +555,12 @@ func isInsecureSkipTLSVerifySet(ce *ocv1alpha1.ClusterExtension) bool {
 func (r *ClusterExtensionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controller, err := ctrl.NewControllerManagedBy(mgr).
 		For(&ocv1alpha1.ClusterExtension{}).
-		Watches(&catalogd.Catalog{},
+		Watches(&catalogd.ClusterCatalog{},
 			crhandler.EnqueueRequestsFromMapFunc(clusterExtensionRequestsForCatalog(mgr.GetClient(), mgr.GetLogger()))).
 		WithEventFilter(predicate.Funcs{
 			UpdateFunc: func(ue event.UpdateEvent) bool {
-				oldObject, isOldCatalog := ue.ObjectOld.(*catalogd.Catalog)
-				newObject, isNewCatalog := ue.ObjectNew.(*catalogd.Catalog)
+				oldObject, isOldCatalog := ue.ObjectOld.(*catalogd.ClusterCatalog)
+				newObject, isNewCatalog := ue.ObjectNew.(*catalogd.ClusterCatalog)
 
 				if !isOldCatalog || !isNewCatalog {
 					return true

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -36,7 +36,7 @@ kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
-kubectl_wait "catalogd-system" "deployment/catalogd-controller-manager" "60s"
+kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 
 kubectl apply -f "${operator_controller_manifest}"
 kubectl_wait "operator-controller-system" "deployment/operator-controller-controller-manager" "60s"

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -36,7 +36,7 @@ const (
 var pollDuration = time.Minute
 var pollInterval = time.Second
 
-func testInit(t *testing.T) (*ocv1alpha1.ClusterExtension, *catalogd.Catalog) {
+func testInit(t *testing.T) (*ocv1alpha1.ClusterExtension, *catalogd.ClusterCatalog) {
 	var err error
 	extensionCatalog, err := createTestCatalog(context.Background(), testCatalogName, os.Getenv(testCatalogRefEnvVar))
 	require.NoError(t, err)
@@ -53,10 +53,10 @@ func testInit(t *testing.T) (*ocv1alpha1.ClusterExtension, *catalogd.Catalog) {
 	return clusterExtension, extensionCatalog
 }
 
-func testCleanup(t *testing.T, cat *catalogd.Catalog, clusterExtension *ocv1alpha1.ClusterExtension) {
+func testCleanup(t *testing.T, cat *catalogd.ClusterCatalog, clusterExtension *ocv1alpha1.ClusterExtension) {
 	require.NoError(t, c.Delete(context.Background(), cat))
 	require.Eventually(t, func() bool {
-		err := c.Get(context.Background(), types.NamespacedName{Name: cat.Name}, &catalogd.Catalog{})
+		err := c.Get(context.Background(), types.NamespacedName{Name: cat.Name}, &catalogd.ClusterCatalog{})
 		return errors.IsNotFound(err)
 	}, pollDuration, pollInterval)
 	require.NoError(t, c.Delete(context.Background(), clusterExtension))
@@ -139,7 +139,7 @@ func TestClusterExtensionInstallReResolvesWhenNewCatalog(t *testing.T) {
 	t.Log("By deleting the catalog first")
 	require.NoError(t, c.Delete(context.Background(), extensionCatalog))
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		err := c.Get(context.Background(), types.NamespacedName{Name: extensionCatalog.Name}, &catalogd.Catalog{})
+		err := c.Get(context.Background(), types.NamespacedName{Name: extensionCatalog.Name}, &catalogd.ClusterCatalog{})
 		assert.True(ct, errors.IsNotFound(err))
 	}, pollDuration, pollInterval)
 
@@ -368,7 +368,7 @@ func getArtifactsOutput(t *testing.T) {
 	}
 
 	// get all catalogsources save them to the artifact path.
-	catalogsources := catalogd.CatalogList{}
+	catalogsources := catalogd.ClusterCatalogList{}
 	if err := c.List(context.Background(), &catalogsources, client.InNamespace("")); err != nil {
 		fmt.Printf("Failed to list catalogsources: %v", err)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,12 +39,12 @@ func TestMain(m *testing.M) {
 // createTestCatalog will create a new catalog on the test cluster, provided
 // the context, catalog name, and the image reference. It returns the created catalog
 // or an error if any errors occurred while creating the catalog.
-func createTestCatalog(ctx context.Context, name string, imageRef string) (*catalogd.Catalog, error) {
-	catalog := &catalogd.Catalog{
+func createTestCatalog(ctx context.Context, name string, imageRef string) (*catalogd.ClusterCatalog, error) {
+	catalog := &catalogd.ClusterCatalog{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: catalogd.CatalogSpec{
+		Spec: catalogd.ClusterCatalogSpec{
 			Source: catalogd.CatalogSource{
 				Type: catalogd.SourceTypeImage,
 				Image: &catalogd.ImageSource{

--- a/test/extension-developer-e2e/extension_developer_test.go
+++ b/test/extension-developer-e2e/extension_developer_test.go
@@ -50,11 +50,11 @@ func TestExtensionDeveloper(t *testing.T) {
 		clusterExtension := ce
 		t.Run(clusterExtension.ObjectMeta.Name, func(t *testing.T) {
 			t.Parallel()
-			catalog := &catalogd.Catalog{
+			catalog := &catalogd.ClusterCatalog{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "catalog",
 				},
-				Spec: catalogd.CatalogSpec{
+				Spec: catalogd.ClusterCatalogSpec{
 					Source: catalogd.CatalogSource{
 						Type: catalogd.SourceTypeImage,
 						Image: &catalogd.ImageSource{


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:spar    * ✨ (:sparkles:, minor/compatible change)
kles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This pull request pulls request renames the `Catalog` object to `ClusterCatalog` in conformance to changes performed in https://github.com/operator-framework/catalogd/pull/268

Changes:
- Bump `github.com/operator-framework/catalogd` package from v0.12.0 to v0.14.0
- Rename references to `Catalog` to `ClusterCatalog`
- Update references to `catalogd-system` namespace to `olmv1-namespace` https://github.com/operator-framework/catalogd/pull/283
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
