### PR TITLE
:book: fix public api links

### DIFF
--- a/docs/project/public-api.md
+++ b/docs/project/public-api.md
@@ -2,9 +2,9 @@
 The public API of OLM v1 is as follows:
 
 - Kubernetes APIs. For more information on these APIs, see:
-    - [operator-controller API reference](./api/operator-controller-api-reference.md)
-    - [catalogd API reference](./api/catalogd-api-reference.md)
-- `Catalogd` web server. For more information on what this includes, see the [catalogd web server documentation](./api/catalogd-webserver.md)
+    - [operator-controller API reference](../api-reference/operator-controller-api-reference.md)
+    - [catalogd API reference](../api-reference/catalogd-api-reference.md)
+- `Catalogd` web server. For more information on what this includes, see the [catalogd web server documentation](../api-reference/catalogd-webserver.md)
 
 !!! warning
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

mkdocs build was reporting some broken links in the public-api page. This fixes them up =D

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
