### PR TITLE
:sparkles: Use x509.CertPools instead of PEM strings

### DIFF
--- a/internal/rukpak/bundledeployment/bundledeployment.go
+++ b/internal/rukpak/bundledeployment/bundledeployment.go
@@ -80,6 +80,4 @@ type ImageSource struct {
 	// fetch the specified image reference.
 	// This should not be used in a production environment.
 	InsecureSkipTLSVerify bool
-	// CertificateData contains the PEM data of the certificate that is to be used for the TLS connection
-	CertificateData string
 }


### PR DESCRIPTION
Fixes #999

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
