### PR TITLE
🌱 enable OwnerReferencesPermissionEnforcement in project kind config

### DIFF
--- a/config/samples/olm_v1alpha1_clusterextension.yaml
+++ b/config/samples/olm_v1alpha1_clusterextension.yaml
@@ -28,7 +28,12 @@ kind: ClusterRole
 metadata:
   name: argocd-installer-clusterrole
 rules:
-# Manage ArgoCD CRDs 
+# Allow ClusterExtension to set blockOwnerDeletion ownerReferences
+- apiGroups: [olm.operatorframework.io]
+  resources: [clusterextensions/finalizers]
+  verbs: [update]
+  resourceNames: [argocd]
+# Manage ArgoCD CRDs
 - apiGroups: [apiextensions.k8s.io]
   resources: [customresourcedefinitions]
   verbs: [create]
@@ -221,32 +226,32 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [serviceaccounts]
-  verbs: [get, list, watch, create, update, patch, delete]
-  resourceNames: [argocd-operator-controller-manager]
+  verbs: [create]
 - apiGroups: [""]
   resources: [serviceaccounts]
+  verbs: [get, list, watch, update, patch, delete]
+  resourceNames: [argocd-operator-controller-manager]
+- apiGroups: [""]
+  resources: [configmaps]
   verbs: [create]
 - apiGroups: [""]
   resources: [configmaps]
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, update, patch, delete]
   resourceNames: [argocd-operator-manager-config]
 - apiGroups: [""]
-  resources: [configmaps]
+  resources: [services]
   verbs: [create]
 - apiGroups: [""]
   resources: [services]
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, update, patch, delete]
   resourceNames: [argocd-operator-controller-manager-metrics-service]
-- apiGroups: [""]
-  resources: [services]
+- apiGroups: [apps]
+  resources: [deployments]
   verbs: [create]
 - apiGroups: [apps]
   resources: [deployments]
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, update, patch, delete]
   resourceNames: [argocd-operator-controller-manager]
-- apiGroups: [apps]
-  resources: [deployments]
-  verbs: [create]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/docs/drafts/permissions-for-owner-references-permission-enforcement-plugin.md
+++ b/docs/drafts/permissions-for-owner-references-permission-enforcement-plugin.md
@@ -1,0 +1,13 @@
+# Configuring a service account when the cluster uses the `OwnerReferencesPermissionEnforcement` admission plugin
+
+The [`OwnerReferencesPermissionEnforcement`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission plugin requires a user to have permission to set finalizers on owner objects when creating or updating an object to contain an `ownerReference` with `blockOwnerDeletion: true`.
+
+When operator-controller installs or upgrades a `ClusterExtension`, it sets an `ownerReference` on each object with `blockOwnerDeletion: true`. Therefore serviceaccounts configured in `.spec.serviceAccount.name` must have the following permission in a bound `ClusterRole`:
+
+   ```yaml
+   - apiGroups: ["olm.operatorframework.io"]
+     resources: ["clusterextensions/finalizers"]
+     verbs: ["update"]
+     resourceNames: ["<clusterExtensionName>"]
+   ```
+

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -8,3 +8,9 @@ nodes:
         hostPort: 30000
         listenAddress: "127.0.0.1"
         protocol: tcp
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+            extraArgs:
+              enable-admission-plugins: OwnerReferencesPermissionEnforcement


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Kubernetes has many admission policy plugins that are disabled by default when using vanilla Kubernetes. Vendors of Kubernetes tend to enable the `OwnerReferencesPermissionEnforcement` plugin. One prominent example of a vendor enabling this plugin is OpenShift.
In order to ensure OLM works seamlessly on as many Kubernetes distributions as possible, we should enable this plugin in our kind config.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
