### PR TITLE
:bug: Fix upgrade-e2e, use updated upload-artifact

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,7 +60,7 @@ jobs:
     - name: Run the upgrade e2e test
       run: ARTIFACT_PATH=/tmp/artifacts make test-upgrade-e2e
 
-    - uses: cytopia/upload-artifact-retry-action@v0.1.7
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: upgrade-e2e-artifacts


### PR DESCRIPTION
Replace cytopia/upload-artifact-retry-action with actions/upload-artifact

This is the same action that e2e-kind uses

cytopia/upload-artifact-retry-action uses an out-of-date upload-artifact action, and has been stale since Nov 2022

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
