### PR TITLE
:seedling: Replace Depecated Action to validate the PR Title with script

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify PR title
     steps:
-    - name: Verify PR title
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify PR title
+        id: get_title
+        run: echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+      - name: Run Check
+        id: check_title
+        run: |
+          ./hack/test/pr-title.sh "${{ env.title }}"

--- a/hack/test/pr-title.sh
+++ b/hack/test/pr-title.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# This file is copied from:
+# https://github.com/kubernetes-sigs/kubebuilder/blob/master/test/pr-title-checker.sh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define regex patterns
+WIP_REGEX="^\W?WIP\W"
+TAG_REGEX="^\[[[:alnum:]\._-]*\]"
+PR_TITLE="$1"
+
+# Trim WIP and tags from title
+trimmed_title=$(echo "$PR_TITLE" | sed -E "s/$WIP_REGEX//" | sed -E "s/$TAG_REGEX//" | xargs)
+
+# Normalize common emojis in text form to actual emojis
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:warning:/⚠/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:sparkles:/✨/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:bug:/🐛/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:book:/📖/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:rocket:/🚀/g")
+trimmed_title=$(echo "$trimmed_title" | sed -E "s/:seedling:/🌱/g")
+
+# Check PR type prefix
+if [[ "$trimmed_title" =~ ^⚠ ]] || [[ "$trimmed_title" =~ ^✨ ]] || [[ "$trimmed_title" =~ ^🐛 ]] || [[ "$trimmed_title" =~ ^📖 ]] || [[ "$trimmed_title" =~ ^🚀 ]] || [[ "$trimmed_title" =~ ^🌱 ]]; then
+    echo "PR title is valid: $trimmed_title"
+    exit 0
+else
+    echo "Error: No matching PR type indicator found in title."
+    echo "You need to have one of these as the prefix of your PR title:"
+    echo "- Breaking change: ⚠ (:warning:)"
+    echo "- Non-breaking feature: ✨ (:sparkles:)"
+    echo "- Patch fix: 🐛 (:bug:)"
+    echo "- Docs: 📖 (:book:)"
+    echo "- Release: 🚀 (:rocket:)"
+    echo "- Infra/Tests/Other: 🌱 (:seedling:)"
+    exit 1
+fi


### PR DESCRIPTION
The action is deprecated and goes away when Kubebuilder GCP Project no longer be available. Therefore, this PR replaces the action for the shell script that does the same check. More info: https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#pr-verification-github-action-deprecated

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
