### PR TITLE
:bug: Revert ":sparkles: Wire up Service Account (#1038)"

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,17 +22,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,7 +42,6 @@ import (
 
 	ocv1alpha1 "github.com/operator-framework/operator-controller/api/v1alpha1"
 	"github.com/operator-framework/operator-controller/internal/action"
-	"github.com/operator-framework/operator-controller/internal/authentication"
 	"github.com/operator-framework/operator-controller/internal/catalogmetadata/cache"
 	catalogclient "github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
 	"github.com/operator-framework/operator-controller/internal/controllers"
@@ -163,34 +158,9 @@ func main() {
 		ext := obj.(*ocv1alpha1.ClusterExtension)
 		return ext.Spec.InstallNamespace, nil
 	})
-	coreClient, err := corev1client.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		setupLog.Error(err, "unable to create core client")
-		os.Exit(1)
-	}
-	tokenGetter := authentication.NewTokenGetter(coreClient, authentication.WithExpirationDuration(1*time.Hour))
-
-	restConfigMapper := func(ctx context.Context, o client.Object, c *rest.Config) (*rest.Config, error) {
-		cExt, ok := o.(*ocv1alpha1.ClusterExtension)
-		if !ok {
-			return c, nil
-		}
-		namespacedName := types.NamespacedName{
-			Name:      cExt.Spec.ServiceAccount.Name,
-			Namespace: cExt.Spec.InstallNamespace,
-		}
-		token, err := tokenGetter.Get(ctx, namespacedName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract SA token, %w", err)
-		}
-		tempConfig := rest.AnonymousClientConfig(c)
-		tempConfig.BearerToken = token
-		return tempConfig, nil
-	}
 	cfgGetter, err := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(),
 		helmclient.StorageNamespaceMapper(installNamespaceMapper),
 		helmclient.ClientNamespaceMapper(installNamespaceMapper),
-		helmclient.RestConfigMapper(restConfigMapper),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to config for creating helm client")

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -5,11 +5,11 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apiextensions.k8s.io
+  - '*'
   resources:
-  - customresourcedefinitions
+  - '*'
   verbs:
-  - get
+  - '*'
 - apiGroups:
   - catalogd.operatorframework.io
   resources:
@@ -37,20 +37,12 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
-- apiGroups:
   - olm.operatorframework.io
   resources:
   - clusterextensions
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - olm.operatorframework.io

--- a/config/samples/olm_v1alpha1_clusterextension.yaml
+++ b/config/samples/olm_v1alpha1_clusterextension.yaml
@@ -7,4 +7,4 @@ spec:
   packageName: argocd-operator
   version: 0.6.0
   serviceAccount:
-    name: default
+    name: argocd-installer

--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -33,42 +33,6 @@ spec:
       insecureSkipTLSVerify: true
 EOF
 
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: upgrade-e2e
-  namespace: default
-EOF
-
-kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: upgrade-e2e
-rules:
-  - apiGroups:
-    - "*"
-    resources:
-    - "*"
-    verbs:
-    - "*"
-EOF
-
-kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: upgrade-e2e
-subjects:
-  - kind: ServiceAccount
-    name: upgrade-e2e
-    namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: upgrade-e2e
-EOF
 
 kubectl apply -f - << EOF
 apiVersion: olm.operatorframework.io/v1alpha1
@@ -80,7 +44,7 @@ spec:
   packageName: prometheus
   version: 1.0.0
   serviceAccount:
-    name: upgrade-e2e
+    name: default
 EOF
 
 kubectl wait --for=condition=Unpacked --timeout=60s ClusterCatalog $TEST_CLUSTER_CATALOG_NAME

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -112,12 +112,11 @@ type Preflight interface {
 	Upgrade(context.Context, *release.Release) error
 }
 
-//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions/status,verbs=update;patch
 //+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create;update;patch;delete;get;list;watch
-//+kubebuilder:rbac:groups=core,resources=serviceaccounts/token,verbs=create
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
+//+kubebuilder:rbac:groups=*,resources=*,verbs=*
 
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=clustercatalogs,verbs=list;watch
 //+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogmetadata,verbs=list;watch


### PR DESCRIPTION
This reverts commit 95b9f0dc5943497028deb47969310dec45792a2d.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This reverts the #1038, which breaks the standard install of OLMv1.

It appears that the code from #1038 still requires the OLMv1 system service account to have `* / * / *` permissions (or at least permission to list/watch everything).

The e2e tests from that PR pass because they layer `* / * / *` permissions back in for both the OLM SA and the ClusterExtension SA, which means that our SA features are essentially untested.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
