### PR TITLE
✨ Apply OperatorHub.io ClusterCatalog during installation

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -38,5 +38,8 @@ kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
 kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 
+kubectl apply -f "https://raw.githubusercontent.com/operator-framework/operator-controller/main/config/samples/catalogd_operatorcatalog.yaml"
+kubectl wait --for=condition=Unpacked "clustercatalog/operatorhubio" --timeout="60s"
+
 kubectl apply -f "${operator_controller_manifest}"
 kubectl_wait "olmv1-system" "deployment/operator-controller-controller-manager" "60s"


### PR DESCRIPTION
This matches the default configuration in OLMv0 by including OperatorHub

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
This change simply adds the OperatorHub ClusterCatalog to the installation script. On a fresh installation, users will now have the same default operator listings as in OLMv0.

Right now I just have the script applying the sample YAML from this repository. If we wanted to match the way we install actual releases of Cert Manager and Catalogd, then I could make a PR in Catalogd to add the OperatorHub catalog yaml to the release artifacts and cut a release of Catalogd for those to be included.

Related issue: #1026

I'll follow up this PR with documentation changes as suggested in 1026

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
