### PR TITLE
✨ expose a nodeport on kind cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ E2E_REGISTRY_NAMESPACE := operator-controller-e2e
 
 export REG_PKG_NAME := registry-operator
 export REGISTRY_ROOT := $(E2E_REGISTRY_NAME).$(E2E_REGISTRY_NAMESPACE).svc:5000
-export CATALOG_IMG := $(REGISTRY_ROOT)/test-catalog:e2e
+export CATALOG_IMG := $(REGISTRY_ROOT)/e2e/test-catalog:e2e
 .PHONY: test-ext-dev-e2e
 test-ext-dev-e2e: $(OPERATOR_SDK) $(KUSTOMIZE) $(KIND) #HELP Run extension create, upgrade and delete tests.
 	test/extension-developer-e2e/setup.sh $(OPERATOR_SDK) $(CONTAINER_RUNTIME) $(KUSTOMIZE) $(KIND) $(KIND_CLUSTER_NAME) $(E2E_REGISTRY_NAMESPACE)
@@ -181,7 +181,7 @@ kind-redeploy: generate docker-build kind-load kind-deploy #EXHELP Redeploy newl
 .PHONY: kind-cluster
 kind-cluster: $(KIND) #EXHELP Standup a kind cluster.
 	-$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
-	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image $(KIND_CLUSTER_IMAGE)
+	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image $(KIND_CLUSTER_IMAGE) --config ./kind-config.yaml
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-clean

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+    extraPortMappings:
+    # e2e image registry service's NodePort
+      - containerPort: 30000
+        hostPort: 30000
+        listenAddress: "127.0.0.1"
+        protocol: tcp

--- a/test/tools/image-registry.sh
+++ b/test/tools/image-registry.sh
@@ -90,8 +90,11 @@ spec:
   selector:
     app: registry
   ports:
-  - port: 5000
+  - name: http
+    port: 5000
     targetPort: 5000
+    nodePort: 30000
+  type: NodePort
 EOF
 
 kubectl wait --for=condition=Available -n "${namespace}" "deploy/${name}" --timeout=60s


### PR DESCRIPTION
# Description

- expose a nodeport on kind cluster
- change image registry service to portforward on port 30000
- add image repository name for all catalog images

## Reviewer Checklist

- [x] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
