### PR TITLE
✨ Check known required permissions for install before installing with the helm applier

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -407,9 +407,12 @@ func run() error {
 		crdupgradesafety.NewPreflight(aeClient.CustomResourceDefinitions()),
 	}
 
+	acm := applier.NewAuthClientMapper(clientRestConfigMapper, mgr.GetConfig())
+
 	helmApplier := &applier.Helm{
 		ActionClientGetter: acg,
 		Preflights:         preflights,
+		AuthClientMapper:   acm,
 	}
 
 	cm := contentmanager.NewManager(clientRestConfigMapper, mgr.GetConfig(), mgr.GetRESTMapper())

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -61,6 +61,7 @@ import (
 	"github.com/operator-framework/operator-controller/internal/operator-controller/action"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/applier"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/authentication"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/catalogmetadata/cache"
 	catalogclient "github.com/operator-framework/operator-controller/internal/operator-controller/catalogmetadata/client"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/contentmanager"
@@ -409,16 +410,16 @@ func run() error {
 		crdupgradesafety.NewPreflight(aeClient.CustomResourceDefinitions()),
 	}
 
-	acm := applier.NewAuthClientMapper(clientRestConfigMapper, mgr.GetConfig())
+	acm := authorization.NewAuthorizationClientMapper(clientRestConfigMapper, mgr.GetConfig())
 	acm.NewForConfig = func(cfg *rest.Config) (authorizationv1client.AuthorizationV1Interface, error) {
 		// *AuthorizationV1Client implements AuthorizationV1Interface
 		return authorizationv1client.NewForConfig(cfg)
 	}
 
 	helmApplier := &applier.Helm{
-		ActionClientGetter: acg,
-		Preflights:         preflights,
-		AuthClientMapper:   acm,
+		ActionClientGetter:        acg,
+		Preflights:                preflights,
+		AuthorizationClientMapper: acm,
 	}
 
 	cm := contentmanager.NewManager(clientRestConfigMapper, mgr.GetConfig(), mgr.GetRESTMapper())

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -37,8 +37,10 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	apimachineryrand "k8s.io/apimachinery/pkg/util/rand"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	"k8s.io/utils/ptr"
@@ -408,6 +410,10 @@ func run() error {
 	}
 
 	acm := applier.NewAuthClientMapper(clientRestConfigMapper, mgr.GetConfig())
+	acm.NewForConfig = func(cfg *rest.Config) (authorizationv1client.AuthorizationV1Interface, error) {
+		// *AuthorizationV1Client implements AuthorizationV1Interface
+		return authorizationv1client.NewForConfig(cfg)
+	}
 
 	helmApplier := &applier.Helm{
 		ActionClientGetter: acg,

--- a/internal/operator-controller/applier/helm.go
+++ b/internal/operator-controller/applier/helm.go
@@ -18,12 +18,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachyaml "k8s.io/apimachinery/pkg/util/yaml"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
-	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
@@ -111,7 +111,6 @@ func shouldSkipPreflight(ctx context.Context, preflight Preflight, ext *ocv1.Clu
 }
 
 func (h *Helm) Apply(ctx context.Context, contentFS fs.FS, ext *ocv1.ClusterExtension, objectLabels map[string]string, storageLabels map[string]string) ([]client.Object, string, error) {
-
 	if features.OperatorControllerFeatureGate.Enabled(features.PreflightPermissions) {
 		authclient, err := h.AuthClientMapper.GetAuthenticationClient(ctx, ext)
 		if err != nil {

--- a/internal/operator-controller/applier/helm_test.go
+++ b/internal/operator-controller/applier/helm_test.go
@@ -115,13 +115,13 @@ func newPassingSSRRAuthClient() authorizationv1client.AuthorizationV1Interface {
 	}
 }
 
-// Helper builds an AuthClientMapper with the passing SSRR
-func newPassingAuthClientMapper() applier.AuthClientMapper {
+// Helper builds an AuthorizationClientMapper with the passing SSRR
+func newPassingAuthorizationClientMapper() applier.AuthorizationClientMapper {
 	fakeRestConfig := &rest.Config{Host: "fake-server"}
 	mockRCM := func(ctx context.Context, obj client.Object, cfg *rest.Config) (*rest.Config, error) {
 		return cfg, nil
 	}
-	acm := applier.NewAuthClientMapper(mockRCM, fakeRestConfig)
+	acm := applier.NewAuthorizationClientMapper(mockRCM, fakeRestConfig)
 	acm.NewForConfig = func(*rest.Config) (authorizationv1client.AuthorizationV1Interface, error) {
 		return newPassingSSRRAuthClient(), nil
 	}
@@ -131,9 +131,9 @@ func newPassingAuthClientMapper() applier.AuthClientMapper {
 // Helper builds a Helm applier with passing SSRR
 func buildHelmApplier(mockAcg *mockActionGetter, preflights []applier.Preflight) applier.Helm {
 	return applier.Helm{
-		ActionClientGetter: mockAcg,
-		AuthClientMapper:   newPassingAuthClientMapper(),
-		Preflights:         preflights,
+		ActionClientGetter:        mockAcg,
+		AuthorizationClientMapper: newPassingAuthorizationClientMapper(),
+		Preflights:                preflights,
 	}
 }
 

--- a/internal/operator-controller/applier/helm_test.go
+++ b/internal/operator-controller/applier/helm_test.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/applier"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/features"
 )
 
@@ -121,7 +122,7 @@ func newPassingAuthorizationClientMapper() applier.AuthorizationClientMapper {
 	mockRCM := func(ctx context.Context, obj client.Object, cfg *rest.Config) (*rest.Config, error) {
 		return cfg, nil
 	}
-	acm := applier.NewAuthorizationClientMapper(mockRCM, fakeRestConfig)
+	acm := authorization.NewAuthorizationClientMapper(mockRCM, fakeRestConfig)
 	acm.NewForConfig = func(*rest.Config) (authorizationv1client.AuthorizationV1Interface, error) {
 		return newPassingSSRRAuthClient(), nil
 	}

--- a/internal/operator-controller/authorization/authorization.go
+++ b/internal/operator-controller/authorization/authorization.go
@@ -1,0 +1,112 @@
+package authorization
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	authv1 "k8s.io/api/authorization/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	SelfSubjectRulesReview  string = "SelfSubjectRulesReview"
+	SelfSubjectAccessReview string = "SelfSubjectAccessReview"
+)
+
+func CheckObjectPermissions(ctx context.Context, authcl *authorizationv1client.AuthorizationV1Client, objects []client.Object, ext *ocv1.ClusterExtension) error {
+	ssrr := &authv1.SelfSubjectRulesReview{
+		Spec: authv1.SelfSubjectRulesReviewSpec{
+			Namespace: ext.Spec.Namespace,
+		},
+	}
+
+	ssrr, err := authcl.SelfSubjectRulesReviews().Create(ctx, ssrr, v1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	rules := []rbacv1.PolicyRule{}
+	for _, rule := range ssrr.Status.ResourceRules {
+		rules = append(rules, rbacv1.PolicyRule{
+			Verbs:         rule.Verbs,
+			APIGroups:     rule.APIGroups,
+			Resources:     rule.Resources,
+			ResourceNames: rule.ResourceNames,
+		})
+	}
+
+	for _, rule := range ssrr.Status.NonResourceRules {
+		rules = append(rules, rbacv1.PolicyRule{
+			Verbs:           rule.Verbs,
+			NonResourceURLs: rule.NonResourceURLs,
+		})
+	}
+
+	resAttrs := []authv1.ResourceAttributes{}
+	namespacedErrs := []error{}
+	clusterScopedErrs := []error{}
+	requiredVerbs := []string{"get", "create", "update", "list", "watch", "delete", "patch"}
+
+	for _, o := range objects {
+		for _, verb := range requiredVerbs {
+			resAttrs = append(resAttrs, authv1.ResourceAttributes{
+				Namespace: o.GetNamespace(),
+				Verb:      verb,
+				Resource:  sanitizeResourceName(o.GetObjectKind().GroupVersionKind().Kind),
+				Group:     o.GetObjectKind().GroupVersionKind().Group,
+				Name:      o.GetName(),
+			})
+		}
+	}
+
+	for _, resAttr := range resAttrs {
+		if !canI(resAttr, rules) {
+			if resAttr.Namespace != "" {
+				namespacedErrs = append(namespacedErrs, fmt.Errorf("cannot %s %s %s in namespace %s",
+					resAttr.Verb,
+					strings.TrimSuffix(resAttr.Resource, "s"),
+					resAttr.Name,
+					resAttr.Namespace))
+				continue
+			}
+			clusterScopedErrs = append(clusterScopedErrs, fmt.Errorf("cannot %s %s %s",
+				resAttr.Verb,
+				strings.TrimSuffix(resAttr.Resource, "s"),
+				resAttr.Name))
+		}
+	}
+	errs := append(namespacedErrs, clusterScopedErrs...)
+	if len(errs) > 0 {
+		errs = append([]error{fmt.Errorf("installer service account %s is missing required permissions", ext.Spec.ServiceAccount.Name)}, errs...)
+	}
+
+	return errors.Join(errs...)
+
+}
+
+// Checks if the rules allow the verb on the GroupVersionKind in resAttr
+func canI(resAttr authv1.ResourceAttributes, rules []rbacv1.PolicyRule) bool {
+	var canI bool
+	for _, rule := range rules {
+		if (slices.Contains(rule.APIGroups, resAttr.Group) || slices.Contains(rule.APIGroups, "*")) &&
+			(slices.Contains(rule.Resources, resAttr.Resource) || slices.Contains(rule.Resources, "*")) &&
+			(slices.Contains(rule.Verbs, resAttr.Verb) || slices.Contains(rule.Verbs, "*")) &&
+			(slices.Contains(rule.ResourceNames, resAttr.Name) || len(rule.ResourceNames) == 0) {
+			canI = true
+			break
+		}
+	}
+	return canI
+}
+
+// SelfSubjectRulesReview formats the resource names as lowercase and plural
+func sanitizeResourceName(resourceName string) string {
+	return strings.ToLower(resourceName) + "s"
+}

--- a/internal/operator-controller/authorization/authorization.go
+++ b/internal/operator-controller/authorization/authorization.go
@@ -21,7 +21,7 @@ const (
 	SelfSubjectAccessReview string = "SelfSubjectAccessReview"
 )
 
-func CheckObjectPermissions(ctx context.Context, authcl *authorizationv1client.AuthorizationV1Client, objects []client.Object, ext *ocv1.ClusterExtension) error {
+func CheckObjectPermissions(ctx context.Context, authcl authorizationv1client.AuthorizationV1Interface, objects []client.Object, ext *ocv1.ClusterExtension) error {
 	ssrr := &authorizationv1.SelfSubjectRulesReview{
 		Spec: authorizationv1.SelfSubjectRulesReviewSpec{
 			Namespace: ext.Spec.Namespace,

--- a/internal/operator-controller/authorization/client.go
+++ b/internal/operator-controller/authorization/client.go
@@ -1,0 +1,33 @@
+package authorization
+
+import (
+	"context"
+
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+)
+
+type NewForConfigFunc func(*rest.Config) (authorizationv1client.AuthorizationV1Interface, error)
+
+// AuthorizationClient is an interface exposing only the needed functionality
+type AuthorizationClient interface {
+	CheckContentPermissions(ctx context.Context, objects []client.Object, ext *ocv1.ClusterExtension) error
+}
+
+// clientImpl wraps the underlying authorization client
+type clientImpl struct {
+	authClient authorizationv1client.AuthorizationV1Interface
+}
+
+// NewClient wraps an authorizationv1client.AuthorizationV1Interface
+func NewClient(authClient authorizationv1client.AuthorizationV1Interface) AuthorizationClient {
+	return &clientImpl{authClient: authClient}
+}
+
+// CheckContentPermissions is the public method that internally calls the generic check
+func (c *clientImpl) CheckContentPermissions(ctx context.Context, objects []client.Object, ext *ocv1.ClusterExtension) error {
+	return CheckObjectPermissions(ctx, c.authClient, objects, ext)
+}


### PR DESCRIPTION
Adds a check that makes sure the installer service account has the necessary get permissions to get all the resources it will need to inspect for a server-connected dry-run and returns errors detailing all the missing get permissions. This prevents a hung server-connected dry-run getting caught on individual missing get permissions.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
