### PR TITLE
:sparkles: Improving the error when fail to find the authFilePath

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -322,7 +322,7 @@ func authFilePathIfPresent(logger logr.Logger) string {
 		return ""
 	}
 	if err != nil {
-		logger.Error(err, "Errors accessing the file in", "path", authFilePath)
+		logger.Error(err, "unable to access the global auth file", "path", authFilePath)
 		os.Exit(1)
 	}
 	return authFilePath

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -322,7 +322,7 @@ func authFilePathIfPresent(logger logr.Logger) string {
 		return ""
 	}
 	if err != nil {
-		logger.Error(err, "could not stat auth file path", "path", authFilePath)
+		logger.Error(err, "Errors accessing the file in", "path", authFilePath)
 		os.Exit(1)
 	}
 	return authFilePath


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
