### PR TITLE
:seedling: Make sure cert-manager is ready

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -42,7 +42,12 @@ function kubectl_wait_rollout() {
 }
 
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
+# Wait for cert-manager to be fully ready
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
+kubectl_wait "cert-manager" "deployment/cert-manager-cainjector" "60s"
+kubectl_wait "cert-manager" "deployment/cert-manager" "60s"
+kubectl wait mutatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
+kubectl wait validatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
 
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
 # Wait for the rollout, and then wait for the deployment to be Available


### PR DESCRIPTION
There have been a number of test and CI failures due to cert-manager not being ready. This adds additional checks to the deployments and specifically to the mutating webhook configuration.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
