### PR TITLE
:seedling: Add check for client in e2e

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -23,10 +23,26 @@ func TestOperatorControllerMetricsExportedEndpoint(t *testing.T) {
 		token     string
 		curlPod   = "curl-metrics"
 		namespace = "olmv1-system"
+		client    = ""
+		clients   = []string{"kubectl", "oc"}
 	)
 
+	t.Log("Looking for k8s client")
+	for _, c := range clients {
+		// Would prefer to use `command -v`, but even that may not be installed!
+		err := exec.Command(c, "version", "--client").Run()
+		if err == nil {
+			client = c
+			break
+		}
+	}
+	if client == "" {
+		t.Skip("k8s client not found, skipping test")
+	}
+	t.Logf("Using %q as k8s client", client)
+
 	t.Log("Creating ClusterRoleBinding for operator controller metrics")
-	cmd := exec.Command("kubectl", "create", "clusterrolebinding", "operator-controller-metrics-binding",
+	cmd := exec.Command(client, "create", "clusterrolebinding", "operator-controller-metrics-binding",
 		"--clusterrole=operator-controller-metrics-reader",
 		"--serviceaccount="+namespace+":operator-controller-controller-manager")
 	output, err := cmd.CombinedOutput()
@@ -34,17 +50,17 @@ func TestOperatorControllerMetricsExportedEndpoint(t *testing.T) {
 
 	defer func() {
 		t.Log("Cleaning up ClusterRoleBinding")
-		_ = exec.Command("kubectl", "delete", "clusterrolebinding", "operator-controller-metrics-binding", "--ignore-not-found=true").Run()
+		_ = exec.Command(client, "delete", "clusterrolebinding", "operator-controller-metrics-binding", "--ignore-not-found=true").Run()
 	}()
 
 	t.Log("Generating ServiceAccount token")
-	tokenCmd := exec.Command("kubectl", "create", "token", "operator-controller-controller-manager", "-n", namespace)
+	tokenCmd := exec.Command(client, "create", "token", "operator-controller-controller-manager", "-n", namespace)
 	tokenOutput, err := tokenCmd.Output()
 	require.NoError(t, err, "Error creating token: %s", string(tokenOutput))
 	token = string(bytes.TrimSpace(tokenOutput))
 
 	t.Log("Creating curl pod to validate the metrics endpoint")
-	cmd = exec.Command("kubectl", "run", curlPod,
+	cmd = exec.Command(client, "run", curlPod,
 		"--image=curlimages/curl:7.87.0", "-n", namespace,
 		"--restart=Never",
 		"--overrides", `{
@@ -73,17 +89,17 @@ func TestOperatorControllerMetricsExportedEndpoint(t *testing.T) {
 
 	defer func() {
 		t.Log("Cleaning up curl pod")
-		_ = exec.Command("kubectl", "delete", "pod", curlPod, "-n", namespace, "--ignore-not-found=true").Run()
+		_ = exec.Command(client, "delete", "pod", curlPod, "-n", namespace, "--ignore-not-found=true").Run()
 	}()
 
 	t.Log("Waiting for the curl pod to be ready")
-	waitCmd := exec.Command("kubectl", "wait", "--for=condition=Ready", "pod", curlPod, "-n", namespace, "--timeout=60s")
+	waitCmd := exec.Command(client, "wait", "--for=condition=Ready", "pod", curlPod, "-n", namespace, "--timeout=60s")
 	waitOutput, waitErr := waitCmd.CombinedOutput()
 	require.NoError(t, waitErr, "Error waiting for curl pod to be ready: %s", string(waitOutput))
 
 	t.Log("Validating the metrics endpoint")
 	metricsURL := "https://operator-controller-controller-manager-metrics-service." + namespace + ".svc.cluster.local:8443/metrics"
-	curlCmd := exec.Command("kubectl", "exec", curlPod, "-n", namespace, "--",
+	curlCmd := exec.Command(client, "exec", curlPod, "-n", namespace, "--",
 		"curl", "-v", "-k", "-H", "Authorization: Bearer "+token, metricsURL)
 	output, err = curlCmd.CombinedOutput()
 	require.NoError(t, err, "Error calling metrics endpoint: %s", string(output))


### PR DESCRIPTION
Depending on how e2e is run, we may not have a k8s client available.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
