### PR TITLE
🌱 Remove kind config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CONTAINER_RUNTIME := docker
 else ifneq (, $(shell command -v podman 2>/dev/null))
 CONTAINER_RUNTIME := podman
 else
-$(warning Could not find docker or podman in path! This may result in targets requiring a container runtime failing!) 
+$(warning Could not find docker or podman in path! This may result in targets requiring a container runtime failing!)
 endif
 
 KUSTOMIZE_BUILD_DIR := config/overlays/tls
@@ -180,8 +180,7 @@ kind-redeploy: generate docker-build kind-load kind-deploy #EXHELP Redeploy newl
 .PHONY: kind-cluster
 kind-cluster: $(KIND) #EXHELP Standup a kind cluster.
 	-$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
-	# kind-config.yaml can be deleted after upgrading to Kubernetes 1.30
-	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image $(KIND_CLUSTER_IMAGE) --config ./kind-config.yaml
+	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image $(KIND_CLUSTER_IMAGE)
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-clean

--- a/dev/podman/kind-with-registry-podman.sh
+++ b/dev/podman/kind-with-registry-podman.sh
@@ -22,10 +22,6 @@ fi
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  "ValidatingAdmissionPolicy": true
-runtimeConfig:
-  "admissionregistration.k8s.io/v1beta1": true
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,8 +1,0 @@
-# Can be deleted after upgrading to Kubernetes 1.30
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  ValidatingAdmissionPolicy: true
-runtimeConfig:
-  admissionregistration.k8s.io/v1beta1: true
-


### PR DESCRIPTION
# Description

We no longer need to enable `ValidatingAdmissionPolicy` since it is enabled by default in K8s 1.30.
This means we can delete `kind-config.yaml`.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
