### PR TITLE
✨ bump helm-operator-plugins to v0.3.0; disable failure rollbacks

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -176,7 +176,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	acg, err := helmclient.NewActionClientGetter(cfgGetter)
+	acg, err := helmclient.NewActionClientGetter(cfgGetter,
+		helmclient.WithFailureRollbacks(false),
+	)
 	if err != nil {
 		setupLog.Error(err, "unable to create helm client")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/operator-framework/api v0.26.0
 	github.com/operator-framework/catalogd v0.17.0
-	github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9
+	github.com/operator-framework/helm-operator-plugins v0.3.0
 	github.com/operator-framework/operator-registry v1.44.0
 	github.com/operator-framework/rukpak v0.24.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/operator-framework/api v0.26.0 h1:YVntU2NkVl5zSLLwK5kFcH6P3oSvN9QDgTs
 github.com/operator-framework/api v0.26.0/go.mod h1:3IxOwzVUeGxYlzfwKCcfCyS+q3EEhWA/4kv7UehbeyM=
 github.com/operator-framework/catalogd v0.17.0 h1:Vsl32qKf2nKbAnKNfJ6eREOkirx5+oxpUuSwMxGS/dc=
 github.com/operator-framework/catalogd v0.17.0/go.mod h1:7zVv39zlmvJvRePtRzdMRqn8s/WRH4ALXMJCKNQMKmc=
-github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9 h1:f7/TMBpuIZEQ3JbD9UyP1L1ZCSLLWdR2aPN+A+dOHFY=
-github.com/operator-framework/helm-operator-plugins v0.2.2-0.20240520180534-f463c36fedf9/go.mod h1:ly6Bd9rSzmt37Wy6WtZHmA+IY9zG958MryJFLcVpCXw=
+github.com/operator-framework/helm-operator-plugins v0.3.0 h1:LNhcb5nPT/TAxZSsKH2LTYh79RgiN2twGFptQR96sRM=
+github.com/operator-framework/helm-operator-plugins v0.3.0/go.mod h1:ly6Bd9rSzmt37Wy6WtZHmA+IY9zG958MryJFLcVpCXw=
 github.com/operator-framework/operator-lib v0.14.0 h1:er+BgZymZD1im2wytLJiPLZpGALAX6N0gXaHx3PKbO4=
 github.com/operator-framework/operator-lib v0.14.0/go.mod h1:wUu4Xb9xzXnIpglvaZ3yucTMSlqGXHIoUEH9+5gWiu0=
 github.com/operator-framework/operator-registry v1.44.0 h1:NW5/xHYR77J2EUYm+6iBER1WNGLNS8gM+G5GBQWqTTs=


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This PR bumps to a new version of helm-operator-plugins, which brings a few new fixes, features, and changes. Notably:
- ActionClientGetter: allow disabling rollbacks after failures 

This PR also:
- makes use of the new ActionClientGetter knob so that operator-controller no longer rolls back a failed install or upgrade.
- sets a max version history of 10 to avoid unlimited piling up of release secrets
- uses helm's new server-side dry-run option, which provides cluster information to helm templates (e.g. when using the `lookup` template function).

For all changes, see https://github.com/operator-framework/helm-operator-plugins/releases/tag/v0.3.0

Closes #994 

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
