### PR TITLE
:seedling: Update to catalogd v0.26.0 and update e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/operator-framework/api v0.27.0
-	github.com/operator-framework/catalogd v0.23.0
+	github.com/operator-framework/catalogd v0.26.0
 	github.com/operator-framework/helm-operator-plugins v0.5.0
 	github.com/operator-framework/operator-registry v1.46.0
 	github.com/spf13/pflag v1.0.5
@@ -161,7 +161,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.2 // indirect
+	github.com/prometheus/client_golang v1.20.3 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11 h1:eT
 github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11/go.mod h1:EmVJt97N+pfWFsli/ipXTBZqSG5F5KGQhm3c3IsGq1o=
 github.com/operator-framework/api v0.27.0 h1:OrVaGKZJvbZo58HTv2guz7aURkhVKYhFqZ/6VpifiXI=
 github.com/operator-framework/api v0.27.0/go.mod h1:lg2Xx+S8NQWGYlEOvFwQvH46E5EK5IrAIL7HWfAhciM=
-github.com/operator-framework/catalogd v0.23.0 h1:LAuiYuFftCQp6Jvol9pWbyvOY04QP7xH0dcf9ZO9RcE=
-github.com/operator-framework/catalogd v0.23.0/go.mod h1:OFG4YhsIctwdi97m2pyrsafjPBgIrXpP6gfK1nNIJjc=
+github.com/operator-framework/catalogd v0.26.0 h1:RDzNEv631o7WgkXGfFrOCiFBaBMwK621/vinRuOS2LI=
+github.com/operator-framework/catalogd v0.26.0/go.mod h1:pR03BacyPJPeVk6KM5OW6CLOoqkHzvyncQSZmiO3+IQ=
 github.com/operator-framework/helm-operator-plugins v0.5.0 h1:qph2OoECcI9mpuUBtOsWOMgvpx52mPTTSvzVxICsT04=
 github.com/operator-framework/helm-operator-plugins v0.5.0/go.mod h1:yVncrZ/FJNqedMil+055fk6sw8aMKRrget/AqGM0ig0=
 github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=
@@ -550,8 +550,8 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
-github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjsejTMiXIyjg=
-github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.3 h1:oPksm4K8B+Vt35tUhw6GbSNSgVlVSBH0qELP/7u83l4=
+github.com/prometheus/client_golang v1.20.3/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -673,7 +673,7 @@ func (w staticCatalogWalker) WalkCatalogs(ctx context.Context, _ string, f Catal
 			ObjectMeta: metav1.ObjectMeta{
 				Name: k,
 				Labels: map[string]string{
-					"olm.operatorframework.io/name": k,
+					"olm.operatorframework.io/metadata.name": k,
 				},
 			},
 		}
@@ -852,7 +852,7 @@ func TestClusterExtensionMatchLabel(t *testing.T) {
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, []string{}, "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
-	ce.Spec.Source.Catalog.Selector.MatchLabels = map[string]string{"olm.operatorframework.io/name": "b"}
+	ce.Spec.Source.Catalog.Selector.MatchLabels = map[string]string{"olm.operatorframework.io/metadata.name": "b"}
 
 	_, _, _, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
@@ -871,7 +871,7 @@ func TestClusterExtensionNoMatchLabel(t *testing.T) {
 	}
 	r := CatalogResolver{WalkCatalogsFunc: w.WalkCatalogs}
 	ce := buildFooClusterExtension(pkgName, []string{}, "", ocv1alpha1.UpgradeConstraintPolicyEnforce)
-	ce.Spec.Source.Catalog.Selector.MatchLabels = map[string]string{"olm.operatorframework.io/name": "a"}
+	ce.Spec.Source.Catalog.Selector.MatchLabels = map[string]string{"olm.operatorframework.io/metadata.name": "a"}
 
 	_, _, _, err := r.Resolve(context.Background(), ce, nil)
 	require.Error(t, err)

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -47,7 +47,7 @@ kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
 # Wait for the rollout, and then wait for the deployment to be Available
 kubectl_wait_rollout "olmv1-system" "deployment/catalogd-controller-manager" "60s"
-kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
+kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 
 if [[ "${install_default_catalogs,,}" != "false" ]]; then
     kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/default-catalogs.yaml"

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -231,7 +231,7 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 			Catalog: &ocv1alpha1.CatalogSource{
 				PackageName: "prometheus",
 				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{"olm.operatorframework.io/name": extensionCatalog.Name},
+					MatchLabels: map[string]string{"olm.operatorframework.io/metadata.name": extensionCatalog.Name},
 				},
 			},
 		},
