### PR TITLE
🌱 consolidate and save all coverage data under ./coverage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           disable_search: true
-          files: e2e-cover.out
+          files: coverage/e2e.out
           flags: e2e
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -26,6 +26,6 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         disable_search: true
-        files: cover.out
+        files: coverage/unit.out
         flags: unit
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/hack/e2e-coverage.sh
+++ b/hack/e2e-coverage.sh
@@ -2,20 +2,15 @@
 
 set -euo pipefail
 
-COVERAGE_OUTPUT="${COVERAGE_OUTPUT:-e2e-cover.out}"
+COVERAGE_OUTPUT="${COVERAGE_OUTPUT:-${ROOT_DIR}/coverage/e2e.out}"
 
 OPERATOR_CONTROLLER_NAMESPACE="olmv1-system"
 OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME="operator-controller-controller-manager"
 COPY_POD_NAME="e2e-coverage-copy-pod"
 
 # Create a temporary directory for coverage
-COVERAGE_DIR=$(mktemp -d)
-
-# Trap to cleanup temporary directory on script exit
-function cleanup {
-    rm -rf "$COVERAGE_DIR"
-}
-trap cleanup EXIT
+COVERAGE_DIR=${ROOT_DIR}/coverage/e2e
+rm -rf ${COVERAGE_DIR} && mkdir -p ${COVERAGE_DIR}
 
 # Coverage-instrumented binary produces coverage on termination,
 # so we scale down the manager before gathering the coverage


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Move:
- `./e2e-cover.out` -> `./coverage/e2e.out`
- `./cover.out` -> `./coverage/unit.out`

Add Go 1.20+ gocoverdirs
- `./coverage/e2e`
- `./coverage/unit` 

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
