### PR TITLE
⚠ (catalogd) Update query endpoint to metas endpoint

### DIFF
--- a/catalogd/internal/storage/localdir.go
+++ b/catalogd/internal/storage/localdir.go
@@ -190,7 +190,7 @@ func (s *LocalDirV1) StorageServerHandler() http.Handler {
 
 	mux.HandleFunc(s.RootURL.JoinPath("{catalog}", "api", "v1", "all").Path, s.handleV1All)
 	if s.EnableQueryHandler {
-		mux.HandleFunc(s.RootURL.JoinPath("{catalog}", "api", "v1", "query").Path, s.handleV1Query)
+		mux.HandleFunc(s.RootURL.JoinPath("{catalog}", "api", "v1", "metas").Path, s.handleV1Query)
 	}
 	allowedMethodsHandler := func(next http.Handler, allowedMethods ...string) http.Handler {
 		allowedMethodSet := sets.New[string](allowedMethods...)

--- a/catalogd/internal/storage/localdir_test.go
+++ b/catalogd/internal/storage/localdir_test.go
@@ -338,7 +338,7 @@ func TestQueryEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/catalogs/test-catalog/api/v1/query%s", testServer.URL, tc.queryParams), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/catalogs/test-catalog/api/v1/metas%s", testServer.URL, tc.queryParams), nil)
 			require.NoError(t, err)
 
 			if strings.Contains(tc.name, "If-Modified-Since") {
@@ -397,7 +397,7 @@ func TestServerLoadHandling(t *testing.T) {
 				var reqs []*http.Request
 				for i := 0; i < 100; i++ {
 					req, _ := http.NewRequest(http.MethodGet,
-						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/query?schema=olm.bundle", baseURL),
+						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/metas?schema=olm.bundle", baseURL),
 						nil)
 					req.Header.Set("Accept", "application/jsonl")
 					reqs = append(reqs, req)
@@ -422,7 +422,7 @@ func TestServerLoadHandling(t *testing.T) {
 				var reqs []*http.Request
 				for i := 0; i < 50; i++ {
 					req, _ := http.NewRequest(http.MethodGet,
-						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/query?package=test-op-%d", baseURL, i),
+						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/metas?package=test-op-%d", baseURL, i),
 						nil)
 					req.Header.Set("Accept", "application/jsonl")
 					reqs = append(reqs, req)
@@ -452,7 +452,7 @@ func TestServerLoadHandling(t *testing.T) {
 						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/all", baseURL),
 						nil)
 					queryReq, _ := http.NewRequest(http.MethodGet,
-						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/query?schema=olm.bundle", baseURL),
+						fmt.Sprintf("%s/catalogs/test-catalog/api/v1/metas?schema=olm.bundle", baseURL),
 						nil)
 					allReq.Header.Set("Accept", "application/jsonl")
 					queryReq.Header.Set("Accept", "application/jsonl")


### PR DESCRIPTION
The [RFC](https://docs.google.com/document/d/1s6_9IFEKGQLNh3ueH7SF4Yrx4PW9NSiNFqFIJx0pU-8/edit?usp=sharing) was updated to reflect a decision to change the new endpoint from $base/api/v1/query to $base/api/v1/metas.

This PR makes that change.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
