### PR TITLE
:bug: renamed catalogd service name in download-catalog hack script

### DIFF
--- a/hack/tools/catalogs/download-catalog
+++ b/hack/tools/catalogs/download-catalog
@@ -8,7 +8,7 @@ assert-commands kubectl jq wget
 
 # ClusterCatalog coordinates
 : "${CATALOGD_CATALOGD_SERVICE_NAMESPACE:=olmv1-system}"
-: "${CATALOGD_SERVICE_NAME:=catalogd-server}"
+: "${CATALOGD_SERVICE_NAME:=catalogd-service}"
 : "${CATALOGD_SERVICE_PORT:=443}" # Assumes the service uses HTTPS on port 443
 : "${CATALOGD_LOCAL_SERVICE_PORT:=8001}"
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

Small fix that changes the name of the catalogd service from `catalogd-server` to the currently used `catalogd-service` in the _hack/tools/catalogs/download-catalog_ script.

Changes separated from https://github.com/operator-framework/operator-controller/pull/1539 as per https://github.com/operator-framework/operator-controller/pull/1539#discussion_r1900596361

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
