### PR TITLE
🌱 move service to kustomize manager dir, rename for general purpose use

### DIFF
--- a/config/base/manager/kustomization.yaml
+++ b/config/base/manager/kustomization.yaml
@@ -1,7 +1,10 @@
-resources:
-- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources:
+- manager.yaml
+- service.yaml
+
 images:
 - name: controller
   newName: quay.io/operator-framework/operator-controller

--- a/config/base/manager/service.yaml
+++ b/config/base/manager/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: service
+  namespace: system
   labels:
     control-plane: operator-controller-controller-manager
-  name: controller-manager-metrics-service
-  namespace: system
 spec:
   ports:
   - name: https

--- a/config/base/rbac/kustomization.yaml
+++ b/config/base/rbac/kustomization.yaml
@@ -23,7 +23,6 @@ resources:
 # can access the metrics endpoint. Comment the following
 # permissions if you want to disable this protection.
 # More info: https://book.kubebuilder.io/reference/metrics.html
-- auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml

--- a/config/components/tls/resources/manager_cert.yaml
+++ b/config/components/tls/resources/manager_cert.yaml
@@ -5,10 +5,8 @@ metadata:
 spec:
   secretName: olmv1-cert
   dnsNames:
-    - operator-controller.olmv1-system.svc
-    - operator-controller.olmv1-system.svc.cluster.local
-    - operator-controller-controller-manager-metrics-service.olmv1-system.svc
-    - operator-controller-controller-manager-metrics-service.olmv1-system.svc.cluster.local
+    - operator-controller-service.olmv1-system.svc
+    - operator-controller-service.olmv1-system.svc.cluster.local
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -98,7 +98,7 @@ func TestOperatorControllerMetricsExportedEndpoint(t *testing.T) {
 	require.NoError(t, waitErr, "Error waiting for curl pod to be ready: %s", string(waitOutput))
 
 	t.Log("Validating the metrics endpoint")
-	metricsURL := "https://operator-controller-controller-manager-metrics-service." + namespace + ".svc.cluster.local:8443/metrics"
+	metricsURL := "https://operator-controller-service." + namespace + ".svc.cluster.local:8443/metrics"
 	curlCmd := exec.Command(client, "exec", curlPod, "-n", namespace, "--",
 		"curl", "-v", "-k", "-H", "Authorization: Bearer "+token, metricsURL)
 	output, err = curlCmd.CombinedOutput()


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This PR renames the internal operator-controller service from "operator-controller-controller-manager-metrics-service" to "operator-controller-service".

It also moves the service kustomize manifest from the `rbac` base to the `manager` base.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
