### PR TITLE
⚠️ Remove `HasValidBundle` condition

### DIFF
--- a/api/v1alpha1/clusterextension_types.go
+++ b/api/v1alpha1/clusterextension_types.go
@@ -101,9 +101,8 @@ type CRDUpgradeSafetyPreflightConfig struct {
 
 const (
 	// TODO(user): add more Types, here and into init()
-	TypeInstalled      = "Installed"
-	TypeResolved       = "Resolved"
-	TypeHasValidBundle = "HasValidBundle"
+	TypeInstalled = "Installed"
+	TypeResolved  = "Resolved"
 
 	// TypeDeprecated is a rollup condition that is present when
 	// any of the deprecated conditions are present.
@@ -121,10 +120,9 @@ const (
 	ReasonInstallationSucceeded     = "InstallationSucceeded"
 	ReasonResolutionFailed          = "ResolutionFailed"
 
-	ReasonSuccess               = "Success"
-	ReasonDeprecated            = "Deprecated"
-	ReasonUpgradeFailed         = "UpgradeFailed"
-	ReasonHasValidBundleUnknown = "HasValidBundleUnknown"
+	ReasonSuccess       = "Success"
+	ReasonDeprecated    = "Deprecated"
+	ReasonUpgradeFailed = "UpgradeFailed"
 
 	ReasonUnpackPending = "UnpackPending"
 	ReasonUnpackSuccess = "UnpackSuccess"
@@ -139,7 +137,6 @@ func init() {
 	conditionsets.ConditionTypes = append(conditionsets.ConditionTypes,
 		TypeInstalled,
 		TypeResolved,
-		TypeHasValidBundle,
 		TypeDeprecated,
 		TypePackageDeprecated,
 		TypeChannelDeprecated,
@@ -157,7 +154,6 @@ func init() {
 		ReasonBundleLoadFailed,
 		ReasonErrorGettingClient,
 		ReasonInstallationStatusUnknown,
-		ReasonHasValidBundleUnknown,
 		ReasonUnpackPending,
 		ReasonUnpackSuccess,
 		ReasonUnpackFailed,

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -274,7 +274,6 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1alp
 	switch unpackResult.State {
 	case rukpaksource.StatePending:
 		setStatusUnpackPending(ext, unpackResult.Message)
-		setHasValidBundleUnknown(ext, "unpack pending")
 		setInstalledStatusConditionUnknown(ext, "installation has not been attempted as unpack is pending")
 
 		return ctrl.Result{}, nil
@@ -294,7 +293,7 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1alp
 
 	bundleFS, err := r.Storage.Load(ctx, ext)
 	if err != nil {
-		setHasValidBundleFailed(ext, err.Error())
+		setInstalledStatusConditionFailed(ext, err.Error())
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controllers/common_controller.go
+++ b/internal/controllers/common_controller.go
@@ -54,28 +54,6 @@ func setInstalledStatusConditionUnknown(ext *ocv1alpha1.ClusterExtension, messag
 	})
 }
 
-// setHasValidBundleUnknown sets the valid bundle condition to unknown.
-func setHasValidBundleUnknown(ext *ocv1alpha1.ClusterExtension, message string) {
-	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
-		Type:               ocv1alpha1.TypeHasValidBundle,
-		Status:             metav1.ConditionUnknown,
-		Reason:             ocv1alpha1.ReasonHasValidBundleUnknown,
-		Message:            message,
-		ObservedGeneration: ext.GetGeneration(),
-	})
-}
-
-// setHasValidBundleFalse sets the ivalid bundle condition to false
-func setHasValidBundleFailed(ext *ocv1alpha1.ClusterExtension, message string) {
-	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
-		Type:               ocv1alpha1.TypeHasValidBundle,
-		Status:             metav1.ConditionFalse,
-		Reason:             ocv1alpha1.ReasonBundleLoadFailed,
-		Message:            message,
-		ObservedGeneration: ext.GetGeneration(),
-	})
-}
-
 // setResolvedStatusConditionFailed sets the resolved status condition to failed.
 func setResolvedStatusConditionFailed(ext *ocv1alpha1.ClusterExtension, message string) {
 	apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -27,6 +27,7 @@ import (
 	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
 )
 
 const (
@@ -82,7 +83,7 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 	t.Log("By eventually reporting a successful resolution and bundle path")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: clusterExtension.Name}, clusterExtension))
-		assert.Len(ct, clusterExtension.Status.Conditions, 8)
+		assert.Len(ct, clusterExtension.Status.Conditions, len(conditionsets.ConditionTypes))
 		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1alpha1.TypeResolved)
 		if !assert.NotNil(ct, cond) {
 			return


### PR DESCRIPTION
# Description

Closes #989 by removing the condition and solves an E2E flake.

Note: in [this brief](https://docs.google.com/document/d/1JWJxnDXM0X1JQ67ZIDx5j1ayb1d7ajrK_uSDDaz0G98/edit) were are revisiting `ClusterExtension` conditions and their reasons. [One of the points](https://docs.google.com/document/d/1JWJxnDXM0X1JQ67ZIDx5j1ayb1d7ajrK_uSDDaz0G98/edit#heading=h.l1ogecrfxz55) is about removal of `HasValidBundle` condition type.

The brief is still in review, but I would like to move forward with this change as it resolves a flake I hit regularly (especially locally).

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
