### PR TITLE
🐛 Replace deprecated upload action for e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Run e2e tests
         run: ARTIFACT_PATH=/tmp/artifacts make test-e2e
 
-      - uses: cytopia/upload-artifact-retry-action@v0.1.7
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: e2e-artifacts


### PR DESCRIPTION
E2E is failing due to an action we use which in turn uses a deprecated version of `actions/upload-artifact`. Confusingly, the article [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) states that this will happen on the 30th, and yet it's failing today ([example](https://github.com/operator-framework/operator-controller/actions/runs/12812852550/job/35725510412))