### PR TITLE
🐛 Ensure catalog caches are valid after restart

### DIFF
--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -63,6 +63,7 @@ import (
 	"github.com/operator-framework/operator-controller/catalogd/internal/storage"
 	"github.com/operator-framework/operator-controller/catalogd/internal/version"
 	"github.com/operator-framework/operator-controller/catalogd/internal/webhook"
+	"github.com/operator-framework/operator-controller/internal/util"
 )
 
 var (
@@ -257,8 +258,8 @@ func main() {
 		systemNamespace = podNamespace()
 	}
 
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
-		setupLog.Error(err, "unable to create cache directory")
+	if err := util.EnsureEmptyDirectory(cacheDir, 0700); err != nil {
+		setupLog.Error(err, "unable to ensure empty cache directory")
 		os.Exit(1)
 	}
 

--- a/catalogd/internal/source/containers_image.go
+++ b/catalogd/internal/source/containers_image.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	catalogdv1 "github.com/operator-framework/operator-controller/catalogd/api/v1"
+	"github.com/operator-framework/operator-controller/internal/rukpak/source"
+	"github.com/operator-framework/operator-controller/internal/util"
 )
 
 const ConfigDirLabel = "operators.operatorframework.io.index.configs.v1"
@@ -76,12 +78,11 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	//
 	//////////////////////////////////////////////////////
 	unpackPath := i.unpackPath(catalog.Name, canonicalRef.Digest())
-	if unpackStat, err := os.Stat(unpackPath); err == nil {
-		if !unpackStat.IsDir() {
-			panic(fmt.Sprintf("unexpected file at unpack path %q: expected a directory", unpackPath))
-		}
+	if isUnpacked, unpackTime, err := source.IsImageUnpacked(unpackPath); isUnpacked && err == nil {
 		l.Info("image already unpacked", "ref", imgRef.String(), "digest", canonicalRef.Digest().String())
-		return successResult(unpackPath, canonicalRef, unpackStat.ModTime()), nil
+		return successResult(unpackPath, canonicalRef, unpackTime), nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error checking image already unpacked: %w", err)
 	}
 
 	//////////////////////////////////////////////////////
@@ -154,7 +155,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	//
 	//////////////////////////////////////////////////////
 	if err := i.unpackImage(ctx, unpackPath, layoutRef, specIsCanonical, srcCtx); err != nil {
-		if cleanupErr := deleteRecursive(unpackPath); cleanupErr != nil {
+		if cleanupErr := source.DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)
 		}
 		return nil, fmt.Errorf("error unpacking image: %w", err)
@@ -195,7 +196,7 @@ func successResult(unpackPath string, canonicalRef reference.Canonical, lastUnpa
 }
 
 func (i *ContainersImageRegistry) Cleanup(_ context.Context, catalog *catalogdv1.ClusterCatalog) error {
-	if err := deleteRecursive(i.catalogPath(catalog.Name)); err != nil {
+	if err := source.DeleteReadOnlyRecursive(i.catalogPath(catalog.Name)); err != nil {
 		return fmt.Errorf("error deleting catalog cache: %w", err)
 	}
 	return nil
@@ -296,8 +297,8 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 		return wrapTerminal(fmt.Errorf("catalog image is missing the required label %q", ConfigDirLabel), specIsCanonical)
 	}
 
-	if err := os.MkdirAll(unpackPath, 0700); err != nil {
-		return fmt.Errorf("error creating unpack directory: %w", err)
+	if err := util.EnsureEmptyDirectory(unpackPath, 0700); err != nil {
+		return fmt.Errorf("error ensuring empty unpack directory: %w", err)
 	}
 	l := log.FromContext(ctx)
 	l.Info("unpacking image", "path", unpackPath)
@@ -315,10 +316,10 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 			l.Info("applied layer", "layer", i)
 			return nil
 		}(); err != nil {
-			return errors.Join(err, deleteRecursive(unpackPath))
+			return errors.Join(err, source.DeleteReadOnlyRecursive(unpackPath))
 		}
 	}
-	if err := setReadOnlyRecursive(unpackPath); err != nil {
+	if err := source.SetReadOnlyRecursive(unpackPath); err != nil {
 		return fmt.Errorf("error making unpack directory read-only: %w", err)
 	}
 	return nil
@@ -362,67 +363,11 @@ func (i *ContainersImageRegistry) deleteOtherImages(catalogName string, digestTo
 			continue
 		}
 		imgDirPath := filepath.Join(catalogPath, imgDir.Name())
-		if err := deleteRecursive(imgDirPath); err != nil {
+		if err := source.DeleteReadOnlyRecursive(imgDirPath); err != nil {
 			return fmt.Errorf("error removing image directory: %w", err)
 		}
 	}
 	return nil
-}
-
-func setReadOnlyRecursive(root string) error {
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		fi, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		if err := func() error {
-			switch typ := fi.Mode().Type(); typ {
-			case os.ModeSymlink:
-				// do not follow symlinks
-				// 1. if they resolve to other locations in the root, we'll find them anyway
-				// 2. if they resolve to other locations outside the root, we don't want to change their permissions
-				return nil
-			case os.ModeDir:
-				return os.Chmod(path, 0500)
-			case 0: // regular file
-				return os.Chmod(path, 0400)
-			default:
-				return fmt.Errorf("refusing to change ownership of file %q with type %v", path, typ.String())
-			}
-		}(); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("error making catalog cache read-only: %w", err)
-	}
-	return nil
-}
-
-func deleteRecursive(root string) error {
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() {
-			return nil
-		}
-		if err := os.Chmod(path, 0700); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("error making catalog cache writable for deletion: %w", err)
-	}
-	return os.RemoveAll(root)
 }
 
 func wrapTerminal(err error, isTerminal bool) error {

--- a/internal/rukpak/source/containers_image.go
+++ b/internal/rukpak/source/containers_image.go
@@ -24,6 +24,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/operator-framework/operator-controller/internal/util"
 )
 
 var insecurePolicy = []byte(`{"default":[{"type":"insecureAcceptAnything"}]}`)
