### PR TITLE
🐛: Fix tilt ci

### DIFF
--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -22,10 +22,16 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: operator-controller
+    - name: Get catalogd version
+      id: get-catalogd-version
+      run: |
+        cd operator-controller
+        echo "CATALOGD_VERSION=$(go list -mod=mod -m -f "{{.Version}}" github.com/operator-framework/catalogd)" >> "$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
       with:
         repository: operator-framework/catalogd
         path: catalogd
+        ref: "${{ steps.get-catalogd-version.outputs.CATALOGD_VERSION }}"
     - name: Install Tilt
       run: |
         TILT_VERSION="0.33.3"


### PR DESCRIPTION
Fixes tilt not using declared catalogd version in go.mod file, causing the ci to fail if catalogd is updated in an incompatible way (i.e. API change).

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
