### PR TITLE
✨ Add ServedVersionValidator preflight check

### DIFF
--- a/internal/rukpak/preflights/crdupgradesafety/checks.go
+++ b/internal/rukpak/preflights/crdupgradesafety/checks.go
@@ -1,0 +1,72 @@
+package crdupgradesafety
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	kappcus "carvel.dev/kapp/pkg/kapp/crdupgradesafety"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	versionhelper "k8s.io/apimachinery/pkg/version"
+)
+
+type ServedVersionValidator struct {
+	Validations []kappcus.ChangeValidation
+}
+
+func (c *ServedVersionValidator) Validate(old, new apiextensionsv1.CustomResourceDefinition) error {
+	// If conversion webhook is specified, pass check
+	if new.Spec.Conversion != nil && new.Spec.Conversion.Strategy == apiextensionsv1.WebhookConverter {
+		return nil
+	}
+
+	errs := []error{}
+	servedVersions := []apiextensionsv1.CustomResourceDefinitionVersion{}
+	for _, version := range new.Spec.Versions {
+		if version.Served {
+			servedVersions = append(servedVersions, version)
+		}
+	}
+
+	slices.SortFunc(servedVersions, func(a, b apiextensionsv1.CustomResourceDefinitionVersion) int {
+		return versionhelper.CompareKubeAwareVersionStrings(a.Name, b.Name)
+	})
+
+	for i, oldVersion := range servedVersions[:len(servedVersions)-1] {
+		for _, newVersion := range servedVersions[i+1:] {
+			flatOld := kappcus.FlattenSchema(oldVersion.Schema.OpenAPIV3Schema)
+			flatNew := kappcus.FlattenSchema(newVersion.Schema.OpenAPIV3Schema)
+			diffs, err := kappcus.CalculateFlatSchemaDiff(flatOld, flatNew)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("calculating schema diff between CRD versions %q and %q", oldVersion.Name, newVersion.Name))
+				continue
+			}
+
+			for field, diff := range diffs {
+				handled := false
+				for _, validation := range c.Validations {
+					ok, err := validation(diff)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("version upgrade %q to %q, field %q: %w", oldVersion.Name, newVersion.Name, field, err))
+					}
+					if ok {
+						handled = true
+						break
+					}
+				}
+
+				if !handled {
+					errs = append(errs, fmt.Errorf("version %q, field %q has unknown change, refusing to determine that change is safe", oldVersion.Name, field))
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (c *ServedVersionValidator) Name() string {
+	return "ServedVersionValidator"
+}

--- a/internal/rukpak/preflights/crdupgradesafety/crdupgradesafety.go
+++ b/internal/rukpak/preflights/crdupgradesafety/crdupgradesafety.go
@@ -31,6 +31,19 @@ type Preflight struct {
 }
 
 func NewPreflight(crdCli apiextensionsv1client.CustomResourceDefinitionInterface, opts ...Option) *Preflight {
+	changeValidations := []kappcus.ChangeValidation{
+		kappcus.EnumChangeValidation,
+		kappcus.RequiredFieldChangeValidation,
+		kappcus.MaximumChangeValidation,
+		kappcus.MaximumItemsChangeValidation,
+		kappcus.MaximumLengthChangeValidation,
+		kappcus.MaximumPropertiesChangeValidation,
+		kappcus.MinimumChangeValidation,
+		kappcus.MinimumItemsChangeValidation,
+		kappcus.MinimumLengthChangeValidation,
+		kappcus.MinimumPropertiesChangeValidation,
+		kappcus.DefaultValueChangeValidation,
+	}
 	p := &Preflight{
 		crdClient: crdCli,
 		// create a default validator. Can be overridden via the options
@@ -39,21 +52,8 @@ func NewPreflight(crdCli apiextensionsv1client.CustomResourceDefinitionInterface
 				kappcus.NewValidationFunc("NoScopeChange", kappcus.NoScopeChange),
 				kappcus.NewValidationFunc("NoStoredVersionRemoved", kappcus.NoStoredVersionRemoved),
 				kappcus.NewValidationFunc("NoExistingFieldRemoved", kappcus.NoExistingFieldRemoved),
-				&kappcus.ChangeValidator{
-					Validations: []kappcus.ChangeValidation{
-						kappcus.EnumChangeValidation,
-						kappcus.RequiredFieldChangeValidation,
-						kappcus.MaximumChangeValidation,
-						kappcus.MaximumItemsChangeValidation,
-						kappcus.MaximumLengthChangeValidation,
-						kappcus.MaximumPropertiesChangeValidation,
-						kappcus.MinimumChangeValidation,
-						kappcus.MinimumItemsChangeValidation,
-						kappcus.MinimumLengthChangeValidation,
-						kappcus.MinimumPropertiesChangeValidation,
-						kappcus.DefaultValueChangeValidation,
-					},
-				},
+				&ServedVersionValidator{Validations: changeValidations},
+				&kappcus.ChangeValidator{Validations: changeValidations},
 			},
 		},
 	}

--- a/internal/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
+++ b/internal/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
@@ -329,6 +329,25 @@ func TestUpgrade(t *testing.T) {
 				`"NoExistingFieldRemoved"`,
 			},
 		},
