### PR TITLE
:seedling: Add golang version check to verify

### DIFF
--- a/hack/tools/check-go-version.sh
+++ b/hack/tools/check-go-version.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+GO_VER=$1
+OLDIFS="${IFS}"
+IFS='.' INPUT_VERS=(${GO_VER})
+IFS="${OLDIFS}"
+
+if [ ${#INPUT_VERS[*]} -ne 3 -a ${#INPUT_VERS[*]} -ne 2 ]; then
+    echo "Invalid go version: ${GO_VER}"
+    exit 1
+fi
+
+GO_MAJOR=${INPUT_VERS[0]}
+GO_MINOR=${INPUT_VERS[1]}
+GO_PATCH=${INPUT_VERS[2]}
+
+check_version () {
+    whole=$1
+    file=$2
+    OLDIFS="${IFS}"
+    IFS='.' ver=(${whole})
+    IFS="${OLDIFS}"
+
+    if [ ${#ver[*]} -eq 2 ] ; then
+        if [ ${ver[0]} -gt ${GO_MAJOR} ] ; then
+            echo "Bad golang version ${whole} in ${file} (expected ${GO_VER} or less)"
+            exit 1
+        fi
+        if [ ${ver[1]} -gt ${GO_MINOR} ] ; then
+            echo "Bad golang version ${whole} in ${file} (expected ${GO_VER} or less)"
+            exit 1
+        fi
+        echo "Version ${whole} in ${file} is good"
+        return
+    fi
+    if [ ${#INPUT_VERS[*]} -eq 2 ]; then
+        echo "Bad golang version ${whole} in ${file} (expecting only major.minor version)"
+        exit 1
+    fi
+    if [ ${#ver[*]} -ne 3 ] ; then
+        echo "Badly formatted golang version ${whole} in ${file}"
+        exit 1
+    fi
+
+    if [ ${ver[0]} -gt ${GO_MAJOR} ]; then
+        echo "Bad golang version ${whole} in ${file} (expected ${GO_VER} or less)"
+        exit 1
+    fi
+    if [ ${ver[1]} -gt ${GO_MINOR} ]; then
+        echo "Bad golang version ${whole} in ${file} (expected ${GO_VER} or less)"
+        exit 1
+    fi
+    if [ ${ver[1]} -eq ${GO_MINOR} -a ${ver[2]} -gt ${GO_PATCH} ]; then
+        echo "Bad golang version ${whole} in ${file} (expected ${GO_VER} or less)"
+        exit 1
+    fi
+    echo "Version ${whole} in ${file} is good"
+}
+
+for f in $(find . -name "*.mod"); do
+    v=$(sed -En 's/^go (.*)$/\1/p' ${f})
+    if [ -z ${v} ]; then
+        echo "Skipping ${f}: no version found"
+    else
+        check_version ${v} ${f}
+    fi
+done


### PR DESCRIPTION
This makes sure that we are not exceeding our golang version Supported golang version is 1.22.5

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
