### PR TITLE
🐛 combine bundle properties from csv and metadata/properties.yaml

### DIFF
--- a/internal/rukpak/convert/registryv1_test.go
+++ b/internal/rukpak/convert/registryv1_test.go
@@ -1,7 +1,9 @@
 package convert
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,7 +26,7 @@ import (
 
 func TestRegistryV1Converter(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RegstryV1 suite")
+	RunSpecs(t, "RegistryV1 suite")
 }
 
 var _ = Describe("RegistryV1 Suite", func() {
@@ -415,6 +417,17 @@ var _ = Describe("RegistryV1 Suite", func() {
 				chrt, err := toChart(registryv1Bundle, installNamespace, watchNamespaces)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(chrt.Metadata.Annotations["olm.properties"]).NotTo(BeNil())
+			})
+		})
+
+		Context("Should read the registry+v1 bundle filesystem correctly", func() {
+			It("should include metadata/properties.yaml and csv.metadata.annotations['olm.properties'] in chart metadata", func() {
+				fsys := os.DirFS("testdata/combine-properties-bundle")
+				chrt, err := RegistryV1ToHelmChart(context.Background(), fsys, "", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(chrt).NotTo(BeNil())
+				Expect(chrt.Metadata).NotTo(BeNil())
+				Expect(chrt.Metadata.Annotations).To(HaveKeyWithValue("olm.properties", `[{"type":"from-csv-annotations-key","value":"from-csv-annotations-value"},{"type":"from-file-key","value":"from-file-value"}]`))
 			})
 		})
 

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/manifests/csv.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/manifests/csv.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.operatorframework.io/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: test.v1.0.0
+  annotations:
+    olm.properties: '[{"type":"from-csv-annotations-key", "value":"from-csv-annotations-value"}]'
+spec:
+  installModes:
+    - type: AllNamespaces
+      supported: true

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/annotations.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/annotations.yaml
@@ -1,0 +1,3 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.package.v1: test

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/properties.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - type: "from-file-key"
+    value: "from-file-value"


### PR DESCRIPTION
When we implemented support for including CSV annotations in chart metadata, we neglected to remember that bundle properties can also come from the `metadata/properties.yaml` file in the bundle filesystem. This PR updates the registry+v1 bundle converter library to read properties from `metadata/properties.yaml` (if it exists) and append any properties that are found into the `metadata.annotations["olm.properties"]` annotation in the CSV.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
