### PR TITLE
:bug: fix list-compatible-bundles script

### DIFF
--- a/hack/tools/catalogs/generate-manifests
+++ b/hack/tools/catalogs/generate-manifests
@@ -17,7 +17,7 @@ assert-container-runtime
 # Check required tools are installed
 assert-commands jq
 
-function usage() {
+usage() {
     print-banner
     echo ""
     echo "Usage:"

--- a/hack/tools/catalogs/list-compatible-bundles
+++ b/hack/tools/catalogs/list-compatible-bundles
@@ -45,13 +45,13 @@ done
 shift $((OPTIND -1))
 
 # Select bundle documents
-function select-bundle-documents() {
+select-bundle-documents() {
     jq 'select(.schema == "olm.bundle")'
 }
 
 # Select bundles that declare AllNamespace install mode
 # or declare nothing at all (older released bundles sans "olm.csv.metadata" property)
-function that-support-allnamespace-install-mode() {
+that-support-allnamespace-install-mode() {
     jq 'select(
             all(.properties[].type; . != "olm.csv.metadata") or
             (.properties[]? |
@@ -65,23 +65,23 @@ function that-support-allnamespace-install-mode() {
 }
 
 # Select bundles without dependencies
-function that-dont-have-dependencies() {
+that-dont-have-dependencies() {
     jq 'select(all(.properties[].type; . != "olm.package.required" and . != "olm.gvk.required"))'
 }
 
 # Select the "olm.package" property from the bundles
 # This contains the packageName and version information
-function extract-olm-package-property() {
+extract-olm-package-property() {
     jq '.properties[] | select(.type == "olm.package") |.value'
 }
 
 # Group packages by name and collect versions into an array
-function group-versions-by-package-name() {
+group-versions-by-package-name() {
     jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})'
 }
 
 # Apply regex on name
-function filter-by-regex-if-necessary() {
+filter-by-regex-if-necessary() {
     jq --arg regex "$REGEX" '
         if $regex != "" then
             map(select(.packageName | test($regex)))

--- a/hack/tools/catalogs/list-compatible-bundles
+++ b/hack/tools/catalogs/list-compatible-bundles
@@ -77,7 +77,7 @@ function extract-olm-package-property() {
 
 # Group packages by name and collect versions into an array
 function group-versions-by-package-name() {
-    jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})' | regex_it
+    jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})'
 }
 
 # Apply regex on name
@@ -90,7 +90,7 @@ function filter-by-regex-if-necessary() {
         end'
 }
 
-cat - | select-bundle-documents | that-support-allnamespace-install-mode | that-dont-have-dependencies | group-versions-by-package-name | filter-by-regex-if-necessary
+cat - | select-bundle-documents | that-support-allnamespace-install-mode | that-dont-have-dependencies | extract-olm-package-property | group-versions-by-package-name | filter-by-regex-if-necessary
 
 echo "NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks" >&2
 echo "WARNING: These results may include bundles with webhooks, which are incompatible" >&2


### PR DESCRIPTION
# Description

I think when I addressed some reviewer comments I didn't do a good job and mangled the script. This fixes it. I've tested it manually and now it works as advertised.

Adding from https://github.com/operator-framework/operator-controller/pull/1539 to keep track the history of this change done by @azych 

 **_hack/tools/catalogs/list-compatible-bundles_ script -** adds the missing `extract-olm-package-property` function to the call chain and uses the correct name of regex filtering function (`filter-by-regex-if-necessary`), making sure the script works.
    The main issues here were two:
    1. `regex_it` did not exist and was renamed during review of the original PR to `filter-by-regex-if-necessary`
    2. `extract-olm-package-property` call was missing from the chain meaning the filter function couldn't recognize the structure it was expecting

Before change result:

>    ➜  operator-controller git:(main) ✗ ./hack/tools/catalogs/list-compatible-bundles < operatorhubio-catalog.json 
> 
> ./hack/tools/catalogs/list-compatible-bundles: line 80: regex_it: command not found
> NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks
> WARNING: These results may include bundles with webhooks, which are incompatible`

After change result:

> ➜  operator-controller git:(main) ✗ ./hack/tools/catalogs/list-compatible-bundles < operatorhubio-catalog.json > filtered.json
> NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks
> WARNING: These results may include bundles with webhooks, which are incompatible
> 
> ➜  operator-controller git:(main) cat filtered.json
> [
>   {
>     "packageName": "ack-acm-controller",
>     "versions": [
>       "0.0.1",
>       "0.0.10",
>       "0.0.12",
>       "0.0.15",
>       "0.0.16",
>       "0.0.17",
>       "0.0.18",
>       "0.0.19",
>       "0.0.2",
>       "0.0.20",
>       "0.0.4",
>       "0.0.5",
>       "0.0.6",
>       "0.0.7",
>       "0.0.9",
>       "1.0.0"
>     ]
>   },
> ...
