### PR TITLE
🐛 incremental improvement in catalogmetadata cache/client performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-ext-dev-e2e: $(OPERATOR_SDK) $(KUSTOMIZE) $(KIND) #HELP Run extension creat
 ENVTEST_VERSION := $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.x/')
 UNIT_TEST_DIRS := $(shell go list ./... | grep -v /test/)
 test-unit: $(SETUP_ENVTEST) #HELP Run the unit tests
-	eval $$($(SETUP_ENVTEST) use -p env $(ENVTEST_VERSION) $(SETUP_ENVTEST_BIN_DIR_OVERRIDE)) && go test -count=1 -short $(UNIT_TEST_DIRS) -coverprofile cover.out
+	eval $$($(SETUP_ENVTEST) use -p env $(ENVTEST_VERSION) $(SETUP_ENVTEST_BIN_DIR_OVERRIDE)) && CGO_ENABLED=1 go test -count=1 -race -short $(UNIT_TEST_DIRS) -coverprofile cover.out
 
 image-registry: ## Setup in-cluster image registry
 	./test/tools/image-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME)

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -378,14 +378,14 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1alp
 
 // resolve returns a Bundle from the catalog that needs to get installed on the cluster.
 func (r *ClusterExtensionReconciler) resolve(ctx context.Context, ext ocv1alpha1.ClusterExtension) (*catalogmetadata.Bundle, error) {
-	allBundles, err := r.BundleProvider.Bundles(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching bundles: %w", err)
-	}
-
 	packageName := ext.Spec.PackageName
 	channelName := ext.Spec.Channel
 	versionRange := ext.Spec.Version
+
+	allBundles, err := r.BundleProvider.Bundles(ctx, packageName)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching bundles: %w", err)
+	}
 
 	installedBundle, err := r.InstalledBundleGetter.GetInstalledBundle(ctx, &ext)
 	if err != nil {

--- a/internal/controllers/clusterextension_controller_test.go
+++ b/internal/controllers/clusterextension_controller_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	"github.com/operator-framework/operator-controller/internal/conditionsets"
 	"github.com/operator-framework/operator-controller/internal/controllers"
+	"github.com/operator-framework/operator-controller/internal/testutil"
 	"github.com/operator-framework/operator-controller/pkg/features"
-	testutil "github.com/operator-framework/operator-controller/test/util"
 )
 
 // Describe: ClusterExtension Controller Test

--- a/internal/controllers/clusterextension_registryv1_validation_test.go
+++ b/internal/controllers/clusterextension_registryv1_validation_test.go
@@ -23,7 +23,7 @@ import (
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata"
 	"github.com/operator-framework/operator-controller/internal/controllers"
-	testutil "github.com/operator-framework/operator-controller/test/util"
+	"github.com/operator-framework/operator-controller/internal/testutil"
 )
 
 func TestClusterExtensionRegistryV1DisallowDependencies(t *testing.T) {

--- a/internal/controllers/common_controller.go
+++ b/internal/controllers/common_controller.go
@@ -29,7 +29,7 @@ import (
 // BundleProvider provides the way to retrieve a list of Bundles from a source,
 // generally from a catalog client of some kind.
 type BundleProvider interface {
-	Bundles(ctx context.Context) ([]*catalogmetadata.Bundle, error)
+	Bundles(ctx context.Context, packageName string) ([]*catalogmetadata.Bundle, error)
 }
 
 // setResolvedStatusConditionSuccess sets the resolved status condition to success.

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -41,8 +41,8 @@ import (
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/controllers"
+	"github.com/operator-framework/operator-controller/internal/testutil"
 	"github.com/operator-framework/operator-controller/pkg/scheme"
-	testutil "github.com/operator-framework/operator-controller/test/util"
 )
 
 // MockUnpacker is a mock of Unpacker interface

--- a/internal/testutil/fake_catalog_client.go
+++ b/internal/testutil/fake_catalog_client.go
@@ -23,9 +23,16 @@ func NewFakeCatalogClientWithError(e error) FakeCatalogClient {
 	}
 }
 
-func (c *FakeCatalogClient) Bundles(_ context.Context) ([]*catalogmetadata.Bundle, error) {
+func (c *FakeCatalogClient) Bundles(_ context.Context, packageName string) ([]*catalogmetadata.Bundle, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
-	return c.bundles, nil
+
+	var out []*catalogmetadata.Bundle
+	for _, b := range c.bundles {
+		if b.Package == packageName {
+			out = append(out, b)
+		}
+	}
+	return out, nil
 }


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This partially resolves #914 by doing two things:
1. Exploding the `all.json` response into separate directories organized by package
2. Updating the BundleProvider to require a package name to be provided in the request, which results in a much smaller set of FBC that needs to be re-parsed into catalogmetadata objects on each reconcile.

This is still not completely resolved though because step (1) still happens synchronously during the reconciliation of a ClusterExtension. In order to finish the improvement (and to complete #948), we need to implement a controller that watches and reconciles ClusterCatalog changes so that it can create (and delete) caches for operator-controller. 

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