@@ -69,12 +71,11 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, bundle *BundleSour
 	//
 	//////////////////////////////////////////////////////
 	unpackPath := i.unpackPath(bundle.Name, canonicalRef.Digest())
-	if unpackStat, err := os.Stat(unpackPath); err == nil {
-		if !unpackStat.IsDir() {
-			panic(fmt.Sprintf("unexpected file at unpack path %q: expected a directory", unpackPath))
-		}
+	if isUnpacked, _, err := IsImageUnpacked(unpackPath); isUnpacked && err == nil {
 		l.Info("image already unpacked", "ref", imgRef.String(), "digest", canonicalRef.Digest().String())
 		return successResult(bundle.Name, unpackPath, canonicalRef), nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error checking bundle already unpacked: %w", err)
 	}
 
 	//////////////////////////////////////////////////////
@@ -147,7 +148,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, bundle *BundleSour
 	//
 	//////////////////////////////////////////////////////
 	if err := i.unpackImage(ctx, unpackPath, layoutRef, srcCtx); err != nil {
-		if cleanupErr := deleteRecursive(unpackPath); cleanupErr != nil {
+		if cleanupErr := DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)
 		}
 		return nil, fmt.Errorf("error unpacking image: %w", err)
@@ -175,7 +176,7 @@ func successResult(bundleName, unpackPath string, canonicalRef reference.Canonic
 }
 
 func (i *ContainersImageRegistry) Cleanup(_ context.Context, bundle *BundleSource) error {
-	return deleteRecursive(i.bundlePath(bundle.Name))
+	return DeleteReadOnlyRecursive(i.bundlePath(bundle.Name))
 }
 
 func (i *ContainersImageRegistry) bundlePath(bundleName string) string {
@@ -265,8 +266,8 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 		}
 	}()
 
-	if err := os.MkdirAll(unpackPath, 0700); err != nil {
-		return fmt.Errorf("error creating unpack directory: %w", err)
+	if err := util.EnsureEmptyDirectory(unpackPath, 0700); err != nil {
+		return fmt.Errorf("error ensuring empty unpack directory: %w", err)
 	}
 	l := log.FromContext(ctx)
 	l.Info("unpacking image", "path", unpackPath)
@@ -284,10 +285,10 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 			l.Info("applied layer", "layer", i)
 			return nil
 		}(); err != nil {
-			return errors.Join(err, deleteRecursive(unpackPath))
+			return errors.Join(err, DeleteReadOnlyRecursive(unpackPath))
 		}
 	}
