### PR TITLE
🐛 EnsureEmptyDirectory should recursively set writable perms prior to delete

### DIFF
--- a/catalogd/internal/source/containers_image.go
+++ b/catalogd/internal/source/containers_image.go
@@ -155,7 +155,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	//
 	//////////////////////////////////////////////////////
 	if err := i.unpackImage(ctx, unpackPath, layoutRef, specIsCanonical, srcCtx); err != nil {
-		if cleanupErr := source.DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
+		if cleanupErr := fsutil.DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)
 		}
 		return nil, fmt.Errorf("error unpacking image: %w", err)
@@ -196,7 +196,7 @@ func successResult(unpackPath string, canonicalRef reference.Canonical, lastUnpa
 }
 
 func (i *ContainersImageRegistry) Cleanup(_ context.Context, catalog *catalogdv1.ClusterCatalog) error {
-	if err := source.DeleteReadOnlyRecursive(i.catalogPath(catalog.Name)); err != nil {
+	if err := fsutil.DeleteReadOnlyRecursive(i.catalogPath(catalog.Name)); err != nil {
 		return fmt.Errorf("error deleting catalog cache: %w", err)
 	}
 	return nil
@@ -316,10 +316,10 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 			l.Info("applied layer", "layer", i)
 			return nil
 		}(); err != nil {
-			return errors.Join(err, source.DeleteReadOnlyRecursive(unpackPath))
+			return errors.Join(err, fsutil.DeleteReadOnlyRecursive(unpackPath))
 		}
 	}
