### PR TITLE
:seedling: add benchmark pipeline

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,46 @@
+name: Benchmark Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies
+        run: |
+          go mod download
+          go mod tidy
+
+      # - name: Debug via SSH
+      #   uses: mxschmitt/action-tmate@v3
+
+      - name: Run benchmark test
+        # working-directory: test/e2e
+        run: |
+          mkdir -p /tmp/artifacts/
+          ARTIFACT_PATH=/tmp/artifacts make test-benchmark
+
+      - name: Compare with baseline
+        run: |
+          go install golang.org/x/perf/cmd/benchstat@latest
+          benchstat benchmarks/baseline.txt /tmp/artifacts/new.txt | tee /tmp/artifacts/output
+
+      - name: Upload benchmark results      
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-artifacts
+          path: /tmp/artifacts/
+          

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  benchmark:
+  run-benchmark:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -33,14 +33,263 @@ jobs:
           mkdir -p /tmp/artifacts/
           ARTIFACT_PATH=/tmp/artifacts make test-benchmark
 
-      - name: Compare with baseline
+      - name: Convert Benchmark Output to Prometheus Metrics
         run: |
-          go install golang.org/x/perf/cmd/benchstat@latest
-          benchstat benchmarks/baseline.txt /tmp/artifacts/new.txt | tee /tmp/artifacts/output
+          mkdir -p /tmp/artifacts/prometheus/
+          echo "RUN_ID=${{ github.run_id }}"
+          export RUN_ID=${{ github.run_id }}
+          cat << 'EOF' > benchmark_to_prometheus.py
+          import sys
+          import re
+          import os
 
