### PR TITLE
🌱 Fix `http.DefaultClient`

### DIFF
--- a/internal/catalogmetadata/cache/cache_test.go
+++ b/internal/catalogmetadata/cache/cache_test.go
@@ -212,8 +212,9 @@ func TestFilesystemCache(t *testing.T) {
 			cacheDir := t.TempDir()
 			tt.tripper.content = make(fstest.MapFS)
 			maps.Copy(tt.tripper.content, tt.contents)
-			httpClient := http.DefaultClient
-			httpClient.Transport = tt.tripper
+			httpClient := &http.Client{
+				Transport: tt.tripper,
+			}
 			c := cache.NewFilesystemCache(cacheDir, func() (*http.Client, error) {
 				return httpClient, nil
 			})


### PR DESCRIPTION
# Description

We do not want to modify `http.DefaultClient` because it can cause undesired effects in other places.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
