### PR TITLE
🌱 Refactor `catalogmetadata` client and cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -222,10 +222,10 @@ func main() {
 		setupLog.Error(err, "unable to create catalogs cache directory")
 		os.Exit(1)
 	}
-	cacheFetcher := cache.NewFilesystemCache(catalogsCachePath, func() (*http.Client, error) {
+	catalogClientBackend := cache.NewFilesystemCache(catalogsCachePath)
+	catalogClient := catalogclient.New(catalogClientBackend, func() (*http.Client, error) {
 		return httputil.BuildHTTPClient(certPoolWatcher)
 	})
-	catalogClient := catalogclient.New(cacheFetcher)
 
 	resolver := &resolve.CatalogResolver{
 		WalkCatalogsFunc: resolve.CatalogWalker(
@@ -284,7 +284,7 @@ func main() {
 
 	if err = (&controllers.ClusterCatalogReconciler{
 		Client: cl,
-		Cache:  cacheFetcher,
+		Cache:  catalogClientBackend,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCatalog")
 		os.Exit(1)

--- a/internal/catalogmetadata/client/client.go
+++ b/internal/catalogmetadata/client/client.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net/http"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,39 +15,62 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 )
 
-// Fetcher is an interface to facilitate fetching
-// catalog contents from catalogd.
-type Fetcher interface {
-	// FetchCatalogContents fetches contents from the catalogd HTTP
-	// server for the catalog provided. It returns a fs.FS containing the FBC contents.
-	// Each sub directory contains FBC for a single package
-	// and the directory name is package name.
-	// Returns an error if any occur.
-	FetchCatalogContents(ctx context.Context, catalog *catalogd.ClusterCatalog) (fs.FS, error)
+type Cache interface {
+	// Get returns cache for a specified catalog name and version (resolvedRef).
+	//
+	// Method behaviour is as follows:
+	//   - If cache exists, it returns a non-nil fs.FS and nil error
+	//   - If cache doesn't exist, it returns nil fs.FS and nil error
+	//   - If there was an error during cache population,
+	//     it returns nil fs.FS and the error from the cache population.
+	//     In other words - cache population errors are also cached.
+	Get(catalogName, resolvedRef string) (fs.FS, error)
+
+	// Put writes content from source or from errToCache in the cache backend
+	// for a specified catalog name and version (resolvedRef).
+	//
+	// Method behaviour is as follows:
+	//   - If successfully populated cache for catalogName and resolvedRef exists,
+	//     errToCache is ignored and existing cache returned with nil error
+	//   - If existing cache for catalogName and resolvedRef exists but
+	//     is populated with an error, update the cache with either
+	//     new content from source or errToCache.
+	//   - If cache doesn't exist, populate it with either new content
+	//     from source or errToCache.
+	Put(catalogName, resolvedRef string, source io.Reader, errToCache error) (fs.FS, error)
 }
 
-func New(fetcher Fetcher) *Client {
+func New(cache Cache, httpClient func() (*http.Client, error)) *Client {
 	return &Client{
-		fetcher: fetcher,
+		cache:      cache,
+		httpClient: httpClient,
 	}
 }
 
 // Client is reading catalog metadata
 type Client struct {
-	// fetcher is the Fetcher to use for fetching catalog contents
-	fetcher Fetcher
+	cache      Cache
+	httpClient func() (*http.Client, error)
 }
 
 func (c *Client) GetPackage(ctx context.Context, catalog *catalogd.ClusterCatalog, pkgName string) (*declcfg.DeclarativeConfig, error) {
-	// if the catalog has not been successfully unpacked, report an error. This ensures that our
-	// reconciles are deterministic and wait for all desired catalogs to be ready.
-	if !meta.IsStatusConditionPresentAndEqual(catalog.Status.Conditions, catalogd.TypeServing, metav1.ConditionTrue) {
-		return nil, fmt.Errorf("catalog %q is not being served", catalog.Name)
+	if err := validateCatalog(catalog); err != nil {
+		return nil, err
 	}
 
-	catalogFsys, err := c.fetcher.FetchCatalogContents(ctx, catalog)
+	catalogFsys, err := c.cache.Get(catalog.Name, catalog.Status.ResolvedSource.Image.ResolvedRef)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching catalog contents: %v", err)
+		return nil, fmt.Errorf("error retrieving catalog cache: %v", err)
+	}
+	if catalogFsys == nil {
+		// TODO: https://github.com/operator-framework/operator-controller/pull/1284
+		// For now we are still populating cache (if absent) on-demand,
+		// but we might end up just returning a "cache not found" error here
+		// once we implement cache population in the controller.
+		catalogFsys, err = c.PopulateCache(ctx, catalog)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching catalog contents: %v", err)
+		}
 	}
 
 	pkgFsys, err := fs.Sub(catalogFsys, pkgName)
@@ -64,4 +89,66 @@ func (c *Client) GetPackage(ctx context.Context, catalog *catalogd.ClusterCatalo
 		return &declcfg.DeclarativeConfig{}, nil
 	}
 	return pkgFBC, nil
+}
+
+func (c *Client) PopulateCache(ctx context.Context, catalog *catalogd.ClusterCatalog) (fs.FS, error) {
+	if err := validateCatalog(catalog); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.doRequest(ctx, catalog)
+	if err != nil {
+		// Any errors from the http request we want to cache
+		// so later on cache get they can be bubbled up to the user.
+		return c.cache.Put(catalog.Name, catalog.Status.ResolvedSource.Image.ResolvedRef, nil, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errToCache := fmt.Errorf("error: received unexpected response status code %d", resp.StatusCode)
+		return c.cache.Put(catalog.Name, catalog.Status.ResolvedSource.Image.ResolvedRef, nil, errToCache)
+	}
+
+	return c.cache.Put(catalog.Name, catalog.Status.ResolvedSource.Image.ResolvedRef, resp.Body, nil)
+}
+
+func (c *Client) doRequest(ctx context.Context, catalog *catalogd.ClusterCatalog) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, catalog.Status.ContentURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error forming request: %v", err)
+	}
+
+	client, err := c.httpClient()
+	if err != nil {
+		return nil, fmt.Errorf("error getting HTTP client: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing request: %v", err)
+	}
+
+	return resp, nil
+}
+
+func validateCatalog(catalog *catalogd.ClusterCatalog) error {
+	if catalog == nil {
+		return fmt.Errorf("error: provided catalog must be non-nil")
+	}
+
+	// if the catalog has not been successfully unpacked, report an error. This ensures that our
+	// reconciles are deterministic and wait for all desired catalogs to be ready.
+	if !meta.IsStatusConditionPresentAndEqual(catalog.Status.Conditions, catalogd.TypeServing, metav1.ConditionTrue) {
+		return fmt.Errorf("catalog %q is not being served", catalog.Name)
+	}
+
+	if catalog.Status.ResolvedSource == nil {
+		return fmt.Errorf("error: catalog %q has a nil status.resolvedSource value", catalog.Name)
+	}
+
+	if catalog.Status.ResolvedSource.Image == nil {
+		return fmt.Errorf("error: catalog %q has a nil status.resolvedSource.image value", catalog.Name)
+	}
+
+	return nil
 }

--- a/internal/catalogmetadata/client/client_test.go
+++ b/internal/catalogmetadata/client/client_test.go
@@ -3,7 +3,10 @@ package client_test
 import (
 	"context"
 	"errors"
+	"io"
 	"io/fs"
+	"net/http"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -16,99 +19,289 @@ import (
 	catalogClient "github.com/operator-framework/operator-controller/internal/catalogmetadata/client"
 )
 
-func TestClientNew(t *testing.T) {
+func defaultCatalog() *catalogd.ClusterCatalog {
+	return &catalogd.ClusterCatalog{
+		ObjectMeta: metav1.ObjectMeta{Name: "catalog-1"},
+		Status: catalogd.ClusterCatalogStatus{
+			Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}},
+			ResolvedSource: &catalogd.ResolvedCatalogSource{Image: &catalogd.ResolvedImageSource{
+				ResolvedRef: "fake/catalog@sha256:fakesha",
+			}},
+			ContentURL: "https://fake-url.svc.local/all.json",
+		},
+	}
+}
+
+func TestClientGetPackage(t *testing.T) {
 	testFS := fstest.MapFS{
 		"pkg-present/olm.package/pkg-present.json": &fstest.MapFile{Data: []byte(`{"schema": "olm.package","name": "pkg-present"}`)},
 	}
 
 	type testCase struct {
 		name    string
-		catalog *catalogd.ClusterCatalog
+		catalog func() *catalogd.ClusterCatalog
 		pkgName string
-		fetcher catalogClient.Fetcher
+		cache   catalogClient.Cache
 		assert  func(*testing.T, *declcfg.DeclarativeConfig, error)
 	}
 	for _, tc := range []testCase{
 		{
-			name:    "not unpacked",
-			catalog: &catalogd.ClusterCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1"}},
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) { return testFS, nil }),
+			name: "not unpacked",
+			catalog: func() *catalogd.ClusterCatalog {
+				return &catalogd.ClusterCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1"}}
+			},
 			assert: func(t *testing.T, dc *declcfg.DeclarativeConfig, err error) {
 				assert.ErrorContains(t, err, `catalog "catalog-1" is not being served`)
 			},
 		},
 		{
-			name: "unpacked, fetcher returns error",
-			catalog: &catalogd.ClusterCatalog{
-				Status: catalogd.ClusterCatalogStatus{Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}}},
-			},
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) { return nil, errors.New("fetch error") }),
+			name:    "unpacked, cache returns error",
+			catalog: defaultCatalog,
+			cache:   &fakeCache{getErr: errors.New("fetch error")},
 			assert: func(t *testing.T, dc *declcfg.DeclarativeConfig, err error) {
-				assert.ErrorContains(t, err, `error fetching catalog contents: fetch error`)
+				assert.ErrorContains(t, err, `error retrieving catalog cache`)
 			},
 		},
 		{
-			name: "unpacked, invalid package path",
-			catalog: &catalogd.ClusterCatalog{
-				Status: catalogd.ClusterCatalogStatus{Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}}},
-			},
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) { return testFS, nil }),
+			name:    "unpacked, invalid package path",
+			catalog: defaultCatalog,
+			cache:   &fakeCache{getFS: testFS},
 			pkgName: "/",
 			assert: func(t *testing.T, dc *declcfg.DeclarativeConfig, err error) {
 				assert.ErrorContains(t, err, `error getting package "/"`)
 			},
 		},
 		{
-			name: "unpacked, package missing",
-			catalog: &catalogd.ClusterCatalog{
-				Status: catalogd.ClusterCatalogStatus{Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}}},
-			},
+			name:    "unpacked, package missing",
+			catalog: defaultCatalog,
 			pkgName: "pkg-missing",
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) { return testFS, nil }),
+			cache:   &fakeCache{getFS: testFS},
 			assert: func(t *testing.T, fbc *declcfg.DeclarativeConfig, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, &declcfg.DeclarativeConfig{}, fbc)
 			},
 		},
 		{
-			name: "unpacked, invalid package present",
-			catalog: &catalogd.ClusterCatalog{
-				Status: catalogd.ClusterCatalogStatus{Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}}},
-			},
+			name:    "unpacked, invalid package present",
+			catalog: defaultCatalog,
 			pkgName: "invalid-pkg-present",
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) {
-				return fstest.MapFS{
-					"invalid-pkg-present/olm.package/invalid-pkg-present.json": &fstest.MapFile{Data: []byte(`{"schema": "olm.package","name": 12345}`)},
-				}, nil
-			}),
+			cache: &fakeCache{getFS: fstest.MapFS{
+				"invalid-pkg-present/olm.package/invalid-pkg-present.json": &fstest.MapFile{Data: []byte(`{"schema": "olm.package","name": 12345}`)},
+			}},
 			assert: func(t *testing.T, fbc *declcfg.DeclarativeConfig, err error) {
 				assert.ErrorContains(t, err, `error loading package "invalid-pkg-present"`)
 				assert.Nil(t, fbc)
 			},
 		},
 		{
-			name: "unpacked, package present",
-			catalog: &catalogd.ClusterCatalog{
-				Status: catalogd.ClusterCatalogStatus{Conditions: []metav1.Condition{{Type: catalogd.TypeServing, Status: metav1.ConditionTrue}}},
-			},
+			name:    "unpacked, package present",
+			catalog: defaultCatalog,
 			pkgName: "pkg-present",
-			fetcher: fetcherFunc(func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error) { return testFS, nil }),
+			cache:   &fakeCache{getFS: testFS},
 			assert: func(t *testing.T, fbc *declcfg.DeclarativeConfig, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, &declcfg.DeclarativeConfig{Packages: []declcfg.Package{{Schema: declcfg.SchemaPackage, Name: "pkg-present"}}}, fbc)
 			},
 		},
