### PR TITLE
📖 Fix table formatting in the "Version ranges" doc

### DIFF
--- a/docs/concepts/version-ranges.md
+++ b/docs/concepts/version-ranges.md
@@ -41,6 +41,7 @@ If you use a wildcard character with the `=` operator, you define a patch level 
 This is equivalent to making a tilde range comparison.
 
 *Example comparisons with wildcard characters*
+
 | Comparison | Equivalent          |
 |------------|---------------------|
 | `1.2.x`    | `>= 1.2.0, < 1.3.0` |
@@ -55,6 +56,7 @@ You can use the tilde (`~`) operator to make patch release comparisons.
 This is useful when you want to specify a minor version up to the next major version.
 
 *Example patch release comparisons*
+
 | Comparison | Equivalent          |
 |------------|---------------------|
 | `~1.2.3`   | `>= 1.2.3, < 1.3.0` |


### PR DESCRIPTION
# Description

Currently this document renders fine on GitHub, but the table is broken in mkdocs website.

> [!TIP]
> We also have docs deployment preview. See the comment from netlify bot below.
> See: [this PR](https://deploy-preview-1462--olmv1.netlify.app/concepts/version-ranges/) vs [live version](https://operator-framework.github.io/operator-controller/concepts/version-ranges/)

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
