### PR TITLE
🐛 dynamicsource: fix race condition with wait and valid scheme

### DIFF
--- a/internal/contentmanager/source/dynamicsource.go
+++ b/internal/contentmanager/source/dynamicsource.go
@@ -139,7 +139,7 @@ func (dis *dynamicInformerSource) Start(ctx context.Context, q workqueue.TypedRa
 			close(dis.syncedChan)
 		})
 
-		_ = wait.PollUntilContextCancel(dis.informerCtx, time.Second, true, func(_ context.Context) (bool, error) {
+		_ = wait.PollUntilContextCancel(dis.informerCtx, time.Millisecond*100, true, func(_ context.Context) (bool, error) {
 			if sharedIndexInf.HasSynced() {
 				syncOnce()
 				return true, nil


### PR DESCRIPTION
Also decreasing 1 second poll interval to 100ms. The `HasSynced` check that repeats every interval simply locks mutexes and checks variables available in memory, so it is extremely fast and has low over head. This decreased the test's average time from >1000ms to ~250ms 

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
