### PR TITLE
📖  fix(docs): fix apiVersion for clustercatalogs. Replace 'catalogd.operatorframework.io/v1alpha1' with 'olm.operatorframework.io/v1alpha1'

### DIFF
--- a/docs/concepts/controlling-catalog-selection.md
+++ b/docs/concepts/controlling-catalog-selection.md
@@ -125,7 +125,7 @@ When multiple catalogs provide the same package, you can set priorities to resol
 In your `ClusterCatalog` resource, set the `priority` field:
 
 ```yaml
-apiVersion: catalogd.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterCatalog
 metadata:
   name: high-priority-catalog
@@ -160,7 +160,7 @@ If the system cannot resolve to a single bundle due to ambiguity, it will genera
 1. **Create or Update `ClusterCatalogs` with Appropriate Labels and Priority**
 
    ```yaml
-   apiVersion: catalogd.operatorframework.io/v1alpha1
+   apiVersion: olm.operatorframework.io/v1alpha1
    kind: ClusterCatalog
    metadata:
      name: catalog-a
@@ -175,7 +175,7 @@ If the system cannot resolve to a single bundle due to ambiguity, it will genera
    ```
 
    ```yaml
-   apiVersion: catalogd.operatorframework.io/v1alpha1
+   apiVersion: olm.operatorframework.io/v1alpha1
    kind: ClusterCatalog
    metadata:
      name: catalog-b

--- a/docs/getting-started/olmv1_getting_started.md
+++ b/docs/getting-started/olmv1_getting_started.md
@@ -35,7 +35,7 @@ To create the catalog, run the following command:
 ```bash
 # Create ClusterCatalog
 kubectl apply -f - <<EOF
-apiVersion: catalogd.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterCatalog
 metadata:
   name: operatorhubio


### PR DESCRIPTION
Replace `apiVersion: catalogd.operatorframework.io/v1alpha1` with `apiVersion: olm.operatorframework.io/v1alpha1` for `clustercatalogs.olm.operatorframework.io`.

Reason:
The API version referenced in the docs appears incorrect. After installing, the correct API name is confirmed with:

```
$ kubectl get crds | grep clustercatalog
clustercatalogs.olm.operatorframework.io   2024-11-06T21:34:38Z
```

The API is listed under `clustercatalogs.olm.operatorframework.io`, not `catalogd`.

Example error faced when trying to apply with the incorrect API name:

```
$ kubectl apply -f - <<EOF
> apiVersion: catalogd.operatorframework.io/v1alpha1
> kind: ClusterCatalog
> metadata:
>   name: operatorhubio
> spec:
>   source:
>     type: Image
>     image:
>       ref: quay.io/operatorhubio/catalog:latest
>       pollInterval: 10m
> EOF
error: resource mapping not found for name: "operatorhubio" namespace: "" from "STDIN": no matches for kind "ClusterCatalog" in version "catalogd.operatorframework.io/v1alpha1"
ensure CRDs are installed first
```

For reference, see the correct API name here:
[olm.operatorframework.io_clustercatalogs.yaml](https://github.com/operator-framework/catalogd/blob/main/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml).