@@ -548,7 +548,7 @@ func TestClusterExtensionInstallReResolvesWhenCatalogIsPatched(t *testing.T) {
 				Selector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "olm.operatorframework.io/name",
+							Key:      "olm.operatorframework.io/metadata.name",
 							Operator: metav1.LabelSelectorOpIn,
 							Values:   []string{extensionCatalog.Name},
 						},
@@ -652,7 +652,7 @@ func TestClusterExtensionInstallReResolvesWhenNewCatalog(t *testing.T) {
 			Catalog: &ocv1alpha1.CatalogSource{
 				PackageName: "prometheus",
 				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{"olm.operatorframework.io/name": extensionCatalog.Name},
+					MatchLabels: map[string]string{"olm.operatorframework.io/metadata.name": extensionCatalog.Name},
 				},
 			},
 		},
@@ -713,8 +713,8 @@ func TestClusterExtensionInstallReResolvesWhenNewCatalog(t *testing.T) {
 		assert.Contains(ct, cond.Message, "resolved to")
 		assert.Equal(ct,
 			&ocv1alpha1.ClusterExtensionResolutionStatus{Bundle: &ocv1alpha1.BundleMetadata{
-				Name:    "prometheus-operator.1.2.0",
-				Version: "1.2.0",
+				Name:    "prometheus-operator.2.0.0",
+				Version: "2.0.0",
 			}},
 			clusterExtension.Status.Resolution,
 		)
@@ -734,7 +734,7 @@ func TestClusterExtensionInstallReResolvesWhenManagedContentChanged(t *testing.T
 			Catalog: &ocv1alpha1.CatalogSource{
 				PackageName: "prometheus",
 				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{"olm.operatorframework.io/name": extensionCatalog.Name},
+					MatchLabels: map[string]string{"olm.operatorframework.io/metadata.name": extensionCatalog.Name},
 				},
 			},
 		},
@@ -806,7 +806,7 @@ func TestClusterExtensionRecoversFromInitialInstallFailedWhenFailureFixed(t *tes
 			Catalog: &ocv1alpha1.CatalogSource{
 				PackageName: "prometheus",
 				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{"olm.operatorframework.io/name": extensionCatalog.Name},
+					MatchLabels: map[string]string{"olm.operatorframework.io/metadata.name": extensionCatalog.Name},
 				},
 			},
 		},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,11 +41,13 @@ func TestMain(m *testing.M) {
 // createTestCatalog will create a new catalog on the test cluster, provided
 // the context, catalog name, and the image reference. It returns the created catalog
 // or an error if any errors occurred while creating the catalog.
+// Note that catalogd will automatically create the label:
+//
+//	"olm.operatorframework.io/metadata.name": name
 func createTestCatalog(ctx context.Context, name string, imageRef string) (*catalogd.ClusterCatalog, error) {
 	catalog := &catalogd.ClusterCatalog{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"olm.operatorframework.io/name": name},
+			Name: name,
 		},
 		Spec: catalogd.ClusterCatalogSpec{
 			Source: catalogd.CatalogSource{


### PR DESCRIPTION
Fix #1115

* Use proper labels from catalogd
* Add better deployment checking
* Fix broken test

This test seems broken, it's supposed to resolve again after updating to V2. The test implies that this should be the 2.0.0 version, but it's checking against 1.2.0 (which was the original version installed).

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
