### PR TITLE
🌱 switch back to use of trusted CA, add extra test for mirror registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,8 @@ test-unit: $(SETUP_ENVTEST) #HELP Run the unit tests
                 $(UNIT_TEST_DIRS) \
                 -test.gocoverdir=$(ROOT_DIR)/coverage/unit
 
-E2E_REGISTRY_CERT_REF := ClusterIssuer/olmv1-ca # By default, we'll use a trusted CA for the registry.
 image-registry: ## Setup in-cluster image registry
-	./hack/test/image-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_CERT_REF)
+	./hack/test/image-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME)
 
 build-push-e2e-catalog: ## Build the testdata catalog used for e2e tests and push it to the image registry
 	./hack/test/build-push-e2e-catalog.sh $(E2E_REGISTRY_NAMESPACE) $(LOCAL_REGISTRY_HOST)/$(E2E_TEST_CATALOG_V1)
@@ -180,7 +179,6 @@ build-push-e2e-catalog: ## Build the testdata catalog used for e2e tests and pus
 test-e2e: KIND_CLUSTER_NAME := operator-controller-e2e
 test-e2e: KUSTOMIZE_BUILD_DIR := config/overlays/e2e
 test-e2e: GO_BUILD_FLAGS := -cover
-test-e2e: E2E_REGISTRY_CERT_REF := Issuer/selfsigned-issuer
 test-e2e: run image-registry build-push-e2e-catalog registry-load-bundles e2e e2e-coverage kind-clean #HELP Run e2e test suite on local kind cluster
 
 .PHONY: extension-developer-e2e

--- a/config/components/registries-conf/registries_conf_configmap.yaml
+++ b/config/components/registries-conf/registries_conf_configmap.yaml
@@ -6,6 +6,5 @@ metadata:
 data:
   registries.conf: |
     [[registry]]
-    prefix = "docker-registry.operator-controller-e2e.svc.cluster.local:5000"
-    insecure = true
+    prefix = "mirrored-registry.operator-controller-e2e.svc.cluster.local:5000"
     location = "docker-registry.operator-controller-e2e.svc.cluster.local:5000"

--- a/hack/test/image-registry.sh
+++ b/hack/test/image-registry.sh
@@ -16,7 +16,7 @@ Argument Descriptions:
     format of 'Issuer/<issuer-name>' or 'ClusterIssuer/<cluster-issuer-name>'
 "
 
-if [[ "$#" -ne 3 ]]; then
+if [[ "$#" -ne 2 ]]; then
   echo "Illegal number of arguments passed"
   echo "${help}"
   exit 1
@@ -24,23 +24,12 @@ fi
 
 namespace=$1
 name=$2
-certRef=$3
-
-echo "CERT_REF: ${certRef}"
 
 kubectl apply -f - << EOF
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ${namespace}
----
- apiVersion: cert-manager.io/v1
- kind: Issuer
- metadata:
-   name: selfsigned-issuer
-   namespace: ${namespace}
- spec:
-   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -57,8 +46,8 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: ${certRef#*/}
-    kind: ${certRef%/*}
+    name: olmv1-ca
+    kind: ClusterIssuer
     group: cert-manager.io
 ---
 apiVersion: apps/v1

--- a/testdata/catalogs/test-catalog-v1/catalog.yaml
+++ b/testdata/catalogs/test-catalog-v1/catalog.yaml
@@ -48,3 +48,24 @@ properties:
     value:
       packageName: prometheus
       version: 1.2.0
+
+---
+schema: olm.package
+name: prometheus-mirrored
+defaultChannel: beta
+---
+schema: olm.channel
+name: beta
+package: prometheus-mirrored
+entries:
+  - name: prometheus-mirrored-operator.1.2.0
+---
+schema: olm.bundle
+name: prometheus-mirrored-operator.1.2.0
+package: prometheus-mirrored
+image: mirrored-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/prometheus-operator:v1.2.0
+properties:
+  - type: olm.package
+    value:
+      packageName: prometheus-mirrored
+      version: 1.2.0


### PR DESCRIPTION
This PR is intended to (partially) resolve issues around the complexity of implementing an e2e test that proves `/etc/containers/registries.conf` is honored.

It:
- puts everything back to a registry with a trusted cert across the board
- changes `registries.conf` in the standard e2e to map from a "mirrored-registry" to "docker-registry"
- adds a new package in the shared catalog called "prometheus-mirrored" whose bundle ref uses the "mirror-registry" domain
- updates the `ClusterExtensionInstallRegistry` e2e test to verify installs of both "prometheus" and the new "prometheus-mirrored" package (the latter would fail without the mapping config)

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
