### PR TITLE
🐛 Fix cache check

### DIFF
--- a/internal/catalogmetadata/cache/cache.go
+++ b/internal/catalogmetadata/cache/cache.go
@@ -119,7 +119,7 @@ func (fsc *filesystemCache) FetchCatalogContents(ctx context.Context, catalog *c
 	// this to be the same value, skip the write logic and return
 	// the cached contents
 	if data, ok := fsc.cacheDataByCatalogName[catalog.Name]; ok {
-		if data.ResolvedRef == catalog.Status.ResolvedSource.Image.Ref {
+		if data.ResolvedRef == catalog.Status.ResolvedSource.Image.ResolvedRef {
 			return os.DirFS(cacheDir), nil
 		}
 	}


### PR DESCRIPTION
# Description

There is a bug in the optimisation where we try to avoid writing, if another thread already updated the cache: I believe we should be checking `catalog.Status.ResolvedSource.Image.ResolvedRef` (includes sha) as in other places instead of `catalog.Status.ResolvedSource.Image.Ref`.

Related:
* #529
* #528

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
