### PR TITLE
⚠: Ambiguous Resolution

### DIFF
--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/sets"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -262,59 +261,24 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 
-	t.Run("always prefer non-deprecated when versions match", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
-			// When the same version exists in both catalogs, we prefer the non-deprecated one.
-			ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <=1.0.1", ocv1alpha1.UpgradeConstraintPolicyEnforce)
-			gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
-			require.NoError(t, err)
-			assert.Equal(t, genBundle(pkgName, "1.0.1").Name, gotBundle.Name)
-			assert.Equal(t, bsemver.MustParse("1.0.1"), *gotVersion)
-			assert.Nil(t, gotDeprecation)
-		}
-	})
-
 	t.Run("when catalog b has a newer version that matches the range", func(t *testing.T) {
-		// When one version exists in one catalog but not the other, we prefer the one that exists.
 		ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <=1.0.3", ocv1alpha1.UpgradeConstraintPolicyEnforce)
 		gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
-		require.NoError(t, err)
-		assert.Equal(t, genBundle(pkgName, "1.0.3").Name, gotBundle.Name)
-		assert.Equal(t, genImgRef("catalog-b", gotBundle.Name), gotBundle.Image)
-		assert.Equal(t, bsemver.MustParse("1.0.3"), *gotVersion)
-		assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "found in multiple catalogs: [b c]")
+		assert.Nil(t, gotBundle)
+		assert.Nil(t, gotVersion)
+		assert.Nil(t, gotDeprecation)
 	})
 
 	t.Run("when catalog c has a newer version that matches the range", func(t *testing.T) {
 		ce := buildFooClusterExtension(pkgName, "", ">=0.1.0 <1.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
 		gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
-		require.NoError(t, err)
-		assert.Equal(t, genBundle(pkgName, "0.1.1").Name, gotBundle.Name)
-		assert.Equal(t, genImgRef("catalog-c", gotBundle.Name), gotBundle.Image)
-		assert.Equal(t, bsemver.MustParse("0.1.1"), *gotVersion)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "found in multiple catalogs: [b c]")
+		assert.Nil(t, gotBundle)
+		assert.Nil(t, gotVersion)
 		assert.Nil(t, gotDeprecation)
-	})
-
-	t.Run("when there is ambiguity between catalogs", func(t *testing.T) {
-		// When there is no way to disambiguate between two versions, the choice is undefined.
-		foundImages := sets.New[string]()
-		foundDeprecations := sets.New[*declcfg.Deprecation]()
-		for i := 0; i < 100; i++ {
-			ce := buildFooClusterExtension(pkgName, "", "0.1.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
-			gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
-			require.NoError(t, err)
-			assert.Equal(t, genBundle(pkgName, "0.1.0").Name, gotBundle.Name)
-			assert.Equal(t, bsemver.MustParse("0.1.0"), *gotVersion)
-			foundImages.Insert(gotBundle.Image)
-			foundDeprecations.Insert(gotDeprecation)
-		}
-		assert.ElementsMatch(t, []string{
-			genImgRef("catalog-b", bundleName(pkgName, "0.1.0")),
-			genImgRef("catalog-c", bundleName(pkgName, "0.1.0")),
-		}, foundImages.UnsortedList())
-
-		assert.Contains(t, foundDeprecations, (*declcfg.Deprecation)(nil))
-		assert.Contains(t, foundDeprecations, ptr.To(packageDeprecation(pkgName)))
 	})
 }
 

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -306,12 +306,10 @@ func TestClusterExtensionInstallRegistryMultipleBundles(t *testing.T) {
 		if !assert.NotNil(ct, cond) {
 			return
 		}
-		// TODO(tmshort/dtfranz): This should fail due to multiple bundles
-		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
-		//assert.Equal(ct, metav1.ConditionFalse, cond.Status)
-		//assert.Equal(ct, ocv1alpha1.ReasonResolutionFailed, cond.Reason)
-		//assert.Contains(ct, cond.Message, "TODO: matching bundles found in multiple catalogs")
-		//assert.Nil(ct, clusterExtension.Status.ResolvedBundle)
+		assert.Equal(ct, metav1.ConditionFalse, cond.Status)
+		assert.Equal(ct, ocv1alpha1.ReasonResolutionFailed, cond.Reason)
+		assert.Contains(ct, cond.Message, "matching packages found in multiple catalogs")
+		assert.Nil(ct, clusterExtension.Status.ResolvedBundle)
 	}, pollDuration, pollInterval)
 }
 


### PR DESCRIPTION
Changes the behavior of catalog resolution by returning an error when multiple packages are available from multiple catalogs. 

Users will need to use forthcoming label selectors to narrow down catalogs when this occurs.

Closes #1110

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
