### PR TITLE
:seedling: Add support for SSL env vars to cert pool watcher

### DIFF
--- a/internal/httputil/certpoolwatcher_test.go
+++ b/internal/httputil/certpoolwatcher_test.go
@@ -72,6 +72,10 @@ func TestCertPoolWatcher(t *testing.T) {
 	t.Logf("Create cert file at %q\n", certName)
 	createCert(t, certName)
 
+	// Update environment variables for the watcher - some of these should not exist
+	os.Setenv("SSL_CERT_DIR", tmpDir+":/tmp/does-not-exist.dir")
+	os.Setenv("SSL_CERT_FILE", "/tmp/does-not-exist.file")
+
 	// Create the cert pool watcher
 	cpw, err := httputil.NewCertPoolWatcher(tmpDir, log.FromContext(context.Background()))
 	require.NoError(t, err)


### PR DESCRIPTION
The SystemRoot store looks at the SSL_CERT_DIR and SSL_CERT_FILE environment variables for certificate locations. Because these variables are under control of the user, we should assume that the user wants to control the contents of the SystemRoot, and subsequently that those contents could change (as compared to certs located in the default /etc/pki location).

Thus, we should watch those locations if they exist.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
