### PR TITLE
:bug: incomplete function chain and renamed function in list-compatibl…

### DIFF
--- a/hack/tools/catalogs/list-compatible-bundles
+++ b/hack/tools/catalogs/list-compatible-bundles
@@ -77,7 +77,7 @@ function extract-olm-package-property() {
 
 # Group packages by name and collect versions into an array
 function group-versions-by-package-name() {
-    jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})' | regex_it
+    jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})'
 }
 
 # Apply regex on name
@@ -90,7 +90,7 @@ function filter-by-regex-if-necessary() {
         end'
 }
 
-cat - | select-bundle-documents | that-support-allnamespace-install-mode | that-dont-have-dependencies | group-versions-by-package-name | filter-by-regex-if-necessary
+cat - | select-bundle-documents | that-support-allnamespace-install-mode | that-dont-have-dependencies | extract-olm-package-property | group-versions-by-package-name | filter-by-regex-if-necessary
 
 echo "NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks" >&2
 echo "WARNING: These results may include bundles with webhooks, which are incompatible" >&2


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

Small fix to the _hack/tools/catalogs/list-compatible-bundles_ script that adds the missing `extract-olm-package-property` function to the call chain and uses the correct name of regex filtering function (`filter-by-regex-if-necessary`), making sure the script works.
    The main issues here were two:
    1. `regex_it` did not exist and was renamed during review of the original PR to `filter-by-regex-if-necessary`
    2. `extract-olm-package-property` call was missing from the chain meaning the filter function couldn't recognize the structure it was expecting

Before change result:

>    ➜  operator-controller git:(main) ✗ ./hack/tools/catalogs/list-compatible-bundles < operatorhubio-catalog.json 
> 
> ./hack/tools/catalogs/list-compatible-bundles: line 80: regex_it: command not found
> NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks
> WARNING: These results may include bundles with webhooks, which are incompatible`

After change result:

> ➜  operator-controller git:(main) ✗ ./hack/tools/catalogs/list-compatible-bundles < operatorhubio-catalog.json > filtered.json
> NOTE: OLM v1 currently only supports bundles that support AllNamespaces install model, don't have dependencies, and don't contain webhooks
> WARNING: These results may include bundles with webhooks, which are incompatible
> 
> ➜  operator-controller git:(main) cat filtered.json
> [
>   {
>     "packageName": "ack-acm-controller",
>     "versions": [
>       "0.0.1",
>       "0.0.10",
>       "0.0.12",
>       "0.0.15",
>       "0.0.16",
>       "0.0.17",
>       "0.0.18",
>       "0.0.19",
>       "0.0.2",
>       "0.0.20",
>       "0.0.4",
>       "0.0.5",
>       "0.0.6",
>       "0.0.7",
>       "0.0.9",
>       "1.0.0"
>     ]
>   },
> ...

Separated from https://github.com/operator-framework/operator-controller/pull/1539 as per https://github.com/operator-framework/operator-controller/pull/1539#discussion_r1900596361

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
