### PR TITLE
:sparkles: use single semver library

### DIFF
--- a/catalogd/internal/version/version.go
+++ b/catalogd/internal/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
 	genericversion "k8s.io/apimachinery/pkg/version"
 )
 
@@ -27,10 +27,11 @@ func Version() genericversion.Info {
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
-	v, err := semver.Parse(strings.TrimPrefix(gitVersion, "v"))
+
+	v, err := mmsemver.NewVersion(strings.TrimPrefix(gitVersion, "v"))
 	if err == nil {
-		info.Major = fmt.Sprintf("%d", v.Major)
-		info.Minor = fmt.Sprintf("%d", v.Minor)
+		info.Major = fmt.Sprintf("%d", v.Major())
+		info.Minor = fmt.Sprintf("%d", v.Minor())
 	}
 	return info
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	carvel.dev/kapp v0.63.3
 	github.com/BurntSushi/toml v1.4.0
 	github.com/Masterminds/semver/v3 v3.3.1
-	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/containerd v1.7.24
 	github.com/containers/image/v5 v5.32.2
 	github.com/fsnotify/fsnotify v1.8.0
@@ -55,6 +54,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/internal/bundleutil/bundle.go
+++ b/internal/bundleutil/bundle.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	bsemver "github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-registry/alpha/property"
@@ -12,25 +12,25 @@ import (
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 )
 
-func GetVersion(b declcfg.Bundle) (*bsemver.Version, error) {
+func GetVersion(b declcfg.Bundle) (*mmsemver.Version, error) {
 	for _, p := range b.Properties {
 		if p.Type == property.TypePackage {
 			var pkg property.Package
 			if err := json.Unmarshal(p.Value, &pkg); err != nil {
 				return nil, fmt.Errorf("error unmarshalling package property: %w", err)
 			}
-			vers, err := bsemver.Parse(pkg.Version)
+			vers, err := mmsemver.NewVersion(pkg.Version)
 			if err != nil {
 				return nil, err
 			}
-			return &vers, nil
+			return vers, nil
 		}
 	}
 	return nil, fmt.Errorf("no package property found in bundle %q", b.Name)
 }
 
 // MetadataFor returns a BundleMetadata for the given bundle name and version.
-func MetadataFor(bundleName string, bundleVersion bsemver.Version) ocv1.BundleMetadata {
+func MetadataFor(bundleName string, bundleVersion *mmsemver.Version) ocv1.BundleMetadata {
 	return ocv1.BundleMetadata{
 		Name:    bundleName,
 		Version: bundleVersion.String(),

--- a/internal/catalogmetadata/compare/compare.go
+++ b/internal/catalogmetadata/compare/compare.go
@@ -19,7 +19,7 @@ func ByVersion(b1, b2 declcfg.Bundle) int {
 
 	// Check for "greater than" because
 	// we want higher versions on top
-	return v2.Compare(*v1)
+	return v2.Compare(v1)
 }
 
 func ByDeprecationFunc(deprecation declcfg.Deprecation) func(a, b declcfg.Bundle) int {

--- a/internal/catalogmetadata/filter/successors.go
+++ b/internal/catalogmetadata/filter/successors.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	mmsemver "github.com/Masterminds/semver/v3"
-	bsemver "github.com/blang/semver/v4"
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
@@ -45,7 +44,7 @@ func SuccessorsOf(installedBundle ocv1.BundleMetadata, channels ...declcfg.Chann
 type successorsPredicateFunc func(installedBundle ocv1.BundleMetadata, channels ...declcfg.Channel) (Predicate[declcfg.Bundle], error)
 
 func legacySuccessor(installedBundle ocv1.BundleMetadata, channels ...declcfg.Channel) (Predicate[declcfg.Bundle], error) {
-	installedBundleVersion, err := bsemver.Parse(installedBundle.Version)
+	installedBundleVersion, err := mmsemver.NewVersion(installedBundle.Version)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing installed bundle version: %w", err)
 	}
@@ -60,8 +59,8 @@ func legacySuccessor(installedBundle ocv1.BundleMetadata, channels ...declcfg.Ch
 			}
 		}
 		if candidateBundleEntry.SkipRange != "" {
-			skipRange, err := bsemver.ParseRange(candidateBundleEntry.SkipRange)
-			if err == nil && skipRange(installedBundleVersion) {
+			skipRange, err := mmsemver.NewConstraint(candidateBundleEntry.SkipRange)
+			if err == nil && skipRange.Check(installedBundleVersion) {
 				return true
 			}
 		}

--- a/internal/catalogmetadata/filter/successors_test.go
+++ b/internal/catalogmetadata/filter/successors_test.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"testing"
 
-	bsemver "github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -134,7 +134,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsEnabled(t *testing.
 	}{
 		{
 			name:            "with non-zero major version",
-			installedBundle: bundleutil.MetadataFor("test-package.v2.0.0", bsemver.MustParse("2.0.0")),
+			installedBundle: bundleutil.MetadataFor("test-package.v2.0.0", mmsemver.MustParse("2.0.0")),
 			expectedResult: []declcfg.Bundle{
 				// Updates are allowed within the major version
 				bundleSet["test-package.v2.2.0"],
@@ -144,7 +144,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsEnabled(t *testing.
 		},
 		{
 			name:            "with zero major and zero minor version",
-			installedBundle: bundleutil.MetadataFor("test-package.v0.0.1", bsemver.MustParse("0.0.1")),
+			installedBundle: bundleutil.MetadataFor("test-package.v0.0.1", mmsemver.MustParse("0.0.1")),
 			expectedResult: []declcfg.Bundle{
 				// No updates are allowed in major version zero when minor version is also zero
 				bundleSet["test-package.v0.0.1"],
@@ -152,7 +152,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsEnabled(t *testing.
 		},
 		{
 			name:            "with zero major and non-zero minor version",
-			installedBundle: bundleutil.MetadataFor("test-package.v0.1.0", bsemver.MustParse("0.1.0")),
+			installedBundle: bundleutil.MetadataFor("test-package.v0.1.0", mmsemver.MustParse("0.1.0")),
 			expectedResult: []declcfg.Bundle{
 				// Patch version updates are allowed within the minor version
 				bundleSet["test-package.v0.1.2"],
@@ -286,7 +286,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsDisabled(t *testing
 	}{
 		{
 			name:            "respect replaces directive from catalog",
-			installedBundle: bundleutil.MetadataFor("test-package.v2.0.0", bsemver.MustParse("2.0.0")),
+			installedBundle: bundleutil.MetadataFor("test-package.v2.0.0", mmsemver.MustParse("2.0.0")),
 			expectedResult: []declcfg.Bundle{
 				// Must only have two bundle:
 				// - the one which replaces the current version
@@ -297,7 +297,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsDisabled(t *testing
 		},
 		{
 			name:            "respect skips directive from catalog",
-			installedBundle: bundleutil.MetadataFor("test-package.v2.2.1", bsemver.MustParse("2.2.1")),
+			installedBundle: bundleutil.MetadataFor("test-package.v2.2.1", mmsemver.MustParse("2.2.1")),
 			expectedResult: []declcfg.Bundle{
 				// Must only have two bundle:
 				// - the one which skips the current version
@@ -308,7 +308,7 @@ func TestSuccessorsPredicateWithForceSemverUpgradeConstraintsDisabled(t *testing
 		},
 		{
 			name:            "respect skipRange directive from catalog",
-			installedBundle: bundleutil.MetadataFor("test-package.v2.3.0", bsemver.MustParse("2.3.0")),
+			installedBundle: bundleutil.MetadataFor("test-package.v2.3.0", mmsemver.MustParse("2.3.0")),
 			expectedResult: []declcfg.Bundle{
 				// Must only have two bundle:
 				// - the one which is skipRanges the current version

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -242,7 +242,7 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1.Cl
 	//         all catalogs?
 	SetDeprecationStatus(ext, resolvedBundle.Name, resolvedDeprecation)
 
-	resolvedBundleMetadata := bundleutil.MetadataFor(resolvedBundle.Name, *resolvedBundleVersion)
+	resolvedBundleMetadata := bundleutil.MetadataFor(resolvedBundle.Name, resolvedBundleVersion)
 	bundleSource := &rukpaksource.BundleSource{
 		Name: ext.GetName(),
 		Type: rukpaksource.SourceTypeImage,

--- a/internal/controllers/clusterextension_controller_test.go
+++ b/internal/controllers/clusterextension_controller_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 	"testing/fstest"
 
-	bsemver "github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func TestClusterExtensionDoesNotExist(t *testing.T) {
 func TestClusterExtensionResolutionFails(t *testing.T) {
 	pkgName := fmt.Sprintf("non-existent-%s", rand.String(6))
 	cl, reconciler := newClientAndReconciler(t)
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
 		return nil, nil, nil, fmt.Errorf("no package %q found", pkgName)
 	})
 	ctx := context.Background()
@@ -154,13 +155,13 @@ func TestClusterExtensionResolutionSuccessfulUnpackFails(t *testing.T) {
 
 			t.Log("It sets resolution success status")
 			t.Log("By running reconcile")
-			reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-				v := bsemver.MustParse("1.0.0")
+			reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+				v := mmsemver.MustParse("1.0.0")
 				return &declcfg.Bundle{
 					Name:    "prometheus.v1.0.0",
 					Package: "prometheus",
 					Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-				}, &v, nil, nil
+				}, v, nil, nil
 			})
 			res, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: extKey})
 			require.Equal(t, ctrl.Result{}, res)
@@ -236,13 +237,13 @@ func TestClusterExtensionUnpackUnexpectedState(t *testing.T) {
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 
 	require.Panics(t, func() {
@@ -294,13 +295,13 @@ func TestClusterExtensionResolutionAndUnpackSuccessfulApplierFails(t *testing.T)
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 	reconciler.Applier = &MockApplier{
 		err: errors.New("apply failure"),
@@ -374,13 +375,13 @@ func TestClusterExtensionApplierFailsWithBundleInstalled(t *testing.T) {
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 
 	reconciler.Manager = &MockManagedContentCacheManager{
@@ -473,13 +474,13 @@ func TestClusterExtensionManagerFailed(t *testing.T) {
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 	reconciler.Applier = &MockApplier{
 		objs: []client.Object{},
@@ -555,13 +556,13 @@ func TestClusterExtensionManagedContentCacheWatchFail(t *testing.T) {
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 	reconciler.Applier = &MockApplier{
 		objs: []client.Object{},
@@ -638,13 +639,13 @@ func TestClusterExtensionInstallationSucceeds(t *testing.T) {
 
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 	reconciler.Applier = &MockApplier{
 		objs: []client.Object{},
@@ -718,13 +719,13 @@ func TestClusterExtensionDeleteFinalizerFails(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("It sets resolution success status")
 	t.Log("By running reconcile")
-	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
-		v := bsemver.MustParse("1.0.0")
+	reconciler.Resolver = resolve.Func(func(_ context.Context, _ *ocv1.ClusterExtension, _ *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
+		v := mmsemver.MustParse("1.0.0")
 		return &declcfg.Bundle{
 			Name:    "prometheus.v1.0.0",
 			Package: "prometheus",
 			Image:   "quay.io/operatorhubio/prometheus@fake1.0.0",
-		}, &v, nil, nil
+		}, v, nil, nil
 	})
 	fakeFinalizer := "fake.testfinalizer.io"
 	finalizersMessage := "still have finalizers"

--- a/internal/resolve/catalog.go
+++ b/internal/resolve/catalog.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	mmsemver "github.com/Masterminds/semver/v3"
-	bsemver "github.com/blang/semver/v4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,7 +37,7 @@ type foundBundle struct {
 }
 
 // Resolve returns a Bundle from a catalog that needs to get installed on the cluster.
-func (r *CatalogResolver) Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
+func (r *CatalogResolver) Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
 	packageName := ext.Spec.Source.Catalog.PackageName
 	versionRange := ext.Spec.Source.Catalog.Version
 	channels := ext.Spec.Source.Catalog.Channels

--- a/internal/resolve/catalog_test.go
+++ b/internal/resolve/catalog_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	bsemver "github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,7 +92,7 @@ func TestPackageExists(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "3.0.0"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("3.0.0"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("3.0.0"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -159,7 +159,7 @@ func TestVersionExists(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "1.0.2"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("1.0.2"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("1.0.2"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -200,7 +200,7 @@ func TestChannelExists(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "1.0.2"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("1.0.2"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("1.0.2"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -260,7 +260,7 @@ func TestChannelAndVersionExist(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "0.1.0"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("0.1.0"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("0.1.0"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -282,7 +282,7 @@ func TestPreferNonDeprecated(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "0.1.0"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("0.1.0"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("0.1.0"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -304,7 +304,7 @@ func TestAcceptDeprecated(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "1.0.1"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("1.0.1"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("1.0.1"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -388,7 +388,7 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 		require.NoError(t, err)
 		// We choose the only non-deprecated package
 		assert.Equal(t, genBundle(pkgName, "1.0.2").Name, gotBundle.Name)
-		assert.Equal(t, bsemver.MustParse("1.0.2"), *gotVersion)
+		assert.Equal(t, mmsemver.MustParse("1.0.2"), gotVersion)
 		assert.Equal(t, (*declcfg.Deprecation)(nil), gotDeprecation)
 	})
 
@@ -420,7 +420,7 @@ func TestPackageVariationsBetweenCatalogs(t *testing.T) {
 		require.NoError(t, err)
 		// Bundles within one catalog for a package will be sorted by semver and deprecation and the best is returned
 		assert.Equal(t, genBundle(pkgName, "1.0.5").Name, gotBundle.Name)
-		assert.Equal(t, bsemver.MustParse("1.0.5"), *gotVersion)
+		assert.Equal(t, mmsemver.MustParse("1.0.5"), gotVersion)
 		assert.Equal(t, (*declcfg.Deprecation)(nil), gotDeprecation)
 	})
 }
@@ -449,7 +449,7 @@ func TestUpgradeFoundLegacy(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, installedBundle)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "1.0.2"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("1.0.2"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("1.0.2"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -504,7 +504,7 @@ func TestUpgradeFoundSemver(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, installedBundle)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "1.0.2"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("1.0.2"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("1.0.2"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -558,7 +558,7 @@ func TestDowngradeFound(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, installedBundle)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "0.1.0"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("0.1.0"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("0.1.0"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -917,7 +917,7 @@ func TestUnequalPriority(t *testing.T) {
 	ce := buildFooClusterExtension(pkgName, []string{}, "", ocv1.UpgradeConstraintPolicyCatalogProvided)
 	_, gotVersion, _, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
-	require.Equal(t, bsemver.MustParse("1.0.0"), *gotVersion)
+	require.Equal(t, mmsemver.MustParse("1.0.0"), gotVersion)
 }
 
 func TestMultiplePriority(t *testing.T) {
@@ -962,7 +962,7 @@ func TestMultipleChannels(t *testing.T) {
 	gotBundle, gotVersion, gotDeprecation, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	assert.Equal(t, genBundle(pkgName, "2.0.0"), *gotBundle)
-	assert.Equal(t, bsemver.MustParse("2.0.0"), *gotVersion)
+	assert.Equal(t, mmsemver.MustParse("2.0.0"), gotVersion)
 	assert.Equal(t, ptr.To(packageDeprecation(pkgName)), gotDeprecation)
 }
 
@@ -1035,5 +1035,5 @@ func TestSomeCatalogsDisabled(t *testing.T) {
 	gotBundle, gotVersion, _, err := r.Resolve(context.Background(), ce, nil)
 	require.NoError(t, err)
 	require.NotNil(t, gotBundle)
-	require.Equal(t, bsemver.MustParse("3.0.0"), *gotVersion)
+	require.Equal(t, mmsemver.MustParse("3.0.0"), gotVersion)
 }

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -3,7 +3,7 @@ package resolve
 import (
 	"context"
 
-	bsemver "github.com/blang/semver/v4"
+	mmsemver "github.com/Masterminds/semver/v3"
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
@@ -11,11 +11,11 @@ import (
 )
 
 type Resolver interface {
-	Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error)
+	Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error)
 }
 
-type Func func(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error)
+type Func func(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error)
 
-func (f Func) Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *bsemver.Version, *declcfg.Deprecation, error) {
+func (f Func) Resolve(ctx context.Context, ext *ocv1.ClusterExtension, installedBundle *ocv1.BundleMetadata) (*declcfg.Bundle, *mmsemver.Version, *declcfg.Deprecation, error) {
 	return f(ctx, ext, installedBundle)
 }


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

There are currently two libraries being used directly in the code to deal with semver: `github.com/Masterminds/semver/v3` and `github.com/blang/semver/v4`.
This PR tries to elimitate one of them (blang/semver), since the second library seems to be covering all use cases where blang was being used.
This has a direct impact on security as well as readability and general development, because we won't be needing to deal with different types that ultimately handle the same thing.

At this stage, this is meant to be a draft looking for opinions and any considerations which would explain why this shouldn't be done. I have not looked into masterminds `NewVersion()` vs `StrictNewVersion()` for example and if there would be a need to use the latter.

Rationale for choosing to go with mastermind's lib in this draft was that we only used two methods from blang that mm covered and used a lot more functionality of mm that blang didin't cover (or at least doesn't seem to cover).

Note: blang/semver still remains as an indirect dependency, potentially because of use in `declcfg`.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
