### PR TITLE
:sparkles: Use a catalog's priority to as a bundle selection tie-breaker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.2
 	github.com/operator-framework/api v0.27.0
-	github.com/operator-framework/catalogd v0.21.0
+	github.com/operator-framework/catalogd v0.22.0
 	github.com/operator-framework/helm-operator-plugins v0.5.0
 	github.com/operator-framework/operator-registry v1.46.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11 h1:eT
 github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11/go.mod h1:EmVJt97N+pfWFsli/ipXTBZqSG5F5KGQhm3c3IsGq1o=
 github.com/operator-framework/api v0.27.0 h1:OrVaGKZJvbZo58HTv2guz7aURkhVKYhFqZ/6VpifiXI=
 github.com/operator-framework/api v0.27.0/go.mod h1:lg2Xx+S8NQWGYlEOvFwQvH46E5EK5IrAIL7HWfAhciM=
-github.com/operator-framework/catalogd v0.21.0 h1:j5C19Aw3u3PpFgJGE1DF0lajS+pEX5FNlDKkocCKrAM=
-github.com/operator-framework/catalogd v0.21.0/go.mod h1:PTMUO/oi7mgXX60U9hDsd23EUwNm1mycnGXAa2hnMsE=
+github.com/operator-framework/catalogd v0.22.0 h1:P03HimAAxMdLLVL4+TYYBE+cFpMNW9jfQbqMfQJ+Hg4=
+github.com/operator-framework/catalogd v0.22.0/go.mod h1:uZYW3dpbsvdxD+ScznAeHclubqd5sU6GNDtdqiydBxU=
 github.com/operator-framework/helm-operator-plugins v0.5.0 h1:qph2OoECcI9mpuUBtOsWOMgvpx52mPTTSvzVxICsT04=
 github.com/operator-framework/helm-operator-plugins v0.5.0/go.mod h1:yVncrZ/FJNqedMil+055fk6sw8aMKRrget/AqGM0ig0=
 github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=

