### PR TITLE
🌱 (chore): configure Codecov to include only relevant directories for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
 codecov:
   notify:
     after_n_builds: 2
+
+# Configure the paths to include in coverage reports.
+# Exclude documentation, YAML configurations, and test files.
+coverage:
+  paths:
+    - "api/"
+    - "cmd/"
+    - "internal/"


### PR DESCRIPTION
- Updated .codecov.yml to include only specific directories (api/, cmd/, internal/) in coverage reports
- Excluded documentation, YAML configurations, and test files to improve coverage accuracy and prevent irrelevant CI coverage failures

Example: 

The PR https://github.com/operator-framework/operator-controller/pull/1430 just add docs and should not fail with but it is:

![Screenshot 2024-11-06 at 20 25 57](https://github.com/user-attachments/assets/b9c81f4c-96fc-48bc-a809-508e347d7fd7)

