### PR TITLE
🌱 enable go-apidiff in merge queue

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,5 +1,6 @@
 name: go-apidiff
 on:
+  merge_group:
   pull_request:
 jobs:
   go-apidiff:


### PR DESCRIPTION
Now that our APIs are stable, we have made `go-apidiff` a required check in CI. As such, we need it to be enabled in the merge queue.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