-	if err := setReadOnlyRecursive(unpackPath); err != nil {
+	if err := SetReadOnlyRecursive(unpackPath); err != nil {
 		return fmt.Errorf("error making unpack directory read-only: %w", err)
 	}
 	return nil
@@ -324,65 +325,9 @@ func (i *ContainersImageRegistry) deleteOtherImages(bundleName string, digestToK
 			continue
 		}
 		imgDirPath := filepath.Join(bundlePath, imgDir.Name())
-		if err := deleteRecursive(imgDirPath); err != nil {
+		if err := DeleteReadOnlyRecursive(imgDirPath); err != nil {
 			return fmt.Errorf("error removing image directory: %w", err)
 		}
 	}
 	return nil
-}
-
-func setReadOnlyRecursive(root string) error {
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		fi, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		if err := func() error {
-			switch typ := fi.Mode().Type(); typ {
-			case os.ModeSymlink:
-				// do not follow symlinks
-				// 1. if they resolve to other locations in the root, we'll find them anyway
-				// 2. if they resolve to other locations outside the root, we don't want to change their permissions
-				return nil
-			case os.ModeDir:
-				return os.Chmod(path, 0500)
-			case 0: // regular file
-				return os.Chmod(path, 0400)
-			default:
-				return fmt.Errorf("refusing to change ownership of file %q with type %v", path, typ.String())
-			}
-		}(); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("error making bundle cache read-only: %w", err)
-	}
-	return nil
-}
-
-func deleteRecursive(root string) error {
-	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() {
-			return nil
-		}
-		if err := os.Chmod(path, 0700); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("error making bundle cache writable for deletion: %w", err)
-	}
-	return os.RemoveAll(root)
 }

--- a/internal/rukpak/source/containers_image_test.go
+++ b/internal/rukpak/source/containers_image_test.go
@@ -277,7 +277,16 @@ func TestUnpackUnexpectedFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(unpackPath, []byte{}, 0600))
 
 	// Attempt to pull and unpack the image
-	assert.Panics(t, func() { _, _ = unpacker.Unpack(context.Background(), bundleSource) })
+	_, err := unpacker.Unpack(context.Background(), bundleSource)
+	require.NoError(t, err)
+
+	// Ensure unpack path is now a directory
+	stat, err := os.Stat(unpackPath)
+	require.NoError(t, err)
+	require.True(t, stat.IsDir())
+
+	// Unset read-only to allow cleanup
+	require.NoError(t, source.UnsetReadOnlyRecursive(unpackPath))
 }
 
 func TestUnpackCopySucceedsMountFails(t *testing.T) {

--- a/internal/rukpak/source/util.go
+++ b/internal/rukpak/source/util.go
@@ -1,0 +1,86 @@
+package source
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SetReadOnlyRecursive sets directory with path given by `root` as read-only
+func SetReadOnlyRecursive(root string) error {
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if err := func() error {
+			switch typ := fi.Mode().Type(); typ {
+			case os.ModeSymlink:
+				// do not follow symlinks
+				// 1. if they resolve to other locations in the root, we'll find them anyway
+				// 2. if they resolve to other locations outside the root, we don't want to change their permissions
+				return nil
+			case os.ModeDir:
+				return os.Chmod(path, 0500)
+			case 0: // regular file
+				return os.Chmod(path, 0400)
+			default:
+				return fmt.Errorf("refusing to change ownership of file %q with type %v", path, typ.String())
+			}
+		}(); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// UnsetReadOnlyRecursive unsets directory with path given by `root` as read-only
+func UnsetReadOnlyRecursive(root string) error {
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if err := os.Chmod(path, 0700); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// DeleteReadOnlyRecursive deletes read-only directory with path given by `root`
+func DeleteReadOnlyRecursive(root string) error {
+	if err := UnsetReadOnlyRecursive(root); err != nil {
+		return fmt.Errorf("error making directory writable for deletion: %w", err)
+	}
+	return os.RemoveAll(root)
+}
+
+// IsImageUnpacked checks whether an image has been unpacked in `unpackPath`.
+// If true, time of unpack will also be returned. If false unpack time is gibberish (zero/epoch time).
+// If `unpackPath` is a file, it will be deleted and false will be returned without an error.
+func IsImageUnpacked(unpackPath string) (bool, time.Time, error) {
+	unpackStat, err := os.Stat(unpackPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, time.Time{}, nil
+		}
+		return false, time.Time{}, err
+	}
+	if !unpackStat.IsDir() {
+		return false, time.Time{}, os.Remove(unpackPath)
+	}
+	return true, unpackStat.ModTime(), nil
+}

--- a/internal/util/fs.go
+++ b/internal/util/fs.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// EnsureEmptyDirectory ensures the directory given by `path` is empty.
+// If the directory does not exist, it will be created with permission bits
+// given by `perm`.
+func EnsureEmptyDirectory(path string, perm fs.FileMode) error {
+	entries, err := os.ReadDir(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(path, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return os.MkdirAll(path, perm)
+}


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
This addresses an intermittent failure we've seen where operator-controller appears to not resolve catalogs that exist. We identified the issue coming from the catalog caches not being valid after a restart.

This PR adds two things to address this issue:
- On startup of the binary, always clear the catalog cache directory

The PR also includes some small refactoring and fixes:
 - moves certain unpack functions to an util package and are now shared by catalog and bundle image unpacker
 - if unpack path happens to be an existing file, we delete it and unpack the image

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
