### PR TITLE
🐛 fix: resolve JSONPath error in caBundle readiness check by adding kubectl_wait_for_query function

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -41,13 +41,40 @@ function kubectl_wait_rollout() {
     kubectl rollout status --namespace="${namespace}" "${runtime}" --timeout="${timeout}"
 }
 
+function kubectl_wait_for_query() {
+    manifest=$1
+    query=$2
+    timeout=$3
+    poll_interval_in_seconds=$4
+
+    if [[ -z "$manifest" || -z "$query" || -z "$timeout" || -z "$poll_interval_in_seconds" ]]; then
+        echo "Error: Missing arguments."
+        echo "Usage: kubectl_wait_for_query <manifest> <query> <timeout> <poll_interval_in_seconds>"
+        exit 1
+    fi
+
+    start_time=$(date +%s)
+    while true; do
+        val=$(kubectl get "${manifest}" -o jsonpath="${query}" 2>/dev/null || echo "")
+        if [[ -n "${val}" ]]; then
+            echo "${manifest} has ${query}."
+            break
+        fi
+        if [[ $(( $(date +%s) - start_time )) -ge ${timeout} ]]; then
+            echo "Timed out waiting for ${manifest} to have ${query}."
+            exit 1
+        fi
+        sleep ${poll_interval_in_seconds}s
+    done
+}
+
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
 # Wait for cert-manager to be fully ready
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 kubectl_wait "cert-manager" "deployment/cert-manager-cainjector" "60s"
 kubectl_wait "cert-manager" "deployment/cert-manager" "60s"
-kubectl wait mutatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
-kubectl wait validatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
+kubectl_wait_for_query "mutatingwebhookconfigurations/cert-manager-webhook" '{.webhooks[0].clientConfig.caBundle}' 60 5
+kubectl_wait_for_query "validatingwebhookconfigurations/cert-manager-webhook" '{.webhooks[0].clientConfig.caBundle}' 60 5
 
 kubectl apply -f "https://github.com/operator-framework/catalogd/releases/download/${catalogd_version}/catalogd.yaml"
 # Wait for the rollout, and then wait for the deployment to be Available


### PR DESCRIPTION
BY running `make kind-deploy` against a kind cluster  or installing the released script from https://operator-framework.github.io/operator-controller/getting-started/olmv1_getting_started/ the following error is faced:

```sh
...
deployment.apps/cert-manager-webhook condition met
deployment.apps/cert-manager-cainjector condition met
deployment.apps/cert-manager condition met
error: jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3
```

This PR fixes an issue with kubectl wait when used to check the caBundle field in `mutatingwebhookconfigurations` and `validatingwebhookconfigurations`. 

### Solution

This PR introduces the `kubectl_wait_for_query` function, which replaces `kubectl wait` for this specific use case. The function repeatedly checks the `caBundle` field by using `kubectl get` in a loop, ensuring that the `caBundle` is populated without relying on status-based conditions. This approach provides a more flexible solution compatible with webhook configurations, bypassing the limitations of `kubectl wait`.

### After the fix:

```sh
$ make kind-deploy
/Users/camiladeomacedo/go/bin/controller-gen-v0.16.1 rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/base/crd/bases output:rbac:artifacts:config=config/base/rbac
/Users/camiladeomacedo/go/bin/kustomize-v4.5.7 build config/overlays/cert-manager > operator-controller.yaml
envsubst '$CATALOGD_VERSION,$CERT_MGR_VERSION,$INSTALL_DEFAULT_CATALOGS,$MANIFEST' < scripts/install.tpl.sh | bash -s
namespace/cert-manager created
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
serviceaccount/cert-manager-cainjector created
serviceaccount/cert-manager created
serviceaccount/cert-manager-webhook created
clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrole.rbac.authorization.k8s.io/cert-manager-cluster-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
role.rbac.authorization.k8s.io/cert-manager:leaderelection created
role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
service/cert-manager created
service/cert-manager-webhook created
deployment.apps/cert-manager-cainjector created
deployment.apps/cert-manager created
deployment.apps/cert-manager-webhook created
mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
deployment.apps/cert-manager-webhook condition met
deployment.apps/cert-manager-cainjector condition met
deployment.apps/cert-manager condition met
mutatingwebhookconfigurations/cert-manager-webhook has {.webhooks[0].clientConfig.caBundle}.
validatingwebhookconfigurations/cert-manager-webhook has {.webhooks[0].clientConfig.caBundle}.
namespace/olmv1-system created
customresourcedefinition.apiextensions.k8s.io/clustercatalogs.olm.operatorframework.io created
serviceaccount/catalogd-controller-manager created
role.rbac.authorization.k8s.io/catalogd-leader-election-role created
clusterrole.rbac.authorization.k8s.io/catalogd-manager-role created
clusterrole.rbac.authorization.k8s.io/catalogd-metrics-reader created
clusterrole.rbac.authorization.k8s.io/catalogd-proxy-role created
rolebinding.rbac.authorization.k8s.io/catalogd-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/catalogd-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/catalogd-proxy-rolebinding created
service/catalogd-service created
deployment.apps/catalogd-controller-manager created
certificate.cert-manager.io/olmv1-ca created
certificate.cert-manager.io/catalogd-service-cert created
clusterissuer.cert-manager.io/olmv1-ca created
issuer.cert-manager.io/self-sign-issuer created
mutatingwebhookconfiguration.admissionregistration.k8s.io/catalogd-mutating-webhook-configuration created
Waiting for deployment "catalogd-controller-manager" rollout to finish: 0 of 1 updated replicas are available...
Waiting for deployment "catalogd-controller-manager" rollout to finish: 0 of 1 updated replicas are available...
deployment "catalogd-controller-manager" successfully rolled out
deployment.apps/catalogd-controller-manager condition met
clustercatalog.olm.operatorframework.io/operatorhubio created
clustercatalog.olm.operatorframework.io/operatorhubio condition met
namespace/olmv1-system configured
customresourcedefinition.apiextensions.k8s.io/clusterextensions.olm.operatorframework.io created
serviceaccount/operator-controller-controller-manager created
role.rbac.authorization.k8s.io/operator-controller-leader-election-role created
role.rbac.authorization.k8s.io/operator-controller-manager-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-clusterextension-editor-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-clusterextension-viewer-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-extension-editor-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-extension-viewer-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-manager-role created
clusterrole.rbac.authorization.k8s.io/operator-controller-metrics-reader created
clusterrole.rbac.authorization.k8s.io/operator-controller-proxy-role created
rolebinding.rbac.authorization.k8s.io/operator-controller-leader-election-rolebinding created
rolebinding.rbac.authorization.k8s.io/operator-controller-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/operator-controller-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/operator-controller-proxy-rolebinding created
service/operator-controller-controller-manager-metrics-service created
deployment.apps/operator-controller-controller-manager created
certificate.cert-manager.io/olmv1-ca configured
certificate.cert-manager.io/olmv1-cert created
clusterissuer.cert-manager.io/olmv1-ca unchanged
issuer.cert-manager.io/self-sign-issuer unchanged
deployment.apps/operator-controller-controller-manager condition met
```
