### PR TITLE
🌱 Fix upgrade-e2e CI job

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -127,7 +127,7 @@ roleRef:
 EOF
 
 kubectl apply -f - << EOF
-apiVersion: olm.operatorframework.io/v1alpha1
+apiVersion: olm.operatorframework.io/v1
 kind: ClusterExtension
 metadata:
   name: ${TEST_CLUSTER_EXTENSION_NAME}


### PR DESCRIPTION
# Description

The latest release v1.0.0-rc1 includes the change to the API: OLM v1alpha1 APIs became v1 and this needs to be reflected in the upgrade-e2e CI job.

Refs:
* https://github.com/operator-framework/operator-controller/pull/1228
* https://github.com/operator-framework/operator-controller/pull/1441

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