--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -44,7 +44,9 @@ func TestErrorWalkingCatalogs(t *testing.T) {
 
 func TestErrorGettingPackage(t *testing.T) {
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return nil, fmt.Errorf("fake error") },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return nil, nil, fmt.Errorf("fake error")
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	pkgName := randPkg()
@@ -55,9 +57,15 @@ func TestErrorGettingPackage(t *testing.T) {
 
 func TestPackageDoesNotExist(t *testing.T) {
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	pkgName := randPkg()
@@ -69,9 +77,15 @@ func TestPackageDoesNotExist(t *testing.T) {
 func TestPackageExists(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -85,9 +99,15 @@ func TestPackageExists(t *testing.T) {
 func TestValidationFailed(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{
 		WalkCatalogsFunc: w.WalkCatalogs,
@@ -105,9 +125,15 @@ func TestValidationFailed(t *testing.T) {
 func TestVersionDoesNotExist(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "3.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -118,9 +144,15 @@ func TestVersionDoesNotExist(t *testing.T) {
 func TestVersionExists(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <2.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -134,9 +166,15 @@ func TestVersionExists(t *testing.T) {
 func TestChannelDoesNotExist(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "stable", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -147,9 +185,15 @@ func TestChannelDoesNotExist(t *testing.T) {
 func TestChannelExists(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "beta", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -163,9 +207,15 @@ func TestChannelExists(t *testing.T) {
 func TestChannelExistsButNotVersion(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "beta", "3.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -176,9 +226,15 @@ func TestChannelExistsButNotVersion(t *testing.T) {
 func TestVersionExistsButNotChannel(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "stable", "1.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -189,9 +245,15 @@ func TestVersionExistsButNotChannel(t *testing.T) {
 func TestChannelAndVersionExist(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "alpha", "0.1.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -205,9 +267,15 @@ func TestChannelAndVersionExist(t *testing.T) {
 func TestPreferNonDeprecated(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", ">=0.1.0 <=1.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -221,9 +289,15 @@ func TestPreferNonDeprecated(t *testing.T) {
 func TestAcceptDeprecated(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <=1.0.1", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -237,8 +311,10 @@ func TestAcceptDeprecated(t *testing.T) {
 func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) {
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			fbc := &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{{Name: pkgName}},
 				Bundles:  []declcfg.Bundle{genBundle(pkgName, "1.0.0")},
@@ -252,9 +328,9 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 					},
 				}},
 			}
-			return fbc, nil
+			return fbc, nil, nil
 		},
-		"c": func() (*declcfg.DeclarativeConfig, error) {
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			fbc := &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{{Name: pkgName}},
 				Bundles:  []declcfg.Bundle{genBundle(pkgName, "1.0.1")},
@@ -268,16 +344,16 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 					},
 				}},
 			}
-			return fbc, nil
+			return fbc, nil, nil
 		},
-		"d": func() (*declcfg.DeclarativeConfig, error) {
+		"d": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			fbc := &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{{Name: pkgName}},
 				Bundles:  []declcfg.Bundle{genBundle(pkgName, "1.0.2")},
 			}
-			return fbc, nil
+			return fbc, nil, nil
 		},
-		"e": func() (*declcfg.DeclarativeConfig, error) {
+		"e": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			fbc := &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{{Name: pkgName}},
 				Bundles:  []declcfg.Bundle{genBundle(pkgName, "1.0.3")},
@@ -291,9 +367,9 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 					},
 				}},
 			}
-			return fbc, nil
+			return fbc, nil, nil
 		},
-		"f": func() (*declcfg.DeclarativeConfig, error) {
+		"f": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			fbc := &declcfg.DeclarativeConfig{
 				Packages: []declcfg.Package{{Name: pkgName}},
 				Bundles: []declcfg.Bundle{
@@ -301,7 +377,7 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 					genBundle(pkgName, "1.0.5"),
 				},
 			}
-			return fbc, nil
+			return fbc, nil, nil
 		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
@@ -353,9 +429,15 @@ func TestUpgradeFoundLegacy(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -375,9 +457,15 @@ func TestUpgradeNotFoundLegacy(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "<1.0.0 >=2.0.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -394,9 +482,15 @@ func TestUpgradeFoundSemver(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, true)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -418,9 +512,15 @@ func TestUpgradeNotFoundSemver(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, true)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "!=0.1.0", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -437,9 +537,15 @@ func TestUpgradeNotFoundSemver(t *testing.T) {
 func TestDowngradeFound(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "<1.0.2", ocv1alpha1.UpgradeConstraintPolicyIgnore)
@@ -459,9 +565,15 @@ func TestDowngradeFound(t *testing.T) {
 func TestDowngradeNotFound(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"c": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", ">0.1.0 <1.0.0", ocv1alpha1.UpgradeConstraintPolicyIgnore)
@@ -544,7 +656,7 @@ func buildFooClusterExtension(pkg, channel, version string, upgradeConstraintPol
 	}
 }
 
-type getPackageFunc func() (*declcfg.DeclarativeConfig, error)
+type getPackageFunc func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error)
 
 type staticCatalogWalker map[string]getPackageFunc
 
@@ -565,7 +677,10 @@ func (w staticCatalogWalker) WalkCatalogs(ctx context.Context, _ string, f Catal
 		if !options.LabelSelector.Matches(labels.Set(cat.ObjectMeta.Labels)) {
 			continue
 		}
-		fbc, fbcErr := v()
+		fbc, catCfg, fbcErr := v()
+		if catCfg != nil {
+			catCfg.DeepCopyInto(&cat.Spec)
+		}
 		if err := f(ctx, cat, fbc, fbcErr); err != nil {
 			return err
 		}
@@ -659,7 +774,9 @@ func TestInvalidClusterExtensionCatalogMatchExpressions(t *testing.T) {
 
 func TestInvalidClusterExtensionCatalogMatchLabelsName(t *testing.T) {
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return genPackage("foo"), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage("foo"), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := &ocv1alpha1.ClusterExtension{
@@ -679,7 +796,9 @@ func TestInvalidClusterExtensionCatalogMatchLabelsName(t *testing.T) {
 
 func TestInvalidClusterExtensionCatalogMatchLabelsValue(t *testing.T) {
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return genPackage("foo"), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage("foo"), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := &ocv1alpha1.ClusterExtension{
@@ -701,8 +820,12 @@ func TestClusterExtensionMatchLabel(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -716,8 +839,12 @@ func TestClusterExtensionNoMatchLabel(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, features.OperatorControllerFeatureGate, features.ForceSemverUpgradeConstraints, false)
 	pkgName := randPkg()
 	w := staticCatalogWalker{
-		"a": func() (*declcfg.DeclarativeConfig, error) { return &declcfg.DeclarativeConfig{}, nil },
-		"b": func() (*declcfg.DeclarativeConfig, error) { return genPackage(pkgName), nil },
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return &declcfg.DeclarativeConfig{}, nil, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), nil, nil
+		},
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, "", "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
@@ -726,4 +853,45 @@ func TestClusterExtensionNoMatchLabel(t *testing.T) {
 	_, _, _, err := r.Resolve(context.Background(), ce, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, fmt.Sprintf("no package %q found", pkgName))
+}
+
+func TestUnequalPriority(t *testing.T) {
+	pkgName := randPkg()
+	w := staticCatalogWalker{
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), &catalogd.ClusterCatalogSpec{Priority: 1}, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), &catalogd.ClusterCatalogSpec{Priority: 0}, nil
+		},
+	}
+	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
+
+	ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <=1.0.1", ocv1alpha1.UpgradeConstraintPolicyEnforce)
+	_, _, _, err := r.Resolve(context.Background(), ce, nil)
+	require.NoError(t, err)
+}
+
+func TestMultiplePriority(t *testing.T) {
+	pkgName := randPkg()
+	w := staticCatalogWalker{
+		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), &catalogd.ClusterCatalogSpec{Priority: 1}, nil
+		},
+		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), &catalogd.ClusterCatalogSpec{Priority: 0}, nil
+		},
+		"c": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
+			return genPackage(pkgName), &catalogd.ClusterCatalogSpec{Priority: 1}, nil
+		},
+	}
+	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
+
+	ce := buildFooClusterExtension(pkgName, "", ">=1.0.0 <=1.0.1", ocv1alpha1.UpgradeConstraintPolicyEnforce)
+	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "found in multiple catalogs: [a b c]")
+	assert.Nil(t, gotBundle)
+	assert.Nil(t, gotVersion)
+	assert.Nil(t, gotDeprecation)
 }


### PR DESCRIPTION
Fixes: #1117 

Lots of changes to the catalog test infrastructure, as I needed to include information about the catalog itself.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
