### PR TITLE
:bug: Use monorepo release for catalogd

### DIFF
--- a/catalogd/hack/scripts/demo-script.sh
+++ b/catalogd/hack/scripts/demo-script.sh
@@ -12,7 +12,7 @@ kubectl cluster-info --context kind-kind
 sleep 10
 
 # use the install script from the latest github release
-curl -L -s https://github.com/operator-framework/catalogd/releases/latest/download/install.sh | bash
+curl -L -s https://github.com/operator-framework/operator-controller/releases/latest/download/install.sh | bash
 
 # inspect crds (clustercatalog)
 kubectl get crds -A


### PR DESCRIPTION
# Description

With the change we will use the operator-controller releases for catalogd demo script

Fixes  #1605

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
