### PR TITLE
:bug: Update test

### DIFF
--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -838,7 +838,7 @@ func TestClusterExtensionMatchLabel(t *testing.T) {
 	pkgName := randPkg()
 	w := staticCatalogWalker{
 		"a": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
-			return &declcfg.DeclarativeConfig{}, nil, nil
+			return genPackage(pkgName), nil, nil
 		},
 		"b": func() (*declcfg.DeclarativeConfig, *catalogd.ClusterCatalogSpec, error) {
 			return genPackage(pkgName), nil, nil


### PR DESCRIPTION
Both catalogs should have a package available for the label selector to really demonstrate that it picks one of two catalogs

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
