### PR TITLE
🌱 Increase timeout for upgrade-e2e test to avoid flakes

### DIFF
--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -109,7 +109,7 @@ func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
 		assert.Contains(ct, cond.Message, "Installed bundle")
 		assert.Equal(ct, ocv1.BundleMetadata{Name: "test-operator.1.0.1", Version: "1.0.1"}, clusterExtension.Status.Install.Bundle)
 		assert.NotEqual(ct, previousVersion, clusterExtension.Status.Install.Bundle.Version)
-	}, time.Minute, time.Second)
+	}, 3*time.Minute, time.Second)
 }
 
 func watchPodLogsForSubstring(ctx context.Context, pod *corev1.Pod, container string, substrings ...string) (bool, error) {


### PR DESCRIPTION
Increasing the timeout to avoid flakes

PS.: I notice that it sometimes fails in GitHub action; therefore, I am just increasing to avoid flakes. 
Example: https://github.com/operator-framework/operator-controller/actions/runs/12653708386/job/35259771016?pr=1542

(I think it occurs when the same action is running and we push more changes )