### PR TITLE
🐛  Use provided imgRef instead of always using canonical ref in containers image source

### DIFF
--- a/internal/rukpak/source/containers_image.go
+++ b/internal/rukpak/source/containers_image.go
@@ -80,7 +80,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, bundle *BundleSour
 	// copy.Image can concurrently pull all the layers.
 	//
 	//////////////////////////////////////////////////////
-	dockerRef, err := docker.NewReference(canonicalRef)
+	dockerRef, err := docker.NewReference(imgRef)
 	if err != nil {
 		return nil, fmt.Errorf("error creating source reference: %w", err)
 	}


### PR DESCRIPTION


<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
Fixes a bug where we always pulled image references using the canonical reference. Now we pull images using the reference provided to the source. Using only the canonical reference resulted in not respecting some mirroring configurations related to tags because we never used tag-based references.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
