### PR TITLE
🌱 Configure ENVTEST Binaries for IDE Debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,32 @@ you can follow the steps below to test your changes:
     make kind-load kind-deploy
     ```
 
+## How to debug controller tests using ENVTEST
+
+[ENVTEST](https://book.kubebuilder.io/reference/envtest) requires k8s binaries to be downloaded to run the tests.
+To download the necessary binaries, follow the steps below:
+
+```sh
+make envtest-k8s-bins
+```
+
+Note that the binaries are downloaded to the `bin/envtest-binaries` directory.
+
+```sh
+$ tree
+.
+├── envtest-binaries
+│   └── k8s
+│       └── 1.31.0-darwin-arm64
+│           ├── etcd
+│           ├── kube-apiserver
+│           └── kubectl
+```
+
+Now, you can debug them with your IDE:
+
+![Screenshot IDE example](https://github.com/user-attachments/assets/3096d524-0686-48ca-911c-5b843093ad1f)
+
 ### Communication Channels
 
 - Email: [operator-framework-olm-dev](mailto:operator-framework-olm-dev@googlegroups.com)


### PR DESCRIPTION
This change introduces downloading the specific binaries required to run ENVTEST-based tests into the project/bin directory. This setup makes configuring tests for debugging directly in an IDE easier.

### Motivation
1. **Ease of IDE Debugging**:
   - By setting the `BinaryAssetsDirectory` dynamically, contributors can debug tests in their preferred IDEs (e.g., GoLand, VSCode) without requiring additional environment configuration such as setting `KUBEBUILDER_ASSETS`.

![Screenshot 2024-11-13 at 17 38 40](https://github.com/user-attachments/assets/3096d524-0686-48ca-911c-5b843093ad1f)

2. **Project-Specific Binaries:**

Installing binaries inside the project avoids conflicts with other projects or system-wide installations, particularly useful for contributors with restricted environments (e.g., corporate laptops).

The binaries installed by envtest-setup are no longer placed in the HOME/global directory. See the default behavior here:
https://github.com/kubernetes-sigs/controller-runtime/blob/e3347b5405cdd0da5bff527af3d406117938ba6b/tools/setup-envtest/README.md?plain=1#L57-L70

This change ensures binaries are placed locally, avoiding the conflicts and clutter caused by global installations.

I’m referring to the binaries required for ENVTEST **(not those managed by BINGO)**.

![Screenshot 2024-11-19 at 01 22 59](https://github.com/user-attachments/assets/05028f1b-63eb-432c-948a-1e50fccd1f22)

Before this PR those are placed for example in a Mac OS at: `/Users/camilam/Library/Application Support/io.kubebuilder.envtest/k8s/1.31.0-darwin-arm64`

```
$ pwd
/Users/camilam/Library/Application Support/io.kubebuilder.envtest/k8s/1.31.0-darwin-arm64

ls -la
total 337856
dr-xr-xr-x  5 camilam  staff       160 19 Nov 09:20 .
drwxr-xr-x  3 camilam  staff        96 19 Nov 09:20 ..
-r-xr-xr-x  1 camilam  staff  26058562 19 Nov 09:20 etcd
-r-xr-xr-x  1 camilam  staff  90359954 19 Nov 09:20 kube-apiserver
-r-xr-xr-x  1 camilam  staff  56560754 19 Nov 09:20 kubectl

```


3. **Simplified Contributor Onboarding**:
   - New contributors often face a learning curve to:
     - Understand ENVTEST and its dependency on binaries.
     - Configure `KUBEBUILDER_ASSETS` manually.
     - Set up their IDE for debugging tests.
   - This setup minimizes friction and ensures tests can be run consistently across different environments.

While setting `KUBEBUILDER_ASSETS` is sufficient for experienced contributors, this change makes it easier for newcomers and supports debugging directly in IDEs without additional configuration.


