### PR TITLE
🐛 fix: separate unpacked bundles by name

### DIFF
--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -247,6 +247,7 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1alp
 	setResolvedStatusConditionSuccess(ext, fmt.Sprintf("resolved to %q", resolvedBundle.Image))
 
 	bundleSource := &rukpaksource.BundleSource{
+		Name: ext.GetName(),
 		Type: rukpaksource.SourceTypeImage,
 		Image: &rukpaksource.ImageSource{
 			Ref: resolvedBundle.Image,


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Fixes a bug caused by not setting the `BundleSource.Name` during unpack. Without the fix, it means that:

1.  All cluster extension unpacking is happening in the same directory
1. Because of (1), only the most recently reconciled bundle will have its FS extracted at once.
1. Because of (2), when a ClusterExtension reconciles it has to re-pull and re-unpack its image if another ClusterExtension has reconciled in the meantime.
1. (Not a problem today) If we turned on concurrent reconciles, then things would likely break even harder because the unpacker would be racing to delete the what it thinks are unused unpack paths while other reconciles are writing to them for other ClusterExtensions.


<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
