### PR TITLE
🐛 Bug: remove old conditional in ClusterExtension

### DIFF
--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -553,9 +553,6 @@ func (r *ClusterExtensionReconciler) getReleaseState(cl helmclient.ActionInterfa
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 		return nil, nil, stateError, err
 	}
-	if errors.Is(err, driver.ErrReleaseNotFound) {
-		return nil, nil, stateNeedsInstall, nil
-	}
 
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		desiredRelease, err := cl.Install(ext.GetName(), ext.Spec.InstallNamespace, chrt, values, func(i *action.Install) error {


### PR DESCRIPTION
Removes old conditional for handling ErrReleaseNotFound which was preventing the new logic from firing.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
