### PR TITLE
:seedling: add vendor dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,8 @@ operator-controller.yaml
 install.sh
 catalogd.yaml
 
-# Kubernetes Generated files - skip generated files, except for vendored files
-
-!vendor/**/zz_generated.*
+# vendored files
+vendor/
 
 # editor and IDE paraphernalia
 .idea/


### PR DESCRIPTION
# Description

Adds `vendor` dir to .gitignore to avoid adding them by mistake

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
