### PR TITLE
📖 Change formatting in the "Catalog queries" doc

### DIFF
--- a/docs/howto/catalog-queries.md
+++ b/docs/howto/catalog-queries.md
@@ -1,73 +1,108 @@
 # Catalog queries
 
+After you [add a catalog of extensions](../tutorials/add-catalog.md) to your cluster, you must port forward your catalog as a service.
+Then you can query the catalog by using `curl` commands and the `jq` CLI tool to find extensions to install.
+
+## Prerequisites
+
+* You have added a ClusterCatalog of extensions, such as [OperatorHub.io](https://operatorhub.io), to your cluster.
+* You have installed the `jq` CLI tool.
+
 !!! note
     By default, Catalogd is installed with TLS enabled for the catalog webserver.
     The following examples will show this default behavior, but for simplicity's sake will ignore TLS verification in the curl commands using the `-k` flag.
 
+You also need to port forward the catalog server service:
 
-You can use the `curl` command with `jq` to query catalogs that are installed on your cluster.
+``` terminal
+kubectl -n olmv1-system port-forward svc/catalogd-service 8443:443
+```
+
+Now you can use the `curl` command with `jq` to query catalogs that are installed on your cluster.
 
 ``` terminal title="Query syntax"
 curl -k https://localhost:8443/catalogs/operatorhubio/api/v1/all | <query>
 ```
+`<query>`
+: One of the `jq` queries from this document
 
 ## Package queries
 
-Available packages in a catalog
-: 
-``` terminal
-jq -s '.[] | select( .schema == "olm.package")'
-```
+* Available packages in a catalog:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.package")'
+    ```
 
-Packages that support `AllNamespaces` install mode and do not use webhooks
+* Packages that support `AllNamespaces` install mode and do not use webhooks:
+    ``` terminal
+    jq -c 'select(.schema == "olm.bundle") | {"package":.package, "version":.properties[] | select(.type == "olm.bundle.object").value.data |  @base64d | fromjson | select(.kind == "ClusterServiceVersion" and (.spec.installModes[] | select(.type == "AllNamespaces" and .supported == true) != null) and .spec.webhookdefinitions == null).spec.version}'
+    ```
 
-: 
-``` terminal
-jq -c 'select(.schema == "olm.bundle") | {"package":.package, "version":.properties[] | select(.type == "olm.bundle.object").value.data |  @base64d | fromjson | select(.kind == "ClusterServiceVersion" and (.spec.installModes[] | select(.type == "AllNamespaces" and .supported == true) != null) and .spec.webhookdefinitions == null).spec.version}'
-```
+* Package metadata:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.package") | select( .name == "<package_name>")'
+    ```
 
-Package metadata
-: 
-``` terminal
-jq -s '.[] | select( .schema == "olm.package") | select( .name == "<package_name>")'
-```
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
 
-Catalog blobs in a package
-: 
-``` terminal
-jq -s '.[] | select( .package == "<package_name>")'
-```
+* Catalog blobs in a package:
+    ``` terminal
+    jq -s '.[] | select( .package == "<package_name>")'
+    ```
+
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
 
 ## Channel queries
 
-Channels in a package
-: 
-``` terminal
-jq -s '.[] | select( .schema == "olm.channel" ) | select( .package == "<package_name>") | .name'
-```
+* Channels in a package:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.channel" ) | select( .package == "<package_name>") | .name'
+    ```
 
-Versions in a channel
-: 
-``` terminal
-jq -s '.[] | select( .package == "<package_name>" ) | select( .schema == "olm.channel" ) | select( .name == "<channel_name>" ) | .entries | .[] | .name'
-```
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
 
-Latest version in a channel and upgrade path
-: 
-``` terminal 
-jq -s '.[] | select( .schema == "olm.channel" ) | select ( .name == "<channel>") | select( .package == "<package_name>")'
-```
+* Versions in a channel:
+    ``` terminal
+    jq -s '.[] | select( .package == "<package_name>" ) | select( .schema == "olm.channel" ) | select( .name == "<channel_name>" ) | .entries | .[] | .name'
+    ```
+
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
+
+    `<channel_name>`
+    : Name of the channel for a given package.
+
+* Latest version in a channel and upgrade path:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.channel" ) | select ( .name == "<channel_name>") | select( .package == "<package_name>")'
+    ```
+
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
+
+    `<channel_name>`
+    : Name of the channel for a given package.
 
 ## Bundle queries
 
-Bundles in a package
-: 
-``` terminal
-jq -s '.[] | select( .schema == "olm.bundle" ) | select( .package == "<package_name>") | .name'
-```
+* Bundles in a package:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.bundle" ) | select( .package == "<package_name>") | .name'
+    ```
 
-Bundle dependencies and available APIs
-: 
-``` terminal
-jq -s '.[] | select( .schema == "olm.bundle" ) | select ( .name == "<bundle_name>") | select( .package == "<package_name>")'
-```
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
+
+* Bundle dependencies and available APIs:
+    ``` terminal
+    jq -s '.[] | select( .schema == "olm.bundle" ) | select ( .name == "<bundle_name>") | select( .package == "<package_name>")'
+    ```
+
+    `<package_name>`
+    : Name of the package from the catalog you are querying.
+
+    `<bundle_name>`
+    : Name of the bundle for a given package.


### PR DESCRIPTION
# Description

This commit adds definition lists for placeholders such as `<package_name>`. The goal of adding definition lists for placeholders is to improve their visibility in the code snippets.

This commit also switches existing definition lists [1] (list of queries) to unordered list. The current list of queries uses definition lists from mkdocs-material. However it relies on a tailing space after a colon to work. E.g. the whole line becomes `: ` and it is prone to errors because:
1. It is easy to overlook a space which is part of markdown.
2. Many editors remove tailing spaces at the end of lines.
3. We are adding more definition lists into this docs to explain placeholders such as `<package_name>`. With nested definition lists markdown of this document going to be very difficult to manage.

[1]: https://squidfunk.github.io/mkdocs-material/reference/lists/#using-definition-lists

> [!TIP]
> We also have docs deployment preview. See the comment from netlify bot below.
> See: [preview of this PR](https://deploy-preview-1461--olmv1.netlify.app/howto/catalog-queries/) vs [live version](https://operator-framework.github.io/operator-controller/howto/catalog-queries/)

> [!TIP]
> Recommend reviewing the changes with `git diff --ignore-all-space` (`-w`) option. GitHub UI also has this option.
>  ![Screenshot 2024-11-12 at 15 59 15](https://github.com/user-attachments/assets/d4c123d8-d6fb-4007-9e01-d4fbfed2e4d6)

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
