### PR TITLE
🐛: Fix ClusterExtension Finalizer RBAC for upgrade-e2e

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -102,6 +102,14 @@ rules:
     - "watch"
     - "bind"
     - "escalate"
+  - apiGroups:
+    - "olm.operatorframework.io"
+    resources:
+    - "clusterextensions/finalizers"
+    verbs:
+    - "update"
+    resourceNames:
+    - "${TEST_CLUSTER_EXTENSION_NAME}"
 EOF
 
 kubectl apply -f - <<EOF


### PR DESCRIPTION
The default kind config for e2e was updated with `OwnerReferencesPermissionEnforcement` and the setup script for the `upgrade-e2e` test was missing the required permissions on the installer clusterrole. This adds the required fields as detailed in our docs.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
