### PR TITLE
:bug: Fix default catalog installation in install script

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -76,11 +76,6 @@ kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 kubectl_wait "olmv1-system" "deployment/operator-controller-controller-manager" "60s"
 
 if [[ "${install_default_catalogs}" != "false" ]]; then
-    if [[ ! -f "$default_catalogs_manifest" ]]; then
-        echo "Error: Missing required default catalogs manifest file at $default_catalogs_manifest"
-        exit 1
-    fi
-
     kubectl apply -f "${default_catalogs_manifest}"
     kubectl wait --for=condition=Serving "clustercatalog/operatorhubio" --timeout="60s"
 fi


### PR DESCRIPTION
# Description

The install script expects `default-catalog.yaml` to be present in the filesystem. But, it references an url. So, we remove the -f check and kubectl apply the url directly.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
