### PR TITLE
🐛 fix catalogd version variable paths in Makefile

### DIFF
--- a/catalogd/Makefile
+++ b/catalogd/Makefile
@@ -121,7 +121,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 endif
 export VERSION
 
-export VERSION_PKG     := $(shell go list -m)/internal/version
+export VERSION_PKG     := $(shell go list -mod=mod ./internal/version)
 
 export GIT_COMMIT      := $(shell git rev-parse HEAD)
 export GIT_VERSION     := $(shell git describe --tags --always --dirty)


### PR DESCRIPTION
# Description
Fix for the catalogd version package path in the Makefile to ensure catalogd binary contains the correct version information.

See https://issues.redhat.com/browse/OCPBUGS-49866
