### PR TITLE
🌱 Fix upgrade-e2e CI job

### DIFF
--- a/config/samples/catalogd_operatorcatalog.yaml
+++ b/config/samples/catalogd_operatorcatalog.yaml
@@ -7,4 +7,4 @@ spec:
     type: Image
     image:
       ref: quay.io/operatorhubio/catalog:latest
-      pollInterval: 10m
+      pollIntervalMinutes: 10

--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -29,7 +29,7 @@ spec:
     type: Image
     image:
       ref: ${TEST_CATALOG_IMG}
-      pollInterval: 24h
+      pollIntervalMinutes: 1440
 EOF
 
 kubectl apply -f - <<EOF
@@ -132,15 +132,14 @@ kind: ClusterExtension
 metadata:
   name: ${TEST_CLUSTER_EXTENSION_NAME}
 spec:
+  namespace: default
+  serviceAccount:
+    name: upgrade-e2e
   source:
     sourceType: Catalog
     catalog:
       packageName: prometheus
       version: 1.0.0
-  install:
-    namespace: default
-    serviceAccount:
-      name: upgrade-e2e
 EOF
 
 kubectl wait --for=condition=Serving --timeout=60s ClusterCatalog $TEST_CLUSTER_CATALOG_NAME


### PR DESCRIPTION
# Description

There were several intentional breaking changes in the API which are now included in v0.18.0 release.

Our upgrade-e2e job need to be updated to make take the changes into account.

Relevant PRs:
* https://github.com/operator-framework/operator-controller/pull/1439
* https://github.com/operator-framework/operator-controller/pull/1434

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
