### PR TITLE
🌱 Define a constant for the finaliser key

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -200,12 +200,10 @@ func main() {
 	}
 
 	clusterExtensionFinalizers := crfinalizer.NewFinalizers()
-	domain := ocv1alpha1.GroupVersion.Group
-	cleanupUnpackCacheKey := fmt.Sprintf("%s/cleanup-unpack-cache", domain)
-	if err := clusterExtensionFinalizers.Register(cleanupUnpackCacheKey, finalizerFunc(func(ctx context.Context, obj client.Object) (crfinalizer.Result, error) {
+	if err := clusterExtensionFinalizers.Register(controllers.ClusterExtensionCleanupUnpackCacheFinalizer, finalizerFunc(func(ctx context.Context, obj client.Object) (crfinalizer.Result, error) {
 		return crfinalizer.Result{}, os.RemoveAll(filepath.Join(unpacker.BaseCachePath, obj.GetName()))
 	})); err != nil {
-		setupLog.Error(err, "unable to register finalizer", "finalizerKey", cleanupUnpackCacheKey)
+		setupLog.Error(err, "unable to register finalizer", "finalizerKey", controllers.ClusterExtensionCleanupUnpackCacheFinalizer)
 		os.Exit(1)
 	}
 

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -57,6 +57,10 @@ import (
 	rukpaksource "github.com/operator-framework/operator-controller/internal/rukpak/source"
 )
 
+const (
+	ClusterExtensionCleanupUnpackCacheFinalizer = "olm.operatorframework.io/cleanup-unpack-cache"
+)
+
 // ClusterExtensionReconciler reconciles a ClusterExtension object
 type ClusterExtensionReconciler struct {
 	client.Client


### PR DESCRIPTION
# Description

Moving finaliser key to a constant instead of dynamically generating it. We do it the same way [in catalod](https://github.com/operator-framework/catalogd/blob/4a6f3160f5b809325f5b8747db5c250ac93ef837/internal/controllers/core/clustercatalog_controller.go#L43). Another finalisers will be added in #1207 in a similar way.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
