### PR TITLE
🐛 Fix nil pointer dereference in upgrade E2E

### DIFF
--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -86,8 +86,9 @@ func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
 		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
 		assert.Equal(ct, ocv1alpha1.ReasonSuccess, cond.Reason)
 		assert.Contains(ct, cond.Message, "Instantiated bundle")
-		assert.NotEmpty(ct, clusterExtension.Status.InstalledBundle)
-		assert.NotEmpty(ct, clusterExtension.Status.InstalledBundle.Version)
+		if assert.NotEmpty(ct, clusterExtension.Status.InstalledBundle) {
+			assert.NotEmpty(ct, clusterExtension.Status.InstalledBundle.Version)
+		}
 	}, time.Minute, time.Second)
 
 	previousVersion := clusterExtension.Status.InstalledBundle.Version


### PR DESCRIPTION
# Description

Example failure is [here](https://github.com/operator-framework/operator-controller/actions/runs/9941062379/job/27459241132?pr=1047):

```
go test -count=1 -v ./test/upgrade-e2e/...
=== RUN   TestClusterExtensionAfterOLMUpgrade
    post_upgrade_test.go:27: Starting checks after OLM upgrade
    post_upgrade_test.go:32: Checking that the controller-manager deployment is updated
    post_upgrade_test.go:48: Waiting for only one controller-manager Pod to remain
    post_upgrade_test.go:54: Reading logs to make sure that ClusterExtension was reconciled by operator-controller before we update it
    post_upgrade_test.go:66: Checking that the ClusterCatalog is unpacked
    post_upgrade_test.go:78: Checking that the ClusterExtension is installed
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x16666b7]

goroutine 21 [running]:
github.com/operator-framework/operator-controller/test/upgrade-e2e.TestClusterExtensionAfterOLMUpgrade.func4(0xc00046e7b0)
	/home/runner/work/operator-controller/operator-controller/test/upgrade-e2e/post_upgrade_test.go:90 +0x277
github.com/stretchr/testify/assert.EventuallyWithT.func1()
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1983 +0x7f
created by github.com/stretchr/testify/assert.EventuallyWithT in goroutine 14
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/assert/assertions.go:1978 +0x277
FAIL	github.com/operator-framework/operator-controller/test/upgrade-e2e	18.109s
```

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
