### PR TITLE
:bug: remove reference to non-existent target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ verify-crd-compatibility: $(CRD_DIFF) manifests
 	$(CRD_DIFF) --config="${CRD_DIFF_CONFIG}" "git://${CRD_DIFF_ORIGINAL_REF}?path=config/base/crd/bases/olm.operatorframework.io_clusterextensions.yaml" ${CRD_DIFF_UPDATED_SOURCE}
 
 .PHONY: test
-test: manifests generate generate-catalogd fmt vet test-unit test-e2e #HELP Run all tests.
+test: manifests generate fmt vet test-unit test-e2e #HELP Run all tests.
 
 .PHONY: e2e
 e2e: #EXHELP Run the e2e tests.


### PR DESCRIPTION
# Description

Noticed the test target references a no longer existent `generate-catalogd` target. Just cleaning that up.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
