### PR TITLE
🐛 fix: reduce unnecessary caching and remove predicate from dynamic watches

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 	registryv1handler "github.com/operator-framework/rukpak/pkg/handler"
 	"github.com/operator-framework/rukpak/pkg/provisioner/registry"
@@ -127,12 +128,13 @@ func main() {
 		LeaderElectionID:       "9c4404e7.operatorframework.io",
 		Cache: crcache.Options{
 			ByObject: map[client.Object]crcache.ByObject{
-				&ocv1alpha1.ClusterExtension{}: {},
+				&ocv1alpha1.ClusterExtension{}: {Label: k8slabels.Everything()},
+				&catalogd.ClusterCatalog{}:     {Label: k8slabels.Everything()},
 			},
 			DefaultNamespaces: map[string]crcache.Config{
-				systemNamespace:       {},
-				crcache.AllNamespaces: {LabelSelector: dependentSelector},
+				systemNamespace: {LabelSelector: k8slabels.Everything()},
 			},
+			DefaultLabelSelector: dependentSelector,
 		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the


### PR DESCRIPTION
Our cache configuration resulted in watching all cluster-scoped resources for each cluster-scoped resource that shows up in a ClusterExtension. Now, we only watch:
- All ClusterExtensions
- All ClusterCatalogs
- All objects in the systemNamespace
- All other objects that specifically match the dependentPredicate

This commit also removes the dependent predicate so that we reconcile for any change to managed resources. This is important to ensure that future features (like health checking) can account for any change to managed operator objects.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
