### PR TITLE
✨ Fix a flake in upgrade e2e

### DIFF
--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -86,7 +86,7 @@ func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
 		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
 		assert.Equal(ct, ocv1alpha1.ReasonSuccess, cond.Reason)
 		assert.Contains(ct, cond.Message, "Installed bundle")
-		if assert.NotEmpty(ct, clusterExtension.Status.Install.Bundle) {
+		if assert.NotNil(ct, clusterExtension.Status.Install) {
 			assert.NotEmpty(ct, clusterExtension.Status.Install.Bundle.Version)
 		}
 	}, time.Minute, time.Second)


### PR DESCRIPTION
# Description

There is a potential for nil pointer dereference in the test. This change adds condition to check for nil.

Example failures:
* https://github.com/operator-framework/operator-controller/actions/runs/11168271140/job/31046293874?pr=1284

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
