### PR TITLE
🌱 Fix codecov-action params

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          disable_search: true
           files: e2e-cover.out
           flags: e2e
-          functionalities: fixes
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: codecov/codecov-action@v4
       with:
+        disable_search: true
         files: cover.out
         flags: unit
-        functionalities: fixes
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Description

* `functionalities` param is no longer exist. It was used to enable file fixes to ignore common lines from coverage. This feature is now seems to be on by default.
* Adding `disable_search` because we do not need for the codecov action to search for coverage files: we explicitly provide files.

This solves:
* Gets rid of "Warning: Unexpected input(s) 'functionalities'" warning.
* Excludes yaml files from coverage report uploaded to codecov.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
