### PR TITLE
:warning: Update to catalogd v0.21.0

### DIFF
--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -11,25 +11,25 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - catalogd.operatorframework.io
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - olm.operatorframework.io
   resources:
   - catalogmetadata
   verbs:
   - list
   - watch
 - apiGroups:
-  - catalogd.operatorframework.io
+  - olm.operatorframework.io
   resources:
   - clustercatalogs
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
 - apiGroups:
   - olm.operatorframework.io
   resources:

--- a/config/samples/catalogd_operatorcatalog.yaml
+++ b/config/samples/catalogd_operatorcatalog.yaml
@@ -1,4 +1,4 @@
-apiVersion: catalogd.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterCatalog
 metadata:
   name: operatorhubio

--- a/docs/Tasks/adding-a-catalog.md
+++ b/docs/Tasks/adding-a-catalog.md
@@ -21,7 +21,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
 1. Create a catalog custom resource (CR):
 
     ``` yaml title="clustercatalog_cr.yaml"
-    apiVersion: catalogd.operatorframework.io/v1alpha1
+    apiVersion: olm.operatorframework.io/v1alpha1
     kind: ClusterCatalog
     metadata:
       name: operatorhubio
@@ -43,7 +43,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
             To disable polling, set a zero value, such as `0s`.
 
     ``` yaml title="Example `operatorhubio.yaml` CR"
-    apiVersion: catalogd.operatorframework.io/v1alpha1
+    apiVersion: olm.operatorframework.io/v1alpha1
     kind: ClusterCatalog
     metadata:
       name: operatorhub
@@ -62,7 +62,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
     ```
 
     ``` text title="Example output"
-    clustercatalog.catalogd.operatorframework.io/operatorhubio created
+    clustercatalog.olm.operatorframework.io/operatorhubio created
     ```
 
 ### Verification
@@ -91,12 +91,12 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
         Namespace:
         Labels:       <none>
         Annotations:  <none>
-        API Version:  catalogd.operatorframework.io/v1alpha1
+        API Version:  olm.operatorframework.io/v1alpha1
         Kind:         ClusterCatalog
         Metadata:
           Creation Timestamp:  2024-03-12T19:34:50Z
           Finalizers:
-            catalogd.operatorframework.io/delete-server-cache
+            olm.operatorframework.io/delete-server-cache
           Generation:        2
           Resource Version:  6469
           UID:               2e2778cb-dda6-4645-96b7-992e8dd37503

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/operator-framework/api v0.27.0
-	github.com/operator-framework/catalogd v0.20.0
+	github.com/operator-framework/catalogd v0.21.0
 	github.com/operator-framework/helm-operator-plugins v0.5.0
 	github.com/operator-framework/operator-registry v1.46.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11 h1:eT
 github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11/go.mod h1:EmVJt97N+pfWFsli/ipXTBZqSG5F5KGQhm3c3IsGq1o=
 github.com/operator-framework/api v0.27.0 h1:OrVaGKZJvbZo58HTv2guz7aURkhVKYhFqZ/6VpifiXI=
 github.com/operator-framework/api v0.27.0/go.mod h1:lg2Xx+S8NQWGYlEOvFwQvH46E5EK5IrAIL7HWfAhciM=
-github.com/operator-framework/catalogd v0.20.0 h1:m5ugxf9fjEUaNHy81lSu6jFzTEt0XpEo44+T7g9On+U=
-github.com/operator-framework/catalogd v0.20.0/go.mod h1:F4KehkAI/bpDI4IVXNxQ7dlWtVBYvc2qkxSa7mIFGRk=
+github.com/operator-framework/catalogd v0.21.0 h1:j5C19Aw3u3PpFgJGE1DF0lajS+pEX5FNlDKkocCKrAM=
+github.com/operator-framework/catalogd v0.21.0/go.mod h1:PTMUO/oi7mgXX60U9hDsd23EUwNm1mycnGXAa2hnMsE=
 github.com/operator-framework/helm-operator-plugins v0.5.0 h1:qph2OoECcI9mpuUBtOsWOMgvpx52mPTTSvzVxICsT04=
 github.com/operator-framework/helm-operator-plugins v0.5.0/go.mod h1:yVncrZ/FJNqedMil+055fk6sw8aMKRrget/AqGM0ig0=
 github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=

--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -20,7 +20,7 @@ TEST_CLUSTER_CATALOG_NAME=$2
 TEST_CLUSTER_EXTENSION_NAME=$3
 
 kubectl apply -f - << EOF
-apiVersion: catalogd.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterCatalog
 metadata:
   name: ${TEST_CLUSTER_CATALOG_NAME}

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -85,8 +85,8 @@ type InstalledBundleGetter interface {
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts/token,verbs=create
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 
-//+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=clustercatalogs,verbs=list;watch
-//+kubebuilder:rbac:groups=catalogd.operatorframework.io,resources=catalogmetadata,verbs=list;watch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clustercatalogs,verbs=list;watch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=catalogmetadata,verbs=list;watch
 
 // The operator controller needs to watch all the bundle objects and reconcile accordingly. Though not ideal, but these permissions are required.
 // This has been taken from rukpak, and an issue was created before to discuss it: https://github.com/operator-framework/rukpak/issues/800.


### PR DESCRIPTION
Alternative to #1172

This has a new API path (olm... vs catalogd...)

Update all references to catalogd.operatorframework.io

This _will_ fail the upgrade-e2e, since it depends on the "latest" version of operator-controller, which does not reference the correct API path.

Once this is merged, then subsequent upgrade-e2e's will pass.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
