### PR TITLE
🐛 Fix operator-controller not using updated registries configuration

### DIFF
--- a/catalogd/internal/source/containers_image.go
+++ b/catalogd/internal/source/containers_image.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/pkg/blobinfocache/none"
 	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
@@ -50,6 +51,9 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	if catalog.Spec.Source.Image == nil {
 		return nil, reconcile.TerminalError(fmt.Errorf("error parsing catalog, catalog %s has a nil image source", catalog.Name))
 	}
+
+	// Reload registries cache in case of configuration update
+	sysregistriesv2.InvalidateCache()
 
 	srcCtx, err := i.SourceContextFunc(l)
 	if err != nil {

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -306,7 +306,8 @@ func main() {
 				return nil, fmt.Errorf("could not stat auth file, error: %w", err)
 			}
 			return srcContext, nil
-		}}
+		},
+	}
 
 	clusterExtensionFinalizers := crfinalizer.NewFinalizers()
 	if err := clusterExtensionFinalizers.Register(controllers.ClusterExtensionCleanupUnpackCacheFinalizer, finalizers.FinalizerFunc(func(ctx context.Context, obj client.Object) (crfinalizer.Result, error) {

--- a/testdata/images/catalogs/test-catalog/v1/configs/catalog.yaml
+++ b/testdata/images/catalogs/test-catalog/v1/configs/catalog.yaml
@@ -69,3 +69,23 @@ properties:
     value:
       packageName: test-mirrored
       version: 1.2.0
+---
+schema: olm.package
+name: dynamic
+defaultChannel: beta
+---
+schema: olm.channel
+name: beta
+package: dynamic
+entries:
+  - name: dynamic-operator.1.2.0
+---
+schema: olm.bundle
+name: dynamic-operator.1.2.0
+package: dynamic
+image: dynamic-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/test-operator:v1.0.0
+properties:
+  - type: olm.package
+    value:
+      packageName: dynamic
+      version: 1.2.0


### PR DESCRIPTION
~NOTE: Same issue applies to catalogd, I'll make a similar change there.~ Done

With this change, operator-controller will be able to invalidate the configuration cache of `containers/image` and accept new configuration at runtime when changes occur.

~For code simplicity's sake, there's a few things to take note of that can be addressed if deemed necessary:~
* ~The cache always invalidates on the first unpack, as we've not yet read the `registries.conf` file. This is easily addressed but I wanted to keep `main()` clear of the file reading op.~
* ~We only check the `registries.conf` file. Checking the entire directory is more involved since we have to traverse the folder tree along with the symlinks dropped in there by k8s (`WalkDir` does not support symlinks , but it might [get easier](https://github.com/golang/go/issues/49580) in `go` 1.25?)~
