### PR TITLE
:seedling: remove 'function' from function defs in bash scripts

### DIFF
--- a/hack/tools/catalogs/generate-manifests
+++ b/hack/tools/catalogs/generate-manifests
@@ -17,7 +17,7 @@ assert-container-runtime
 # Check required tools are installed
 assert-commands jq
 
-function usage() {
+usage() {
     print-banner
     echo ""
     echo "Usage:"

--- a/hack/tools/catalogs/list-compatible-bundles
+++ b/hack/tools/catalogs/list-compatible-bundles
@@ -45,13 +45,13 @@ done
 shift $((OPTIND -1))
 
 # Select bundle documents
-function select-bundle-documents() {
+select-bundle-documents() {
     jq 'select(.schema == "olm.bundle")'
 }
 
 # Select bundles that declare AllNamespace install mode
 # or declare nothing at all (older released bundles sans "olm.csv.metadata" property)
-function that-support-allnamespace-install-mode() {
+that-support-allnamespace-install-mode() {
     jq 'select(
             all(.properties[].type; . != "olm.csv.metadata") or
             (.properties[]? |
@@ -65,23 +65,23 @@ function that-support-allnamespace-install-mode() {
 }
 
 # Select bundles without dependencies
-function that-dont-have-dependencies() {
+that-dont-have-dependencies() {
     jq 'select(all(.properties[].type; . != "olm.package.required" and . != "olm.gvk.required"))'
 }
 
 # Select the "olm.package" property from the bundles
 # This contains the packageName and version information
-function extract-olm-package-property() {
+extract-olm-package-property() {
     jq '.properties[] | select(.type == "olm.package") |.value'
 }
 
 # Group packages by name and collect versions into an array
-function group-versions-by-package-name() {
+group-versions-by-package-name() {
     jq -s 'group_by(.packageName) | map({packageName: .[0].packageName, versions: map(.version)})'
 }
 
 # Apply regex on name
-function filter-by-regex-if-necessary() {
+filter-by-regex-if-necessary() {
     jq --arg regex "$REGEX" '
         if $regex != "" then
             map(select(.packageName | test($regex)))

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -25,7 +25,7 @@ if [[ -z "$catalogd_version" || -z "$cert_mgr_version" ]]; then
     exit 1
 fi
 
-function kubectl_wait() {
+kubectl_wait() {
     namespace=$1
     runtime=$2
     timeout=$3
@@ -33,7 +33,7 @@ function kubectl_wait() {
     kubectl wait --for=condition=Available --namespace="${namespace}" "${runtime}" --timeout="${timeout}"
 }
 
-function kubectl_wait_rollout() {
+kubectl_wait_rollout() {
     namespace=$1
     runtime=$2
     timeout=$3
@@ -41,7 +41,7 @@ function kubectl_wait_rollout() {
     kubectl rollout status --namespace="${namespace}" "${runtime}" --timeout="${timeout}"
 }
 
-function kubectl_wait_for_query() {
+kubectl_wait_for_query() {
     manifest=$1
     query=$2
     timeout=$3


### PR DESCRIPTION
# Description

Seems it's poor bash form to use the `function` keyword when defining functions. This PR cleans up our bash scripts in this regard.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
