### PR TITLE
🐛 fix: remove unnecessary bundle cache volume

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -196,8 +196,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	localStorageRoot := filepath.Join(cachePath, "bundles")
+	if err := os.MkdirAll(localStorageRoot, 0755); err != nil {
+		setupLog.Error(err, "unable to create local storage root directory", "root", localStorageRoot)
+		os.Exit(1)
+	}
 	localStorage := &storage.LocalDirectory{
-		RootDirectory: filepath.Join(cachePath, "bundles"),
+		RootDirectory: localStorageRoot,
 		URL:           url.URL{},
 	}
 	if err := clusterExtensionFinalizers.Register(deleteCachedBundleKey, finalizerFunc(func(ctx context.Context, obj client.Object) (crfinalizer.Result, error) {

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -61,8 +61,6 @@ spec:
         volumeMounts:
           - name: cache
             mountPath: /var/cache
-          - name: bundle-cache
-            mountPath: /var/cache/bundles
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -112,6 +110,4 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cache
-          emptyDir: {}
-        - name: bundle-cache
           emptyDir: {}


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

When I removed the flag that controlled the bundle cache root directory in #941, I missed the fact that we also had a volumeMount for it, which is a child of our broader `/var/cache` volume emptyDir volume.

This commit eliminates the unnecessary extra volume and instead just creates the `/var/cache/bundles` directory in the existing volume.

This is important to eliminate the potential for issues when attempting to rename files across filesystem boundaries using `os.Rename` (e.g. if we ever needed to do something like  rename `/var/cache/tmp/foobar.txt` to `/var/cache/bundles/foobar.txt`)

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
