### PR TITLE
:seedling: improve the verify-crd-compatibility make target

### DIFF
--- a/.github/workflows/crd-diff.yaml
+++ b/.github/workflows/crd-diff.yaml
@@ -14,5 +14,5 @@ jobs:
           go-version-file: go.mod
 
       - name: Run make verify-crd-compatibility
-        run: make verify-crd-compatibility CRD_DIFF_ORIGINAL_REF=${{ github.event.pull_request.base.sha }} CRD_DIFF_UPDATED_REF=${{ github.event.pull_request.head.sha }}
+        run: make verify-crd-compatibility CRD_DIFF_ORIGINAL_REF=${{ github.event.pull_request.base.sha }} CRD_DIFF_UPDATED_SOURCE="git://${{ github.event.pull_request.head.sha }}?path=config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml"
 

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ bingo-upgrade: $(BINGO) #EXHELP Upgrade tools
 
 .PHONY: verify-crd-compatibility
 CRD_DIFF_ORIGINAL_REF := main
-CRD_DIFF_UPDATED_REF  := HEAD
+CRD_DIFF_UPDATED_SOURCE := file://config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml
 CRD_DIFF_CONFIG := crd-diff-config.yaml
-verify-crd-compatibility: $(CRD_DIFF)
-	$(CRD_DIFF) --config="${CRD_DIFF_CONFIG}" "git://${CRD_DIFF_ORIGINAL_REF}?path=config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml" "git://${CRD_DIFF_UPDATED_REF}?path=config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml"
+verify-crd-compatibility: $(CRD_DIFF) manifests
+	$(CRD_DIFF) --config="${CRD_DIFF_CONFIG}" "git://${CRD_DIFF_ORIGINAL_REF}?path=config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml" ${CRD_DIFF_UPDATED_SOURCE}
 
 .PHONY: test
 test: manifests generate fmt vet test-unit test-e2e #HELP Run all tests.


### PR DESCRIPTION
for use during local development by making the default updated source be the local file, picking up changes not yet committed. The previous git sourcing required changes to be committed to be picked up and is not a very good developer experience as you should validate the changes prior to commiting them. Since the git source is necessary for CI, the GitHub Action is updated to specify the git source for the updated file.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
