### PR TITLE
🌱 Add dependabot K8s dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       interval: "daily"
     commit-message:
       prefix: ":seedling:"
+    groups:
+      k8s-dependencies:
+        patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description

This should help group k8s dependencies into a single PR when possible.

Relevant doc: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