-	if err := source.SetReadOnlyRecursive(unpackPath); err != nil {
+	if err := fsutil.SetReadOnlyRecursive(unpackPath); err != nil {
 		return fmt.Errorf("error making unpack directory read-only: %w", err)
 	}
 	return nil
@@ -363,7 +363,7 @@ func (i *ContainersImageRegistry) deleteOtherImages(catalogName string, digestTo
 			continue
 		}
 		imgDirPath := filepath.Join(catalogPath, imgDir.Name())
-		if err := source.DeleteReadOnlyRecursive(imgDirPath); err != nil {
+		if err := fsutil.DeleteReadOnlyRecursive(imgDirPath); err != nil {
 			return fmt.Errorf("error removing image directory: %w", err)
 		}
 	}

--- a/internal/fsutil/helpers_test.go
+++ b/internal/fsutil/helpers_test.go
@@ -1,13 +1,12 @@
-package fsutil_test
+package fsutil
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/operator-framework/operator-controller/internal/fsutil"
 )
 
 func TestEnsureEmptyDirectory(t *testing.T) {
@@ -16,7 +15,7 @@ func TestEnsureEmptyDirectory(t *testing.T) {
 	dirPerms := os.FileMode(0755)
 
 	t.Log("Ensure directory is created with the correct perms if it does not already exist")
-	require.NoError(t, fsutil.EnsureEmptyDirectory(dirPath, dirPerms))
+	require.NoError(t, EnsureEmptyDirectory(dirPath, dirPerms))
 
 	stat, err := os.Stat(dirPath)
 	require.NoError(t, err)
@@ -25,15 +24,16 @@ func TestEnsureEmptyDirectory(t *testing.T) {
 
 	t.Log("Create a file inside directory")
 	file := filepath.Join(dirPath, "file1")
-	// nolint:gosec
-	require.NoError(t, os.WriteFile(file, []byte("test"), 0640))
+	// write file as read-only to verify EnsureEmptyDirectory can still delete it.
+	require.NoError(t, os.WriteFile(file, []byte("test"), 0400))
 
 	t.Log("Create a sub-directory inside directory")
 	subDir := filepath.Join(dirPath, "subdir")
-	require.NoError(t, os.Mkdir(subDir, dirPerms))
+	// write subDir as read-execute-only to verify EnsureEmptyDirectory can still delete it.
+	require.NoError(t, os.Mkdir(subDir, 0500))
 
 	t.Log("Call EnsureEmptyDirectory against directory with different permissions")
-	require.NoError(t, fsutil.EnsureEmptyDirectory(dirPath, 0640))
+	require.NoError(t, EnsureEmptyDirectory(dirPath, 0640))
 
 	t.Log("Ensure directory is now empty")
 	entries, err := os.ReadDir(dirPath)
@@ -44,4 +44,98 @@ func TestEnsureEmptyDirectory(t *testing.T) {
 	stat, err = os.Stat(dirPath)
 	require.NoError(t, err)
 	require.Equal(t, dirPerms, stat.Mode().Perm())
+}
+
+func TestSetReadOnlyRecursive(t *testing.T) {
+	tempDir := t.TempDir()
+	targetFilePath := filepath.Join(tempDir, "target")
+	nestedDir := filepath.Join(tempDir, "nested")
+	filePath := filepath.Join(nestedDir, "testfile")
+	symlinkPath := filepath.Join(nestedDir, "symlink")
+
+	t.Log("Create symlink target file outside directory with its own permissions")
+	// nolint:gosec
+	require.NoError(t, os.WriteFile(targetFilePath, []byte("something"), 0644))
+
+	t.Log("Create a nested directory structure that contains a file and sym. link")
+	require.NoError(t, os.Mkdir(nestedDir, ownerWritableDirMode))
+	require.NoError(t, os.WriteFile(filePath, []byte("test"), ownerWritableFileMode))
+	require.NoError(t, os.Symlink(targetFilePath, symlinkPath))
+
+	t.Log("Set directory structure as read-only")
+	require.NoError(t, SetReadOnlyRecursive(nestedDir))
+
+	t.Log("Check file permissions")
+	stat, err := os.Stat(filePath)
+	require.NoError(t, err)
+	require.Equal(t, ownerReadOnlyFileMode, stat.Mode().Perm())
+
+	t.Log("Check directory permissions")
+	nestedStat, err := os.Stat(nestedDir)
+	require.NoError(t, err)
+	require.Equal(t, ownerReadOnlyDirMode, nestedStat.Mode().Perm())
+
+	t.Log("Check symlink target file permissions - should not be affected")
+	stat, err = os.Stat(targetFilePath)
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0644), stat.Mode().Perm())
+
+	t.Log("Make directory writable to enable test clean-up")
+	require.NoError(t, SetWritableRecursive(tempDir))
+}
+
+func TestSetWritableRecursive(t *testing.T) {
+	tempDir := t.TempDir()
+	targetFilePath := filepath.Join(tempDir, "target")
+	nestedDir := filepath.Join(tempDir, "nested")
+	filePath := filepath.Join(nestedDir, "testfile")
+	symlinkPath := filepath.Join(nestedDir, "symlink")
+
+	t.Log("Create symlink target file outside directory with its own permissions")
+	// nolint:gosec
+	require.NoError(t, os.WriteFile(targetFilePath, []byte("something"), 0644))
+
+	t.Log("Create a nested directory (writable) structure that contains a file (read-only) and sym. link")
+	require.NoError(t, os.Mkdir(nestedDir, ownerWritableDirMode))
+	require.NoError(t, os.WriteFile(filePath, []byte("test"), ownerReadOnlyFileMode))
+	require.NoError(t, os.Symlink(targetFilePath, symlinkPath))
+
+	t.Log("Make directory read-only")
+	require.NoError(t, os.Chmod(nestedDir, ownerReadOnlyDirMode))
+
+	t.Log("Call SetWritableRecursive")
+	require.NoError(t, SetWritableRecursive(nestedDir))
+
+	t.Log("Check file is writable")
+	stat, err := os.Stat(filePath)
+	require.NoError(t, err)
+	require.Equal(t, ownerWritableFileMode, stat.Mode().Perm())
+
+	t.Log("Check directory is writable")
+	nestedStat, err := os.Stat(nestedDir)
+	require.NoError(t, err)
+	require.Equal(t, ownerWritableDirMode, nestedStat.Mode().Perm())
+
+	t.Log("Check symlink target file permissions - should not be affected")
+	stat, err = os.Stat(targetFilePath)
+	require.NoError(t, err)
+	require.Equal(t, fs.FileMode(0644), stat.Mode().Perm())
+}
+
+func TestDeleteReadOnlyRecursive(t *testing.T) {
+	tempDir := t.TempDir()
+	nestedDir := filepath.Join(tempDir, "nested")
+	filePath := filepath.Join(nestedDir, "testfile")
+
+	t.Log("Create a nested read-only directory structure that contains a file and sym. link")
+	require.NoError(t, os.Mkdir(nestedDir, ownerWritableDirMode))
+	require.NoError(t, os.WriteFile(filePath, []byte("test"), ownerReadOnlyFileMode))
+	require.NoError(t, os.Chmod(nestedDir, ownerReadOnlyDirMode))
+
+	t.Log("Set directory structure as read-only via DeleteReadOnlyRecursive")
+	require.NoError(t, DeleteReadOnlyRecursive(nestedDir))
+
+	t.Log("Ensure directory was deleted")
+	_, err := os.Stat(nestedDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/internal/rukpak/source/containers_image.go
+++ b/internal/rukpak/source/containers_image.go
@@ -148,7 +148,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, bundle *BundleSour
 	//
 	//////////////////////////////////////////////////////
 	if err := i.unpackImage(ctx, unpackPath, layoutRef, srcCtx); err != nil {
-		if cleanupErr := DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
+		if cleanupErr := fsutil.DeleteReadOnlyRecursive(unpackPath); cleanupErr != nil {
 			err = errors.Join(err, cleanupErr)
 		}
 		return nil, fmt.Errorf("error unpacking image: %w", err)
@@ -176,7 +176,7 @@ func successResult(bundleName, unpackPath string, canonicalRef reference.Canonic
 }
 
 func (i *ContainersImageRegistry) Cleanup(_ context.Context, bundle *BundleSource) error {
-	return DeleteReadOnlyRecursive(i.bundlePath(bundle.Name))
+	return fsutil.DeleteReadOnlyRecursive(i.bundlePath(bundle.Name))
 }
 
 func (i *ContainersImageRegistry) bundlePath(bundleName string) string {
@@ -285,10 +285,10 @@ func (i *ContainersImageRegistry) unpackImage(ctx context.Context, unpackPath st
 			l.Info("applied layer", "layer", i)
 			return nil
 		}(); err != nil {
-			return errors.Join(err, DeleteReadOnlyRecursive(unpackPath))
+			return errors.Join(err, fsutil.DeleteReadOnlyRecursive(unpackPath))
 		}
 	}
-	if err := SetReadOnlyRecursive(unpackPath); err != nil {
+	if err := fsutil.SetReadOnlyRecursive(unpackPath); err != nil {
 		return fmt.Errorf("error making unpack directory read-only: %w", err)
 	}
 	return nil
@@ -325,7 +325,7 @@ func (i *ContainersImageRegistry) deleteOtherImages(bundleName string, digestToK
 			continue
 		}
 		imgDirPath := filepath.Join(bundlePath, imgDir.Name())
-		if err := DeleteReadOnlyRecursive(imgDirPath); err != nil {
+		if err := fsutil.DeleteReadOnlyRecursive(imgDirPath); err != nil {
 			return fmt.Errorf("error removing image directory: %w", err)
 		}
 	}

--- a/internal/rukpak/source/containers_image_test.go
+++ b/internal/rukpak/source/containers_image_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/operator-framework/operator-controller/internal/fsutil"
 	"github.com/operator-framework/operator-controller/internal/rukpak/source"
 )
 
@@ -286,7 +287,7 @@ func TestUnpackUnexpectedFile(t *testing.T) {
 	require.True(t, stat.IsDir())
 
 	// Unset read-only to allow cleanup
-	require.NoError(t, source.SetWritableRecursive(unpackPath))
+	require.NoError(t, fsutil.SetWritableRecursive(unpackPath))
 }
 
 func TestUnpackCopySucceedsMountFails(t *testing.T) {

--- a/internal/rukpak/source/helpers.go
+++ b/internal/rukpak/source/helpers.go
@@ -2,36 +2,9 @@ package source
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 )
-
-const (
-	OwnerWritableFileMode os.FileMode = 0700
-	OwnerWritableDirMode  os.FileMode = 0700
-	OwnerReadOnlyFileMode os.FileMode = 0400
-	OwnerReadOnlyDirMode  os.FileMode = 0500
-)
-
-// SetReadOnlyRecursive recursively sets files and directories under the path given by `root` as read-only
-func SetReadOnlyRecursive(root string) error {
-	return setModeRecursive(root, OwnerReadOnlyFileMode, OwnerReadOnlyDirMode)
-}
-
-// SetWritableRecursive recursively sets files and directories under the path given by `root` as writable
-func SetWritableRecursive(root string) error {
-	return setModeRecursive(root, OwnerWritableFileMode, OwnerWritableDirMode)
-}
-
-// DeleteReadOnlyRecursive deletes read-only directory with path given by `root`
-func DeleteReadOnlyRecursive(root string) error {
-	if err := SetWritableRecursive(root); err != nil {
-		return fmt.Errorf("error making directory writable for deletion: %w", err)
-	}
-	return os.RemoveAll(root)
-}
 
 // IsImageUnpacked checks whether an image has been unpacked in `unpackPath`.
 // If true, time of unpack will also be returned. If false unpack time is gibberish (zero/epoch time).
@@ -48,33 +21,4 @@ func IsImageUnpacked(unpackPath string) (bool, time.Time, error) {
 		return false, time.Time{}, os.Remove(unpackPath)
 	}
 	return true, unpackStat.ModTime(), nil
-}
-
-func setModeRecursive(path string, fileMode os.FileMode, dirMode os.FileMode) error {
-	return filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		fi, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		switch typ := fi.Mode().Type(); typ {
-		case os.ModeSymlink:
-			// do not follow symlinks
-			// 1. if they resolve to other locations in the root, we'll find them anyway
-			// 2. if they resolve to other locations outside the root, we don't want to change their permissions
-			return nil
-		case os.ModeDir:
-			return os.Chmod(path, dirMode)
-		case 0: // regular file
-			return os.Chmod(path, fileMode)
-		default:
-			return fmt.Errorf("refusing to change ownership of file %q with type %v", path, typ.String())
-		}
-	})
 }

--- a/internal/rukpak/source/helpers_test.go
+++ b/internal/rukpak/source/helpers_test.go
@@ -1,7 +1,6 @@
 package source_test
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,100 +9,6 @@ import (
 
 	"github.com/operator-framework/operator-controller/internal/rukpak/source"
 )
-
-func TestSetReadOnlyRecursive(t *testing.T) {
-	tempDir := t.TempDir()
-	targetFilePath := filepath.Join(tempDir, "target")
-	nestedDir := filepath.Join(tempDir, "nested")
-	filePath := filepath.Join(nestedDir, "testfile")
-	symlinkPath := filepath.Join(nestedDir, "symlink")
-
-	t.Log("Create symlink target file outside directory with its own permissions")
-	// nolint:gosec
-	require.NoError(t, os.WriteFile(targetFilePath, []byte("something"), 0644))
-
-	t.Log("Create a nested directory structure that contains a file and sym. link")
-	require.NoError(t, os.Mkdir(nestedDir, source.OwnerWritableDirMode))
-	require.NoError(t, os.WriteFile(filePath, []byte("test"), source.OwnerWritableFileMode))
-	require.NoError(t, os.Symlink(targetFilePath, symlinkPath))
-
-	t.Log("Set directory structure as read-only")
-	require.NoError(t, source.SetReadOnlyRecursive(nestedDir))
-
-	t.Log("Check file permissions")
-	stat, err := os.Stat(filePath)
-	require.NoError(t, err)
-	require.Equal(t, source.OwnerReadOnlyFileMode, stat.Mode().Perm())
-
-	t.Log("Check directory permissions")
-	nestedStat, err := os.Stat(nestedDir)
-	require.NoError(t, err)
-	require.Equal(t, source.OwnerReadOnlyDirMode, nestedStat.Mode().Perm())
-
-	t.Log("Check symlink target file permissions - should not be affected")
-	stat, err = os.Stat(targetFilePath)
-	require.NoError(t, err)
-	require.Equal(t, fs.FileMode(0644), stat.Mode().Perm())
-
-	t.Log("Make directory writable to enable test clean-up")
-	require.NoError(t, source.SetWritableRecursive(tempDir))
-}
-
-func TestSetWritableRecursive(t *testing.T) {
-	tempDir := t.TempDir()
-	targetFilePath := filepath.Join(tempDir, "target")
-	nestedDir := filepath.Join(tempDir, "nested")
-	filePath := filepath.Join(nestedDir, "testfile")
-	symlinkPath := filepath.Join(nestedDir, "symlink")
-
-	t.Log("Create symlink target file outside directory with its own permissions")
-	// nolint:gosec
-	require.NoError(t, os.WriteFile(targetFilePath, []byte("something"), 0644))
-
-	t.Log("Create a nested directory (writable) structure that contains a file (read-only) and sym. link")
-	require.NoError(t, os.Mkdir(nestedDir, source.OwnerWritableDirMode))
-	require.NoError(t, os.WriteFile(filePath, []byte("test"), source.OwnerReadOnlyFileMode))
-	require.NoError(t, os.Symlink(targetFilePath, symlinkPath))
-
-	t.Log("Make directory read-only")
-	require.NoError(t, os.Chmod(nestedDir, source.OwnerReadOnlyDirMode))
-
-	t.Log("Call SetWritableRecursive")
-	require.NoError(t, source.SetWritableRecursive(nestedDir))
-
-	t.Log("Check file is writable")
-	stat, err := os.Stat(filePath)
-	require.NoError(t, err)
-	require.Equal(t, source.OwnerWritableFileMode, stat.Mode().Perm())
-
-	t.Log("Check directory is writable")
-	nestedStat, err := os.Stat(nestedDir)
-	require.NoError(t, err)
-	require.Equal(t, source.OwnerWritableDirMode, nestedStat.Mode().Perm())
-
-	t.Log("Check symlink target file permissions - should not be affected")
-	stat, err = os.Stat(targetFilePath)
-	require.NoError(t, err)
-	require.Equal(t, fs.FileMode(0644), stat.Mode().Perm())
-}
-
-func TestDeleteReadOnlyRecursive(t *testing.T) {
-	tempDir := t.TempDir()
-	nestedDir := filepath.Join(tempDir, "nested")
-	filePath := filepath.Join(nestedDir, "testfile")
-
-	t.Log("Create a nested read-only directory structure that contains a file and sym. link")
-	require.NoError(t, os.Mkdir(nestedDir, source.OwnerWritableDirMode))
-	require.NoError(t, os.WriteFile(filePath, []byte("test"), source.OwnerReadOnlyFileMode))
-	require.NoError(t, os.Chmod(nestedDir, source.OwnerReadOnlyDirMode))
-
-	t.Log("Set directory structure as read-only")
-	require.NoError(t, source.DeleteReadOnlyRecursive(nestedDir))
-
-	t.Log("Ensure directory was deleted")
-	_, err := os.Stat(nestedDir)
-	require.ErrorIs(t, err, os.ErrNotExist)
-}
 
 func TestIsImageUnpacked(t *testing.T) {
 	tempDir := t.TempDir()
@@ -116,7 +21,7 @@ func TestIsImageUnpacked(t *testing.T) {
 	require.True(t, modTime.IsZero())
 
 	t.Log("Test case: unpack path points to file")
-	require.NoError(t, os.WriteFile(unpackPath, []byte("test"), source.OwnerWritableFileMode))
+	require.NoError(t, os.WriteFile(unpackPath, []byte("test"), 0600))
 
 	unpacked, modTime, err = source.IsImageUnpacked(filepath.Join(tempDir, "myimage"))
 	require.NoError(t, err)
@@ -128,7 +33,7 @@ func TestIsImageUnpacked(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 
 	t.Log("Test case: unpack path points to directory (happy path)")
-	require.NoError(t, os.Mkdir(unpackPath, source.OwnerWritableDirMode))
+	require.NoError(t, os.Mkdir(unpackPath, 0700))
 
 	unpacked, modTime, err = source.IsImageUnpacked(unpackPath)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

This fix is required because If there are read-only files or directories in the cache dir when the process starts up (which can easily happen in catalogd), then we can't delete them and error out instead. This fix tries to set the files writable before deleting them.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
