### PR TITLE
:sparkles: feat:  dump csv annotations into chart metadata

### DIFF
--- a/internal/rukpak/convert/registryv1.go
+++ b/internal/rukpak/convert/registryv1.go
@@ -101,12 +101,17 @@ func RegistryV1ToHelmChart(ctx context.Context, rv1 fs.FS, installNamespace stri
 		return nil, err
 	}
 
-	plain, err := Convert(reg, installNamespace, watchNamespaces)
+	return toChart(reg, installNamespace, watchNamespaces)
+}
+
+func toChart(in RegistryV1, installNamespace string, watchNamespaces []string) (*chart.Chart, error) {
+	plain, err := Convert(in, installNamespace, watchNamespaces)
 	if err != nil {
 		return nil, err
 	}
 
 	chrt := &chart.Chart{Metadata: &chart.Metadata{}}
+	chrt.Metadata.Annotations = in.CSV.GetAnnotations()
 	for _, obj := range plain.Objects {
 		jsonData, err := json.Marshal(obj)
 		if err != nil {


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This is needed for the cluster olm operator to find the ocp max version

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
