### PR TITLE
🐛  Fixes reference to catalogd repo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ controllers, and tooling that support the packaging, distribution, and lifecycli
 
 OLM v1 consists of two different components:
 
-* operator-controller (this repository)
-* [catalogd](https://github.com/operator-framework/catalogd)
+* operator-controller
+* catalogd
 
 For a more complete overview of OLM v1 and how it differs from OLM v0, see our [overview](docs/project/olmv1_design_decisions.md).
 


### PR DESCRIPTION
We should not refer to catalogd repo since the monorepo implementation.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
