### PR TITLE
✨ Migrate operator-controller cli handling to cobra

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -82,16 +82,16 @@ var (
 )
 
 type config struct {
-	metricsAddr               string
-	certFile                  string
-	keyFile                   string
-	enableLeaderElection      bool
-	probeAddr                 string
-	cachePath                 string
-	systemNamespace           string
-	catalogdCasDir            string
-	pullCasDir                string
-	globalPullSecret          string
+	metricsAddr          string
+	certFile             string
+	keyFile              string
+	enableLeaderElection bool
+	probeAddr            string
+	cachePath            string
+	systemNamespace      string
+	catalogdCasDir       string
+	pullCasDir           string
+	globalPullSecret     string
 }
 
 const authFilePrefix = "operator-controller-global-pull-secrets"
@@ -113,7 +113,7 @@ var operatorControllerCmd = &cobra.Command{
 	Short: "operator-controller is the central component of Operator Lifecycle Manager (OLM) v1",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateMetricsFlags(); err != nil {
-			return fmt.Errorf("Error: %v\n", err)
+			return err
 		}
 		return run()
 	},
@@ -128,7 +128,6 @@ var versionCommand = &cobra.Command{
 }
 
 func init() {
-
 	//create flagset, the collection of flags for this command
 	flags := operatorControllerCmd.Flags()
 	flags.StringVar(&cfg.metricsAddr, "metrics-bind-address", "", "The address for the metrics endpoint. Requires tls-cert and tls-key. (Default: ':8443')")
@@ -157,7 +156,6 @@ func init() {
 
 	//add feature gate flags to flagset
 	features.OperatorControllerFeatureGate.AddFlag(flags)
-
 }
 func validateMetricsFlags() error {
 	if (cfg.certFile != "" && cfg.keyFile == "") || (cfg.certFile == "" && cfg.keyFile != "") {
@@ -485,7 +483,8 @@ func run() error {
 }
 
 func main() {
-
-	operatorControllerCmd.Execute()
-
+	if err := operatorControllerCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -88,7 +88,6 @@ type config struct {
 	enableLeaderElection      bool
 	probeAddr                 string
 	cachePath                 string
-	operatorControllerVersion bool
 	systemNamespace           string
 	catalogdCasDir            string
 	pullCasDir                string
@@ -122,7 +121,7 @@ var operatorControllerCmd = &cobra.Command{
 
 var versionCommand = &cobra.Command{
 	Use:   "version",
-	Short: "Prints version info of operator-controller",
+	Short: "Prints operator-controller version information",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(version.String())
 	},
@@ -142,7 +141,6 @@ func init() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache", "The local directory path used for filesystem based caching")
-	flags.BoolVar(&cfg.operatorControllerVersion, "version", false, "Prints operator-controller version information")
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "Configures the namespace that gets used to deploy system resources.")
 	flags.StringVar(&cfg.globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/operator-framework/operator-registry v1.50.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3
+	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
@@ -198,7 +199,6 @@ require (
 	github.com/sigstore/rekor v1.3.6 // indirect
 	github.com/sigstore/sigstore v1.8.9 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
Migrate operator-controller cli command handling to cobra
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->
Maintain/update flag handling by migrating to cobra as requested @ https://github.com/operator-framework/operator-controller/issues/1650

Changes:

- Stopped using pflags, moved to cobra
- Changed how the version flag is processed, instead adding it as a subcommand
- Moved flag processing/validation out of main()
- Integrated cobra error handling with RunE while preserving setupLog error messages

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
