### PR TITLE
✨ fix a v1 promotion doc mistake

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"

--- a/config/samples/catalogd_operatorcatalog.yaml
+++ b/config/samples/catalogd_operatorcatalog.yaml
@@ -1,4 +1,4 @@
-apiVersion: olm.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1
 kind: ClusterCatalog
 metadata:
   name: operatorhubio

--- a/docs/api-reference/catalogd-api-reference.md
+++ b/docs/api-reference/catalogd-api-reference.md
@@ -1,20 +1,12 @@
 # API Reference
 
 ## Packages
-- [olm.operatorframework.io/core](#olmoperatorframeworkiocore)
-- [olm.operatorframework.io/v1alpha1](#olmoperatorframeworkiov1alpha1)
+- [olm.operatorframework.io/v1](#olmoperatorframeworkiov1)
 
 
-## olm.operatorframework.io/core
+## olm.operatorframework.io/v1
 
-Package api is the internal version of the API.
-
-
-
-
-## olm.operatorframework.io/v1alpha1
-
-Package v1alpha1 contains API Schema definitions for the core v1alpha1 API group
+Package v1 contains API Schema definitions for the core v1 API group
 
 ### Resource Types
 - [ClusterCatalog](#clustercatalog)
@@ -71,7 +63,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | `olm.operatorframework.io/v1alpha1` | | |
+| `apiVersion` _string_ | `olm.operatorframework.io/v1` | | |
 | `kind` _string_ | `ClusterCatalog` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
@@ -92,7 +84,7 @@ ClusterCatalogList contains a list of ClusterCatalog
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ | `olm.operatorframework.io/v1alpha1` | | |
+| `apiVersion` _string_ | `olm.operatorframework.io/v1` | | |
 | `kind` _string_ | `ClusterCatalogList` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |

--- a/docs/concepts/controlling-catalog-selection.md
+++ b/docs/concepts/controlling-catalog-selection.md
@@ -125,7 +125,7 @@ When multiple catalogs provide the same package, you can set priorities to resol
 In your `ClusterCatalog` resource, set the `priority` field:
 
 ```yaml
-apiVersion: olm.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1
 kind: ClusterCatalog
 metadata:
   name: high-priority-catalog
@@ -160,7 +160,7 @@ If the system cannot resolve to a single bundle due to ambiguity, it will genera
 1. **Create or Update `ClusterCatalogs` with Appropriate Labels and Priority**
 
    ```yaml
-   apiVersion: olm.operatorframework.io/v1alpha1
+   apiVersion: olm.operatorframework.io/v1
    kind: ClusterCatalog
    metadata:
      name: catalog-a
@@ -175,7 +175,7 @@ If the system cannot resolve to a single bundle due to ambiguity, it will genera
    ```
 
    ```yaml
-   apiVersion: olm.operatorframework.io/v1alpha1
+   apiVersion: olm.operatorframework.io/v1
    kind: ClusterCatalog
    metadata:
      name: catalog-b

--- a/docs/getting-started/olmv1_getting_started.md
+++ b/docs/getting-started/olmv1_getting_started.md
@@ -35,7 +35,7 @@ To create the catalog, run the following command:
 ```bash
 # Create ClusterCatalog
 kubectl apply -f - <<EOF
-apiVersion: olm.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1
 kind: ClusterCatalog
 metadata:
   name: operatorhubio

--- a/docs/howto/how-to-version-range-upgrades.md
+++ b/docs/howto/how-to-version-range-upgrades.md
@@ -21,4 +21,4 @@ spec:
       name: argocd-installer
 ```
 
-For more information on SemVer version ranges see [version-rages](../concepts/version-ranges.md)
+For more information on SemVer version ranges see [version-ranges](../concepts/version-ranges.md)

--- a/docs/tutorials/add-catalog.md
+++ b/docs/tutorials/add-catalog.md
@@ -26,7 +26,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
 1. Create a catalog custom resource (CR):
 
     ``` yaml title="clustercatalog_cr.yaml"
-    apiVersion: olm.operatorframework.io/v1alpha1
+    apiVersion: olm.operatorframework.io/v1
     kind: ClusterCatalog
     metadata:
       name: operatorhubio
@@ -48,7 +48,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
             To disable polling, set a zero value, such as `0s`.
 
     ``` yaml title="Example `operatorhubio.yaml` CR"
-    apiVersion: olm.operatorframework.io/v1alpha1
+    apiVersion: olm.operatorframework.io/v1
     kind: ClusterCatalog
     metadata:
       name: operatorhub
@@ -96,7 +96,7 @@ This catalog is distributed as an image [quay.io/operatorhubio/catalog](https://
         Namespace:
         Labels:       olm.operatorframework.io/metadata.name=operatorhubio
         Annotations:  <none>
-        API Version:  olm.operatorframework.io/v1alpha1
+        API Version:  olm.operatorframework.io/v1
         Kind:         ClusterCatalog
         Metadata:
         Creation Timestamp:  2024-10-02T19:51:24Z

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/operator-framework/api v0.27.0
-	github.com/operator-framework/catalogd v0.36.0
+	github.com/operator-framework/catalogd v1.0.0-rc1
 	github.com/operator-framework/helm-operator-plugins v0.7.0
 	github.com/operator-framework/operator-registry v1.48.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11 h1:eT
 github.com/openshift/crd-schema-checker v0.0.0-20240404194209-35a9033b1d11/go.mod h1:EmVJt97N+pfWFsli/ipXTBZqSG5F5KGQhm3c3IsGq1o=
 github.com/operator-framework/api v0.27.0 h1:OrVaGKZJvbZo58HTv2guz7aURkhVKYhFqZ/6VpifiXI=
 github.com/operator-framework/api v0.27.0/go.mod h1:lg2Xx+S8NQWGYlEOvFwQvH46E5EK5IrAIL7HWfAhciM=
-github.com/operator-framework/catalogd v0.36.0 h1:4ySpKitCooKPpTqQon/2dIGR7oEOIee8WYrRYwwQZ00=
-github.com/operator-framework/catalogd v0.36.0/go.mod h1:ERq4C2ksfkf3wu3XmtGP2fIkBSqS6LfaHhtcSEcU7Ww=
+github.com/operator-framework/catalogd v1.0.0-rc1 h1:wuM8yLy52lwrfyVJJ++l8zV+pxJOnuQLC84fO0UTbts=
+github.com/operator-framework/catalogd v1.0.0-rc1/go.mod h1:ERq4C2ksfkf3wu3XmtGP2fIkBSqS6LfaHhtcSEcU7Ww=
 github.com/operator-framework/helm-operator-plugins v0.7.0 h1:YmtIWFc9BaNaDc5mk/dkG0P2BqPZOqpDvjWih5Fczuk=
 github.com/operator-framework/helm-operator-plugins v0.7.0/go.mod h1:fUUCJR3bWtMBZ1qdDhbwjacsBHi9uT576tF4u/DwOgQ=
 github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=

--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -20,7 +20,7 @@ TEST_CLUSTER_CATALOG_NAME=$2
 TEST_CLUSTER_EXTENSION_NAME=$3
 
 kubectl apply -f - << EOF
-apiVersion: olm.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1
 kind: ClusterCatalog
 metadata:
   name: ${TEST_CLUSTER_CATALOG_NAME}

--- a/internal/catalogmetadata/client/client.go
+++ b/internal/catalogmetadata/client/client.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 )
 

--- a/internal/catalogmetadata/client/client_test.go
+++ b/internal/catalogmetadata/client/client_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
 	catalogClient "github.com/operator-framework/operator-controller/internal/catalogmetadata/client"

--- a/internal/controllers/clustercatalog_controller.go
+++ b/internal/controllers/clustercatalog_controller.go
@@ -25,7 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 )
 
 type CatalogCache interface {

--- a/internal/controllers/clustercatalog_controller_test.go
+++ b/internal/controllers/clustercatalog_controller_test.go
@@ -14,7 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	"github.com/operator-framework/operator-controller/internal/controllers"
 	"github.com/operator-framework/operator-controller/internal/scheme"

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -45,7 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 

--- a/internal/resolve/catalog.go
+++ b/internal/resolve/catalog.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"

--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
 

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -7,7 +7,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 )

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/env"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 )

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -13,7 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	"github.com/operator-framework/operator-controller/internal/scheme"
 )

--- a/test/extension-developer-e2e/extension_developer_test.go
+++ b/test/extension-developer-e2e/extension_developer_test.go
@@ -18,7 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogd "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 )

--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogdv1alpha1 "github.com/operator-framework/catalogd/api/core/v1alpha1"
+	catalogd "github.com/operator-framework/catalogd/api/v1"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 )
@@ -65,14 +65,14 @@ func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
 
 	t.Log("Checking that the ClusterCatalog is serving")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		var clusterCatalog catalogdv1alpha1.ClusterCatalog
+		var clusterCatalog catalogd.ClusterCatalog
 		assert.NoError(ct, c.Get(ctx, types.NamespacedName{Name: testClusterCatalogName}, &clusterCatalog))
-		cond := apimeta.FindStatusCondition(clusterCatalog.Status.Conditions, catalogdv1alpha1.TypeServing)
+		cond := apimeta.FindStatusCondition(clusterCatalog.Status.Conditions, catalogd.TypeServing)
 		if !assert.NotNil(ct, cond) {
 			return
 		}
 		assert.Equal(ct, metav1.ConditionTrue, cond.Status)
-		assert.Equal(ct, catalogdv1alpha1.ReasonAvailable, cond.Reason)
+		assert.Equal(ct, catalogd.ReasonAvailable, cond.Reason)
 	}, time.Minute, time.Second)
 
 	t.Log("Checking that the ClusterExtension is installed")


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
@LalatenduMohanty , @everettraven y'all were going so 🚀 on #1441 that I didn't get a chance to complete review.  It looks like you caught the things that I caught as well, except for this minor docs issue.  We could conceivably ignore this and it will become correct once we complete v1 api promotion in operator-controller.  

On the off case that we want to keep it consistent with context, here's this PR. 

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
