### PR TITLE
🐛 pre-upgrade-setup.sh: use updated ClusterCatalog API

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -26,11 +26,10 @@ metadata:
   name: ${TEST_CLUSTER_CATALOG_NAME}
 spec:
   source:
-    type: image
+    type: Image
     image:
       ref: ${TEST_CATALOG_IMG}
       pollInterval: 24h
-      insecureSkipTLSVerify: true
 EOF
 
 kubectl apply -f - <<EOF
@@ -144,5 +143,5 @@ spec:
       name: upgrade-e2e
 EOF
 
-kubectl wait --for=condition=Unpacked --timeout=60s ClusterCatalog $TEST_CLUSTER_CATALOG_NAME
+kubectl wait --for=condition=Serving --timeout=60s ClusterCatalog $TEST_CLUSTER_CATALOG_NAME
 kubectl wait --for=condition=Installed --timeout=60s ClusterExtension $TEST_CLUSTER_EXTENSION_NAME


### PR DESCRIPTION
Fix the upgrade-e2e

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
