### PR TITLE
:sparkles: Add in catalog label selection support

### DIFF
--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -306,7 +306,7 @@ func TestClusterExtensionInstallRegistryMultipleBundles(t *testing.T) {
 		if !assert.NotNil(ct, cond) {
 			return
 		}
-		// TODO(tmshort/dfranz): This should fail due to multiple bundles
+		// TODO(tmshort/dtfranz): This should fail due to multiple bundles
 		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
 		//assert.Equal(ct, metav1.ConditionFalse, cond.Status)
 		//assert.Equal(ct, ocv1alpha1.ReasonResolutionFailed, cond.Reason)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -44,7 +44,8 @@ func TestMain(m *testing.M) {
 func createTestCatalog(ctx context.Context, name string, imageRef string) (*catalogd.ClusterCatalog, error) {
 	catalog := &catalogd.ClusterCatalog{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: map[string]string{"olm.operatorframework.io/name": name},
 		},
 		Spec: catalogd.ClusterCatalogSpec{
 			Source: catalogd.CatalogSource{


### PR DESCRIPTION
Fix #1112

Adds some tests to validate the label selector.
Modified some tests to add labels and selectors. They are not necessary now, but will be once 1110 is resolved; as that issue adds the ambiguity that this PR helps resolve.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
