### PR TITLE
🐛 Fix pulling signed images

### DIFF
--- a/internal/rukpak/source/containers_image.go
+++ b/internal/rukpak/source/containers_image.go
@@ -123,6 +123,12 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, bundle *BundleSour
 	//////////////////////////////////////////////////////
 	if _, err := copy.Image(ctx, policyContext, layoutRef, dockerRef, &copy.Options{
 		SourceCtx: srcCtx,
+		// We use the OCI layout as a temporary storage and
+		// pushing signatures for OCI images is not supported
+		// so we remove the source signatures when copying.
+		// Signature validation will still be performed
+		// accordingly to a provided policy context.
+		RemoveSignatures: true,
 	}); err != nil {
 		return nil, fmt.Errorf("error copying image: %w", err)
 	}


### PR DESCRIPTION
# Description

This fixes "pushing signatures for OCI images is not supported" error when working with signed source images.

If policy context requires signature validation for a registry we will still be performing it on pull, but we will be removing source signatures when copying into a temporary OCI layout for unpacking.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