-      - name: Upload benchmark results      
+          def parse_benchmark_output(benchmark_output):
+              metrics = []
+              round = 0
+              value = os.getenv('RUN_ID') #get the github action run id so that those metrics cannot be overwritten
+              for line in benchmark_output.split("\n"):
+                  match = re.match(r"Benchmark([\w\d]+)-\d+\s+\d+\s+([\d]+)\s+ns/op\s+([\d]+)\s+B/op\s+([\d]+)\s+allocs/op", line)
+                  if match:
+                      benchmark_name = match.group(1).lower()
+                      time_ns = match.group(2)
+                      memory_bytes = match.group(3)
+                      allocs = match.group(4)
+
+                      metrics.append(f"benchmark_{benchmark_name}_ns {{run_id=\"{value}\", round=\"{round}\"}} {time_ns}")
+                      metrics.append(f"benchmark_{benchmark_name}_allocs {{run_id=\"{value}\", round=\"{round}\"}} {allocs}")
+                      metrics.append(f"benchmark_{benchmark_name}_mem_bytes {{run_id=\"{value}\", round=\"{round}\"}} {memory_bytes}")
+                      round+=1
+
+              return "\n".join(metrics)
+
+          if __name__ == "__main__":
+              benchmark_output = sys.stdin.read()
+              metrics = parse_benchmark_output(benchmark_output)
+              print(metrics)
+          EOF
+
+          cat /tmp/artifacts/new.txt | python3 benchmark_to_prometheus.py | tee /tmp/artifacts/prometheus/metrics.txt
+
+      # - name: Compare with baseline
+      #   run: |
+      #     go install golang.org/x/perf/cmd/benchstat@latest
+      #     benchstat benchmarks/baseline.txt /tmp/artifacts/new.txt | tee /tmp/artifacts/output
+
+      - name: Upload Benchmark Metrics     
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-artifacts
-          path: /tmp/artifacts/
+          name: benchmark-metrics
+          path: /tmp/artifacts/prometheus/
+
+  run-prometheus:
+    needs: run-benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ToDo: use GitHub REST API to download artifact across repos
+      - name: Download Prometheus Snapshot
+        run: |
+          echo "Available Artifacts in this run:"
+          gh run list --repo operator-framework/operator-controller --limit 5
+          gh run download --repo operator-framework/operator-controller --name prometheus-snapshot --dir .
+          ls -lh ./
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # #this step is invalid if download the artifacts in a different job    
+      # - name: Download Prometheus Snapshot2
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: prometheus-snapshot
+      #     path: ./
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Benchmark Metrics
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-metrics
+          path: ./
+
+      - name: Get Host IP
+        run: | 
+          echo "HOST_IP=$(ip route get 1 | awk '{print $7}')" | tee -a $GITHUB_ENV
+
+      # localhost doesn't work, use host IP directly
+      - name: Set Up Prometheus Config
+        run: |
+          echo "HOST_IP is $HOST_IP"
+          cat << EOF > prometheus.yml
+          global:
+            scrape_interval: 5s
+          scrape_configs:
+            - job_name: 'benchmark_metrics'
+              static_configs:
+                - targets: ['$HOST_IP:9000']
+          EOF
+          mkdir -p ${{ github.workspace }}/prometheus-data
+          sudo chown -R 65534:65534 ${{ github.workspace }}/prometheus-data
+          sudo chmod -R 777 ${{ github.workspace }}/prometheus-data
+
+      - name: Extract and Restore Prometheus Snapshot
+        run: |
+          SNAPSHOT_ZIP="${{ github.workspace }}/prometheus-snapshot.zip"
+          SNAPSHOT_TAR="${{ github.workspace }}/prometheus_snapshot.tar.gz"
+          SNAPSHOT_DIR="${{ github.workspace }}/prometheus-data/snapshots"
+
+          mkdir -p "$SNAPSHOT_DIR"
+
+          if [[ -f "$SNAPSHOT_ZIP" ]]; then
+            echo "📦 Detected ZIP archive: $SNAPSHOT_ZIP"
+            unzip -o "$SNAPSHOT_ZIP" -d "$SNAPSHOT_DIR"
+            echo "✅ Successfully extracted ZIP snapshot."
+          elif [[ -f "$SNAPSHOT_TAR" ]]; then
+            echo "📦 Detected TAR archive: $SNAPSHOT_TAR"
+            tar -xzf "$SNAPSHOT_TAR" -C "$SNAPSHOT_DIR"
+            echo "✅ Successfully extracted TAR snapshot."
+          else
+            echo "⚠️ WARNING: No snapshot file found. Skipping extraction."
+          fi
+
+      - name: Run Prometheus
+        run: |
+          docker run -d --name prometheus -p 9090:9090 \
+            --user=root \
+            -v ${{ github.workspace }}/prometheus.yml:/etc/prometheus/prometheus.yml \
+            -v ${{ github.workspace }}/prometheus-data:/prometheus \
+            prom/prometheus --config.file=/etc/prometheus/prometheus.yml \
+            --storage.tsdb.path=/prometheus \
+            --storage.tsdb.retention.time=1h \
+            --web.enable-admin-api
+
+      - name: Wait for Prometheus to start
+        run: sleep 10
+
+      - name: Check Prometheus is running
+        run: |
+           set -e
+           curl -s http://localhost:9090/-/ready || (docker logs prometheus && exit 1)
+          
+      - name: Start HTTP Server to Expose Metrics
+        run: |
+          cat << 'EOF' > server.py
+          from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+          class MetricsHandler(SimpleHTTPRequestHandler):
+              def do_GET(self):
+                  if self.path == "/metrics":
+                      self.send_response(200)
+                      self.send_header("Content-type", "text/plain")
+                      self.end_headers()
+                      with open("metrics.txt", "r") as f:
+                          self.wfile.write(f.read().encode())
+                  else:
+                      self.send_response(404)
+                      self.end_headers()
+
+          if __name__ == "__main__":
+              server = HTTPServer(('0.0.0.0', 9000), MetricsHandler)
+              print("Serving on port 9000...")
+              server.serve_forever()
+          EOF
+          
+          nohup python3 server.py &
+
+      - name: Wait for Prometheus to Collect Data
+        run: sleep 30
+
+      - name: Check Prometheus targets page
+        run: |
+          http_status=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:9090/targets)
+          if [ "$http_status" -eq 200 ]; then
+            echo "Prometheus targets page is reachable."
+          else
+            echo "Error: Prometheus targets page is not reachable. Status code: $http_status"
+            exit 1
+          fi
+
+          http_status=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:9090/targets)
+          if [ "$http_status" -eq 200 ]; then
+            echo "Prometheus targets page is reachable."
+            
+            # Check for lastError field in the targets API
+            error=$(curl -s http://localhost:9090/api/v1/targets | jq -r '.data.activeTargets[].lastError')
+            if [ "$error" != "null" ] && [ -n "$error" ]; then
+              echo "Error: Prometheus target has an error: $error"
+              exit 1
+            else
+              echo "No errors found in Prometheus targets."
+            fi
+
+          else
+            echo "Error: Prometheus targets page is not reachable. Status code: $http_status"
+            exit 1
+          fi
+
+      # - name: Debug via SSH
+      #   uses: mxschmitt/action-tmate@v3
+
+      - name: Check Benchmark Metrics Against Threshold
+        run: |
+          MAX_TIME_NS=1200000000  # 1.2s
+          MAX_ALLOCS=4000
+          MAX_MEM_BYTES=450000
+
+          # Query Prometheus Metrics, get the max value
+          time_ns=$(curl -s "http://localhost:9090/api/v1/query?query=max(benchmark_createclustercatalog_ns)" | jq -r '.data.result[0].value[1]')
+          allocs=$(curl -s "http://localhost:9090/api/v1/query?query=max(benchmark_createclustercatalog_allocs)" | jq -r '.data.result[0].value[1]')
+          mem_bytes=$(curl -s "http://localhost:9090/api/v1/query?query=max(benchmark_createclustercatalog_mem_bytes)" | jq -r '.data.result[0].value[1]')
+
+          echo "⏳ Benchmark Execution Time: $time_ns ns"
+          echo "🛠️ Memory Allocations: $allocs"
+          echo "💾 Memory Usage: $mem_bytes bytes"
+
+          # threshold checking
+          if (( $(echo "$time_ns > $MAX_TIME_NS" | bc -l) )); then
+            echo "❌ ERROR: Execution time exceeds threshold!"
+            exit 1
+          fi
+
+          if (( $(echo "$allocs > $MAX_ALLOCS" | bc -l) )); then
+            echo "❌ ERROR: Too many memory allocations!"
+            exit 1
+          fi
+
+          if (( $(echo "$mem_bytes > $MAX_MEM_BYTES" | bc -l) )); then
+            echo "❌ ERROR: Memory usage exceeds threshold!"
+            exit 1
+          fi
+
+          echo "✅ All benchmarks passed within threshold!"
+
+      - name: Trigger Prometheus Snapshot
+        run: |
+          set -e
+          curl -X POST http://localhost:9090/api/v1/admin/tsdb/snapshot || (docker logs prometheus && exit 1)
+
+      - name: Find and Upload Prometheus Snapshot
+        run: |
+          SNAPSHOT_PATH=$(ls -td ${{ github.workspace }}/prometheus-data/snapshots/* 2>/dev/null | head -1 || echo "")
+          if [[ -z "$SNAPSHOT_PATH" ]]; then
+            echo "❌ No Prometheus snapshot found!"
+            docker logs prometheus
+            exit 1
+          fi
+
+          echo "✅ Prometheus snapshot stored in: $SNAPSHOT_PATH"
+          tar -czf $GITHUB_WORKSPACE/prometheus_snapshot.tar.gz -C "$SNAPSHOT_PATH" .
+
+
+      - name: Stop Prometheus
+        run: docker stop prometheus
+
+      - name: Upload Prometheus Snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: prometheus-snapshot
+          path: prometheus_snapshot.tar.gz
           

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,11 @@ test: manifests generate fmt lint test-unit test-e2e #HELP Run all tests.
 e2e: #EXHELP Run the e2e tests.
 	go test -count=1 -v ./test/e2e/...
 
+.PHONY: benchmark
+benchmark: #EXHELP Run the benchmark tests.
+	export CATALOG_IMG=registry.redhat.io/redhat/redhat-operator-index:v4.18
+	go test -v -run=^$$ -bench=. -benchmem -count=10 -v ./test/e2e/... | tee /tmp/artifacts/new.txt
+
 E2E_REGISTRY_NAME := docker-registry
 E2E_REGISTRY_NAMESPACE := operator-controller-e2e
 
@@ -255,6 +260,12 @@ catalogd-pre-upgrade-setup:
 
 catalogd-image-registry: ## Setup in-cluster image registry
 	./test/tools/imageregistry/registry.sh $(ISSUER_KIND) $(ISSUER_NAME)
+
+.PHONY: test-benchmark
+test-benchmark: KIND_CLUSTER_NAME := operator-controller-benchmark
+test-benchmark: KUSTOMIZE_BUILD_DIR := config/overlays/e2e
+test-benchmark: GO_BUILD_FLAGS := -cover
+test-benchmark: run image-registry benchmark kind-clean #HELP Run benchmark test suite on local kind cluster
 
 .PHONY: extension-developer-e2e
 extension-developer-e2e: KUSTOMIZE_BUILD_DIR := config/overlays/cert-manager

--- a/benchmarks/baseline.txt
+++ b/benchmarks/baseline.txt
@@ -1,0 +1,16 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/operator-framework/operator-controller/test/e2e
+cpu: Apple M1 Pro
+BenchmarkCreateClusterCatalog-10    	       1	1352852042 ns/op	  404520 B/op	    3914 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  86982353 ns/op	   36907 B/op	     394 allocs/op
+BenchmarkCreateClusterCatalog-10    	      12	  84962496 ns/op	   34555 B/op	     393 allocs/op
+BenchmarkCreateClusterCatalog-10    	      18	  70375363 ns/op	   34880 B/op	     388 allocs/op
+BenchmarkCreateClusterCatalog-10    	      15	  71715708 ns/op	   37654 B/op	     399 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  85251170 ns/op	   36572 B/op	     396 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  83413260 ns/op	   38435 B/op	     393 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  93851487 ns/op	   37249 B/op	     395 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  78722212 ns/op	   36593 B/op	     393 allocs/op
+BenchmarkCreateClusterCatalog-10    	      13	  86393522 ns/op	   37404 B/op	     395 allocs/op
+PASS
+ok  	github.com/operator-framework/operator-controller/test/e2e	32.699s

--- a/test/e2e/benchmark_test.go
+++ b/test/e2e/benchmark_test.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkCreateClusterCatalog(b *testing.B) {
+	catalogImageRef := os.Getenv(testCatalogRefEnvVar)
+	if catalogImageRef == "" {
+		b.Fatalf("environment variable %s is not set", testCatalogRefEnvVar)
+	}
+	ctx := context.Background()
+	b.ResetTimer()
+	// b.RunParallel(func(pb *testing.PB) {
+	// 	for pb.Next() {
+	// 		catalogObj, err := createTestCatalog(ctx, getRandomStringParallel(6), catalogImageRef)
+	// 		if err != nil {
+	// 			b.Logf("failed to create ClusterCatalog: %v", err)
+	// 		}
+
+	// 		if err := deleteTestCatalog(ctx, catalogObj); err != nil {
+	// 			b.Logf("failed to remove ClusterCatalog: %v", err)
+	// 		}
+	// 	}
+	// })
+	for i := 0; i < b.N; i++ {
+		catalogObj, err := createTestCatalog(ctx, getRandomString(8), catalogImageRef)
+		if err != nil {
+			b.Logf("failed to create ClusterCatalog: %v", err)
+		}
+
+		if err := deleteTestCatalog(ctx, catalogObj); err != nil {
+			b.Logf("failed to remove ClusterCatalog: %v", err)
+		}
+	}
+}
+
+var (
+	mu        sync.Mutex
+	usedChars = make(map[string]struct{})
+	alphabet  = "abcdefghijklmnopqrstuvwxyz"
+)
+
+func getRandomStringParallel(length int) string {
+	// Ensure we seed the random number generator only once
+	rand.Seed(time.Now().UnixNano())
+
+	// Lock to ensure no concurrent access to shared resources (e.g., usedChars)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Try generating a random string and ensure it's unique
+	for {
+		var result []rune
+		for i := 0; i < length; i++ {
+			result = append(result, rune(alphabet[rand.Intn(len(alphabet))]))
+		}
+		// Convert result to string
+		randomStr := string(result)
+
+		// Check if the generated string is unique
+		if _, exists := usedChars[randomStr]; !exists {
+			// If it's unique, add it to the map and return it
+			usedChars[randomStr] = struct{}{}
+			return randomStr
+		}
+	}
+}
+
+// GetRandomString generates a random string of the given length
+func getRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyz"
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/test/e2e/benchmark_test.go
+++ b/test/e2e/benchmark_test.go
@@ -2,11 +2,10 @@ package e2e
 
 import (
 	"context"
-	"math/rand"
 	"os"
-	"sync"
 	"testing"
-	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func BenchmarkCreateClusterCatalog(b *testing.B) {
@@ -16,70 +15,26 @@ func BenchmarkCreateClusterCatalog(b *testing.B) {
 	}
 	ctx := context.Background()
 	b.ResetTimer()
-	// b.RunParallel(func(pb *testing.PB) {
-	// 	for pb.Next() {
-	// 		catalogObj, err := createTestCatalog(ctx, getRandomStringParallel(6), catalogImageRef)
-	// 		if err != nil {
-	// 			b.Logf("failed to create ClusterCatalog: %v", err)
-	// 		}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			catalogObj, err := createTestCatalog(ctx, rand.String(6), catalogImageRef)
+			if err != nil {
+				b.Logf("failed to create ClusterCatalog: %v", err)
+			}
 
-	// 		if err := deleteTestCatalog(ctx, catalogObj); err != nil {
-	// 			b.Logf("failed to remove ClusterCatalog: %v", err)
-	// 		}
+			if err := deleteTestCatalog(ctx, catalogObj); err != nil {
+				b.Logf("failed to remove ClusterCatalog: %v", err)
+			}
+		}
+	})
+	// for i := 0; i < b.N; i++ {
+	// 	catalogObj, err := createTestCatalog(ctx, rand.String(8), catalogImageRef)
+	// 	if err != nil {
+	// 		b.Logf("failed to create ClusterCatalog: %v", err)
 	// 	}
-	// })
-	for i := 0; i < b.N; i++ {
-		catalogObj, err := createTestCatalog(ctx, getRandomString(8), catalogImageRef)
-		if err != nil {
-			b.Logf("failed to create ClusterCatalog: %v", err)
-		}
 
-		if err := deleteTestCatalog(ctx, catalogObj); err != nil {
-			b.Logf("failed to remove ClusterCatalog: %v", err)
-		}
-	}
-}
-
-var (
-	mu        sync.Mutex
-	usedChars = make(map[string]struct{})
-	alphabet  = "abcdefghijklmnopqrstuvwxyz"
-)
-
-func getRandomStringParallel(length int) string {
-	// Ensure we seed the random number generator only once
-	rand.Seed(time.Now().UnixNano())
-
-	// Lock to ensure no concurrent access to shared resources (e.g., usedChars)
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Try generating a random string and ensure it's unique
-	for {
-		var result []rune
-		for i := 0; i < length; i++ {
-			result = append(result, rune(alphabet[rand.Intn(len(alphabet))]))
-		}
-		// Convert result to string
-		randomStr := string(result)
-
-		// Check if the generated string is unique
-		if _, exists := usedChars[randomStr]; !exists {
-			// If it's unique, add it to the map and return it
-			usedChars[randomStr] = struct{}{}
-			return randomStr
-		}
-	}
-}
-
-// GetRandomString generates a random string of the given length
-func getRandomString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyz"
-	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
-	}
-	return string(b)
+	// 	if err := deleteTestCatalog(ctx, catalogObj); err != nil {
+	// 		b.Logf("failed to remove ClusterCatalog: %v", err)
+	// 	}
+	// }
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -65,6 +65,10 @@ func createTestCatalog(ctx context.Context, name string, imageRef string) (*cata
 	return catalog, err
 }
 
+func deleteTestCatalog(ctx context.Context, catalog *catalogd.ClusterCatalog) error {
+	return c.Delete(ctx, catalog)
+}
+
 // patchTestCatalog will patch the existing clusterCatalog on the test cluster, provided
 // the context, catalog name, and the image reference. It returns an error
 // if any errors occurred while updating the catalog.


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
See more: https://github.com/operator-framework/operator-controller/issues/920
- Serial run on AWS, Cluster version is 4.18.0-0.nightly-2025-01-25-163410

```golang
jiazha-mac:e2e jiazha$ go test -run=^$ -bench=. -count=10 -memprofile=mem.out -cpuprofile=cpu.out
goos: darwin
goarch: arm64
pkg: github.com/operator-framework/operator-controller/test/e2e
cpu: Apple M1 Pro
BenchmarkCreateClusterCatalog-10    	       1	1444716583 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 619736229 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 594375416 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 599388104 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 578713375 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 604820354 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 614665062 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 613025938 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 622365104 ns/op
BenchmarkCreateClusterCatalog-10    	       2	 591780896 ns/op
PASS
ok  	github.com/operator-framework/operator-controller/test/e2e	18.360s
jiazha-mac:e2e jiazha$ go tool pprof mem.out 
File: e2e.test
Type: alloc_space
Time: Jan 27, 2025 at 2:00pm (CST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 6893.09kB, 72.92% of 9453.29kB total
Showing top 10 nodes out of 93
      flat  flat%   sum%        cum   cum%
 1762.94kB 18.65% 18.65%  1762.94kB 18.65%  runtime/pprof.StartCPUProfile
  902.59kB  9.55% 28.20%  1485.59kB 15.72%  compress/flate.NewWriter
  583.01kB  6.17% 34.36%   583.01kB  6.17%  compress/flate.newDeflateFast (inline)
  548.84kB  5.81% 40.17%  1573.29kB 16.64%  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName
  532.26kB  5.63% 45.80%   532.26kB  5.63%  github.com/gogo/protobuf/proto.RegisterType
  513.50kB  5.43% 51.23%   513.50kB  5.43%  k8s.io/apimachinery/pkg/conversion.ConversionFuncs.AddUntyped
  512.75kB  5.42% 56.66%   512.75kB  5.42%  vendor/golang.org/x/crypto/cryptobyte.(*Builder).add
  512.62kB  5.42% 62.08%   512.62kB  5.42%  k8s.io/api/apps/v1beta2.addKnownTypes
  512.44kB  5.42% 67.50%   512.44kB  5.42%  sync.(*Map).dirtyLocked
  512.14kB  5.42% 72.92%   512.14kB  5.42%  k8s.io/api/resource/v1alpha3.init
(pprof) exit
jiazha-mac:e2e jiazha$ go tool pprof cpu.out 
File: e2e.test
Type: cpu
Time: Jan 27, 2025 at 2:00pm (CST)
Duration: 17.83s, Total samples = 160ms (  0.9%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 160ms, 100% of 160ms total
Showing top 10 nodes out of 93
      flat  flat%   sum%        cum   cum%
      40ms 25.00% 25.00%       40ms 25.00%  runtime.pthread_cond_signal
      40ms 25.00% 50.00%       40ms 25.00%  runtime.scanobject
      40ms 25.00% 75.00%       40ms 25.00%  syscall.syscall
      10ms  6.25% 81.25%       10ms  6.25%  crypto/internal/edwards25519/field.addMul64 (inline)
      10ms  6.25% 87.50%       10ms  6.25%  k8s.io/apimachinery/pkg/runtime.(*clientNegotiator).Decoder
      10ms  6.25% 93.75%       10ms  6.25%  runtime.pthread_kill
      10ms  6.25%   100%       10ms  6.25%  runtime.usleep
         0     0%   100%       30ms 18.75%  bufio.(*Writer).Flush
         0     0%   100%       10ms  6.25%  crypto/ecdh.(*PrivateKey).PublicKey
         0     0%   100%       10ms  6.25%  crypto/ecdh.(*PrivateKey).PublicKey.func1
(pprof) exit
```

- parallel run on AWS, Cluster version is 4.18.0-0.nightly-2025-01-25-163410
```go
jiazha-mac:e2e jiazha$ go test -run=^$ -bench=. -count=10 -memprofile=mem.out -cpuprofile=cpu.out
goos: darwin
goarch: arm64
pkg: github.com/operator-framework/operator-controller/test/e2e
cpu: Apple M1 Pro
BenchmarkCreateClusterCatalog-10    	       1	1559796167 ns/op
BenchmarkCreateClusterCatalog-10    	      12	 105038868 ns/op
BenchmarkCreateClusterCatalog-10    	      13	  88542141 ns/op
BenchmarkCreateClusterCatalog-10    	      13	  94152035 ns/op
BenchmarkCreateClusterCatalog-10    	      13	  93457205 ns/op
BenchmarkCreateClusterCatalog-10    	      13	  94673955 ns/op
BenchmarkCreateClusterCatalog-10    	      20	  62803019 ns/op
BenchmarkCreateClusterCatalog-10    	      13	  87578115 ns/op
BenchmarkCreateClusterCatalog-10    	      12	 107728125 ns/op
BenchmarkCreateClusterCatalog-10    	      12	  98580924 ns/op
PASS
ok  	github.com/operator-framework/operator-controller/test/e2e	38.984s
jiazha-mac:e2e jiazha$ go tool pprof cpu.out 
File: e2e.test
Type: cpu
Time: Jan 27, 2025 at 2:09pm (CST)
Duration: 38.06s, Total samples = 570ms ( 1.50%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 410ms, 71.93% of 570ms total
Showing top 10 nodes out of 201
      flat  flat%   sum%        cum   cum%
      70ms 12.28% 12.28%       70ms 12.28%  runtime.kevent
      70ms 12.28% 24.56%       70ms 12.28%  runtime.pthread_cond_signal
      60ms 10.53% 35.09%       60ms 10.53%  runtime.pthread_cond_wait
      60ms 10.53% 45.61%       60ms 10.53%  syscall.syscall
      50ms  8.77% 54.39%       50ms  8.77%  runtime.pthread_kill
      30ms  5.26% 59.65%       30ms  5.26%  runtime.madvise
      30ms  5.26% 64.91%       30ms  5.26%  runtime.pthread_cond_timedwait_relative_np
      20ms  3.51% 68.42%       20ms  3.51%  runtime.(*mspan).writeHeapBitsSmall
      10ms  1.75% 70.18%       10ms  1.75%  crypto/internal/bigmod.(*Nat).reset
      10ms  1.75% 71.93%       10ms  1.75%  k8s.io/apimachinery/pkg/runtime.setTargetKind
(pprof) exit
jiazha-mac:e2e jiazha$ go tool pprof mem.out 
File: e2e.test
Type: alloc_space
Time: Jan 27, 2025 at 2:09pm (CST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 10718.54kB, 61.67% of 17380.55kB total
Showing top 10 nodes out of 166
      flat  flat%   sum%        cum   cum%
 2048.12kB 11.78% 11.78%  2048.12kB 11.78%  path.Join
 1762.94kB 10.14% 21.93%  1762.94kB 10.14%  runtime/pprof.StartCPUProfile
 1536.56kB  8.84% 30.77%  1536.56kB  8.84%  golang.org/x/net/http2.(*ClientConn).roundTrip
 1065.48kB  6.13% 36.90%  2101.58kB 12.09%  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName
 1025.38kB  5.90% 42.80%  1025.38kB  5.90%  sync.(*Pool).pinSlow
 1024.14kB  5.89% 48.69%  1536.17kB  8.84%  k8s.io/client-go/rest.(*Request).URL
  650.62kB  3.74% 52.43%   650.62kB  3.74%  compress/flate.(*compressor).init
  553.04kB  3.18% 55.62%   553.04kB  3.18%  github.com/gogo/protobuf/proto.RegisterType
  528.17kB  3.04% 58.65%   528.17kB  3.04%  regexp.(*bitState).reset
  524.09kB  3.02% 61.67%   524.09kB  3.02%  k8s.io/apimachinery/pkg/conversion.ConversionFuncs.AddUntyped
(pprof) exit
```

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
