### PR TITLE
:bug:  Fixing the labels for better  metrics collection

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
   name: system
@@ -15,18 +14,18 @@ metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
   labels:
-    control-plane: controller-manager
+    control-plane: operator-controller-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: operator-controller-controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: operator-controller-controller-manager
     spec:
       affinity:
         nodeAffinity:
@@ -106,7 +105,7 @@ spec:
             cpu: 5m
             memory: 64Mi
         terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccountName: controller-manager
+      serviceAccountName: operator-controller-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cache

--- a/config/base/prometheus/monitor.yaml
+++ b/config/base/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: operator-controller-controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: operator-controller-controller-manager

--- a/config/base/rbac/auth_proxy_service.yaml
+++ b/config/base/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: operator-controller-controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: operator-controller-controller-manager

--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -27,7 +27,7 @@ func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
 	t.Log("Starting checks after OLM upgrade")
 	ctx := context.Background()
 
-	managerLabelSelector := labels.Set{"control-plane": "controller-manager"}
+	managerLabelSelector := labels.Set{"control-plane": "operator-controller-controller-manager"}
 
 	t.Log("Checking that the controller-manager deployment is updated")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {


### PR DESCRIPTION
As the label selector used for both catalogd and operator-controller metrics services is "control-plane: controller-manager". Hence changing the labels in both operator-controller and catalogd to make sure we do not overlap.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
