### PR TITLE
🐛 (catalogd) Don't write to header after checking for Preconditions

### DIFF
--- a/catalogd/internal/storage/http_precoditions_check.go
+++ b/catalogd/internal/storage/http_precoditions_check.go
@@ -57,7 +57,7 @@ func checkIfModifiedSince(r *http.Request, w http.ResponseWriter, modtime time.T
 	if ims == "" || isZeroTime(modtime) {
 		return condTrue
 	}
-	t, err := ParseTime(ims)
+	t, err := parseTime(ims)
 	if err != nil {
 		httpError(w, err)
 		return condNone
@@ -76,7 +76,7 @@ func checkIfUnmodifiedSince(r *http.Request, modtime time.Time) condResult {
 	if ius == "" || isZeroTime(modtime) {
 		return condNone
 	}
-	t, err := ParseTime(ius)
+	t, err := parseTime(ius)
 	if err != nil {
 		return condNone
 	}
@@ -90,18 +90,18 @@ func checkIfUnmodifiedSince(r *http.Request, modtime time.Time) condResult {
 	return condFalse
 }
 
-// TimeFormat is the time format to use when generating times in HTTP
+// timeFormat is the time format to use when generating times in HTTP
 // headers. It is like [time.RFC1123] but hard-codes GMT as the time
 // zone. The time being formatted must be in UTC for Format to
 // generate the correct format.
 //
 // For parsing this time format, see [ParseTime].
-const TimeFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
+const timeFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
 
 var (
 	unixEpochTime = time.Unix(0, 0)
 	timeFormats   = []string{
-		TimeFormat,
+		timeFormat,
 		time.RFC850,
 		time.ANSIC,
 	}
@@ -155,11 +155,11 @@ func checkIfNoneMatch(r *http.Request) condResult {
 	return condTrue
 }
 
-// ParseTime parses a time header (such as the Date: header),
+// parseTime parses a time header (such as the Date: header),
 // trying each of the three formats allowed by HTTP/1.1:
 // [TimeFormat], [time.RFC850], and [time.ANSIC].
 // nolint:nonamedreturns
-func ParseTime(text string) (t time.Time, err error) {
+func parseTime(text string) (t time.Time, err error) {
 	for _, layout := range timeFormats {
 		t, err = time.Parse(layout, text)
 		if err == nil {

--- a/catalogd/internal/storage/localdir.go
+++ b/catalogd/internal/storage/localdir.go
@@ -231,9 +231,9 @@ func (s *LocalDirV1) handleV1Query(w http.ResponseWriter, r *http.Request) {
 	}
 	defer catalogFile.Close()
 
-	w.Header().Set("Last-Modified", catalogStat.ModTime().UTC().Format(TimeFormat))
-	if checkPreconditions(w, r, catalogStat.ModTime()) {
-		w.WriteHeader(http.StatusNotModified)
+	w.Header().Set("Last-Modified", catalogStat.ModTime().UTC().Format(timeFormat))
+	done := checkPreconditions(w, r, catalogStat.ModTime())
+	if done {
 		return
 	}
 


### PR DESCRIPTION
`checkPreconditions` already writes http.StatusNotModified to the writer. It also writes http.StatusPreconditionFailed in certain cases. Writing again could overwrite the status written by `checkPreconditions`. This PR fixes the issue.

Refers [the source](https://cs.opensource.google/go/go/+/master:src/net/http/fs.go;l=271-274) for correct usage.


Additionally un-exports previously exported function/variable in the copied code from net/http. 

Signed-off-by: Anik Bhattacharjee <anbhatta@redhat.com>
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