+		{
+			name:       "webhook conversion strategy exists",
+			oldCrdPath: "crd-conversion-webhook-old.json",
+			release: &release.Release{
+				Name:     "test-release",
+				Manifest: getManifestString(t, "crd-conversion-webhook.json"),
+			},
+		},
+		{
+			name:       "new crd validation failure when missing conversion strategy and enum values removed",
+			oldCrdPath: "crd-conversion-webhook-old.json",
+			release: &release.Release{
+				Name:     "test-release",
+				Manifest: getManifestString(t, "crd-conversion-no-webhook.json"),
+			},
+			wantErrMsgs: []string{
+				`"ServedVersionValidator" validation failed: version upgrade "v1" to "v2", field "^.spec.foobarbaz": enum values removed`,
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/testdata/manifests/crd-conversion-no-webhook.json
+++ b/testdata/manifests/crd-conversion-no-webhook.json
@@ -1,0 +1,70 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "crontabs.stable.example.com"
+    },
+    "spec": {
+        "group": "stable.example.com",
+        "versions": [
+            {
+                "name": "v2",
+                "served": true,
+                "storage": false,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "foobarbaz": {
+                                        "type":"string",
+                                        "enum":[
+                                            "bark",
+                                            "woof"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "v1",
+                "served": true,
+                "storage": false,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "foobarbaz": {
+                                        "type":"string",
+                                        "enum":[
+                                            "foo",
+                                            "bar",
+                                            "baz"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Cluster",
+        "names": {
+            "plural": "crontabs",
+            "singular": "crontab",
+            "kind": "CronTab",
+            "shortNames": [
+                "ct"
+            ]
+        }
+    }
+}

--- a/testdata/manifests/crd-conversion-webhook-old.json
+++ b/testdata/manifests/crd-conversion-webhook-old.json
@@ -1,0 +1,46 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "crontabs.stable.example.com"
+    },
+    "spec": {
+        "group": "stable.example.com",
+        "versions": [
+            {
+                "name": "v1",
+                "served": true,
+                "storage": false,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "foobarbaz": {
+                                        "type":"string",
+                                        "enum":[
+                                            "foo",
+                                            "bar",
+                                            "baz"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Cluster",
+        "names": {
+            "plural": "crontabs",
+            "singular": "crontab",
+            "kind": "CronTab",
+            "shortNames": [
+                "ct"
+            ]
+        }
+    }
+}

--- a/testdata/manifests/crd-conversion-webhook.json
+++ b/testdata/manifests/crd-conversion-webhook.json
@@ -1,0 +1,82 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "crontabs.stable.example.com"
+    },
+    "spec": {
+        "group": "stable.example.com",
+        "versions": [
+            {
+                "name": "v2",
+                "served": true,
+                "storage": false,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "foobarbaz": {
+                                        "type":"string",
+                                        "enum":[
+                                            "bark",
+                                            "woof"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "v1",
+                "served": true,
+                "storage": false,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "foobarbaz": {
+                                        "type":"string",
+                                        "enum":[
+                                            "foo",
+                                            "bar",
+                                            "baz"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Cluster",
+        "names": {
+            "plural": "crontabs",
+            "singular": "crontab",
+            "kind": "CronTab",
+            "shortNames": [
+                "ct"
+            ]
+        },
+        "conversion": {
+            "strategy": "Webhook",
+            "webhook": {
+                    "clientConfig": {
+                    "service": {
+                        "namespace": "crd-conversion-webhook",
+                        "name": "crd-conversion-webhook",
+                        "path": "/crdconversion"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testdata/manifests/crd-field-removed.json
+++ b/testdata/manifests/crd-field-removed.json
@@ -15,7 +15,42 @@
                     "openAPIV3Schema": {
                         "type": "object",
                         "properties": {
-                        }
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "removedField": {
+                                        "type":"integer"
+                                    },
+                                    "enum": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxValue": {
+                                        "type":"integer"
+                                    },
+                                    "required": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxItems": {
+                                        "type":"array",
+                                        "items": {
+                                            "type":"string"
+                                        }
+                                    },
+                                    "minMaxLength": {
+                                        "type":"string"
+                                    },
+                                    "defaultVal": {
+                                        "type": "string"
+                                    },
+                                    "requiredVal": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "required": [
+                            "requiredVal"
+                        ]
                     }
                 }
             },

--- a/testdata/manifests/crd-valid-upgrade.json
+++ b/testdata/manifests/crd-valid-upgrade.json
@@ -15,7 +15,42 @@
                     "openAPIV3Schema": {
                         "type": "object",
                         "properties": {
-                        }
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "removedField": {
+                                        "type":"integer"
+                                    },
+                                    "enum": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxValue": {
+                                        "type":"integer"
+                                    },
+                                    "required": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxItems": {
+                                        "type":"array",
+                                        "items": {
+                                            "type":"string"
+                                        }
+                                    },
+                                    "minMaxLength": {
+                                        "type":"string"
+                                    },
+                                    "defaultVal": {
+                                        "type": "string"
+                                    },
+                                    "requiredVal": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "required": [
+                            "requiredVal"
+                        ]
                     }
                 }
             },

--- a/testdata/manifests/old-crd.json
+++ b/testdata/manifests/old-crd.json
@@ -15,7 +15,42 @@
                     "openAPIV3Schema": {
                         "type": "object",
                         "properties": {
-                        }
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "removedField": {
+                                        "type":"integer"
+                                    },
+                                    "enum": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxValue": {
+                                        "type":"integer"
+                                    },
+                                    "required": {
+                                        "type":"integer"
+                                    },
+                                    "minMaxItems": {
+                                        "type":"array",
+                                        "items": {
+                                            "type":"string"
+                                        }
+                                    },
+                                    "minMaxLength": {
+                                        "type":"string"
+                                    },
+                                    "defaultVal": {
+                                        "type": "string"
+                                    },
+                                    "requiredVal": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "required": [
+                            "requiredVal"
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
New preflight check that checks for either the presence of the "Webhook" conversion strategy to pass, or checks for any incompatible changes between served versions in the new CRD which, if found, causes failure..

Closes #1091

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
Adds a new preflight check, ServedVersionValidator, which checks for breaking changes between served versions in the new CRD when upgrading.

Happy to change up any naming or error messages.

Existing test data had to be edited so it wouldn't trigger the new check--the empty v1 in all the test data has just been filled in to match the test data v2.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
