### PR TITLE
🌱 Bump go to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/operator-framework/operator-controller
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.5
 
 require (
 	carvel.dev/kapp v0.62.1-0.20240508153820-7d8a03ed7ccf


### PR DESCRIPTION
# Description

This will be required for us to bump kapp which requires 1.22.5 and [currently fails](https://github.com/operator-framework/operator-controller/pull/1063):

```
Error: load packages in root "/home/runner/work/operator-controller/operator-controller": err: exit status 1: stderr: go: carvel.dev/kapp@v0.63.2 requires go >= 1.22.5 (running go 1.22.0)
```

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