+		{
+			name:    "cache unpopulated",
+			catalog: defaultCatalog,
+			pkgName: "pkg-present",
+			cache: &fakeCache{putFunc: func(source string, errToCache error) (fs.FS, error) {
+				return testFS, nil
+			}},
+			assert: func(t *testing.T, fbc *declcfg.DeclarativeConfig, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, &declcfg.DeclarativeConfig{Packages: []declcfg.Package{{Schema: declcfg.SchemaPackage, Name: "pkg-present"}}}, fbc)
+			},
+		},
+		{
+			name:    "cache unpopulated and fails to populate",
+			catalog: defaultCatalog,
+			pkgName: "pkg-present",
+			cache:   &fakeCache{putErr: errors.New("fake cache put error")},
+			assert: func(t *testing.T, fbc *declcfg.DeclarativeConfig, err error) {
+				assert.Nil(t, fbc)
+				assert.ErrorContains(t, err, "error fetching catalog contents")
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := catalogClient.New(tc.fetcher)
-			fbc, err := c.GetPackage(context.Background(), tc.catalog, tc.pkgName)
+			ctx := context.Background()
+
+			c := catalogClient.New(tc.cache, func() (*http.Client, error) {
+				return &http.Client{
+					// This is to prevent actual network calls
+					Transport: &fakeTripper{resp: &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}},
+				}, nil
+			})
+			fbc, err := c.GetPackage(ctx, tc.catalog(), tc.pkgName)
 			tc.assert(t, fbc, err)
 		})
 	}
 }
 
