### PR TITLE
:sparkles: Use a separate namespace for each e2e test

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
@@ -32,6 +33,7 @@ func TestMain(m *testing.M) {
 	cfg = ctrl.GetConfigOrDie()
 
 	var err error
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 	c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	utilruntime.Must(err)
 


### PR DESCRIPTION
Fixes #1307

Create and use a new namespace for every e2e test. This means that extension resources are placed in their own namespace. The tests deletes the namespace, and then waits until completion. This ensures that _most_ of an extension's resources are deleted.

It does guarantee that global resources (e.g. CRDs, CRs, CRBs) are deleted.

And would eventually allow the tests to be run in parallel (assuming the installed extensions allow for that).

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