-type fetcherFunc func(context.Context, *catalogd.ClusterCatalog) (fs.FS, error)
+func TestClientPopulateCache(t *testing.T) {
+	testFS := fstest.MapFS{
+		"pkg-present/olm.package/pkg-present.json": &fstest.MapFile{Data: []byte(`{"schema": "olm.package","name": "pkg-present"}`)},
+	}
 
-func (f fetcherFunc) FetchCatalogContents(ctx context.Context, catalog *catalogd.ClusterCatalog) (fs.FS, error) {
-	return f(ctx, catalog)
+	type testCase struct {
+		name               string
+		catalog            func() *catalogd.ClusterCatalog
+		httpClient         func() (*http.Client, error)
+		putFuncConstructor func(t *testing.T) func(source string, errToCache error) (fs.FS, error)
+		assert             func(t *testing.T, fs fs.FS, err error)
+	}
+	for _, tt := range []testCase{
+		{
+			name:    "cache unpopulated, successful http request",
+			catalog: defaultCatalog,
+			httpClient: func() (*http.Client, error) {
+				return &http.Client{
+					// This is to prevent actual network calls
+					Transport: &fakeTripper{resp: &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("fake-success-response-body")),
+					}},
+				}, nil
+			},
+			assert: func(t *testing.T, fs fs.FS, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, testFS, fs)
+			},
+			putFuncConstructor: func(t *testing.T) func(source string, errToCache error) (fs.FS, error) {
+				return func(source string, errToCache error) (fs.FS, error) {
+					assert.Equal(t, "fake-success-response-body", source)
+					assert.NoError(t, errToCache)
+					return testFS, errToCache
+				}
+			},
+		},
+		{
+			name: "not unpacked",
+			catalog: func() *catalogd.ClusterCatalog {
+				return &catalogd.ClusterCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1"}}
+			},
+			assert: func(t *testing.T, fs fs.FS, err error) {
+				assert.Nil(t, fs)
+				assert.ErrorContains(t, err, `catalog "catalog-1" is not being served`)
+			},
+		},
+		{
+			name:    "cache unpopulated, error on getting a http client",
+			catalog: defaultCatalog,
+			httpClient: func() (*http.Client, error) {
+				return nil, errors.New("fake error getting a http client")
+			},
+			putFuncConstructor: func(t *testing.T) func(source string, errToCache error) (fs.FS, error) {
+				return func(source string, errToCache error) (fs.FS, error) {
+					assert.Empty(t, source)
+					assert.Error(t, errToCache)
+					return nil, errToCache
+				}
+			},
+			assert: func(t *testing.T, fs fs.FS, err error) {
+				assert.Nil(t, fs)
+				assert.ErrorContains(t, err, "error getting HTTP client")
+			},
+		},
+		{
+			name:    "cache unpopulated, error on http request",
+			catalog: defaultCatalog,
+			httpClient: func() (*http.Client, error) {
+				return &http.Client{
+					// This is to prevent actual network calls
+					Transport: &fakeTripper{err: errors.New("fake error on a http request")},
+				}, nil
+			},
+			putFuncConstructor: func(t *testing.T) func(source string, errToCache error) (fs.FS, error) {
+				return func(source string, errToCache error) (fs.FS, error) {
+					assert.Empty(t, source)
+					assert.Error(t, errToCache)
+					return nil, errToCache
+				}
+			},
+			assert: func(t *testing.T, fs fs.FS, err error) {
+				assert.Nil(t, fs)
+				assert.ErrorContains(t, err, "error performing request")
+			},
+		},
+		{
+			name:    "cache unpopulated, unexpected http status",
+			catalog: defaultCatalog,
+			httpClient: func() (*http.Client, error) {
+				return &http.Client{
+					// This is to prevent actual network calls
+					Transport: &fakeTripper{resp: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       io.NopCloser(strings.NewReader("fake-unexpected-code-response-body")),
+					}},
+				}, nil
+			},
+			putFuncConstructor: func(t *testing.T) func(source string, errToCache error) (fs.FS, error) {
+				return func(source string, errToCache error) (fs.FS, error) {
+					assert.Empty(t, source)
+					assert.Error(t, errToCache)
+					return nil, errToCache
+				}
+			},
+			assert: func(t *testing.T, fs fs.FS, err error) {
+				assert.Nil(t, fs)
+				assert.ErrorContains(t, err, "received unexpected response status code 500")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			cache := &fakeCache{}
+			if tt.putFuncConstructor != nil {
+				cache.putFunc = tt.putFuncConstructor(t)
+			}
+
+			c := catalogClient.New(cache, tt.httpClient)
+			fs, err := c.PopulateCache(ctx, tt.catalog())
+			tt.assert(t, fs, err)
+		})
+	}
+}
+
+type fakeCache struct {
+	getFS  fs.FS
+	getErr error
+
+	putFunc func(source string, errToCache error) (fs.FS, error)
+	putErr  error
+}
+
+func (c *fakeCache) Get(catalogName, resolvedRef string) (fs.FS, error) {
+	return c.getFS, c.getErr
+}
+
+func (c *fakeCache) Put(catalogName, resolvedRef string, source io.Reader, errToCache error) (fs.FS, error) {
+	if c.putFunc != nil {
+		buf := new(strings.Builder)
+		if source != nil {
+			io.Copy(buf, source) // nolint:errcheck
+		}
+		return c.putFunc(buf.String(), errToCache)
+	}
+	if c.putErr != nil {
+		return nil, c.putErr
+	}
+
+	return nil, errors.New("unexpected error")
+}
+
+type fakeTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (ft *fakeTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return ft.resp, ft.err
 }


### PR DESCRIPTION
# Description

It is now possible to cache errors occured on the cache population. This will be useful when we start proactively populating cache from `ClusterCatalogReconciler` instead of doing this on-demand.

This refactoring also moves the responsibility of performing network requests out of the cache backend into the client.

This is done in preparation for #1284


## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
