### PR TITLE
🌱 (cleanup): Refactor metrics endpoint tests by extracting shared helpers

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// FindK8sClient returns the first available Kubernetes CLI client from the system,
+// It checks for the existence of each client by running `version --client`.
+// If no suitable client is found, the function terminates the test with a failure.
+func FindK8sClient(t *testing.T) string {
+	t.Logf("Finding kubectl client")
+	clients := []string{"kubectl", "oc"}
+	for _, c := range clients {
+		// Would prefer to use `command -v`, but even that may not be installed!
+		if err := exec.Command(c, "version", "--client").Run(); err == nil {
+			t.Logf("Using %q as k8s client", c)
+			return c
+		}
+	}
+	t.Fatal("k8s client not found")
+	return ""
+}


### PR DESCRIPTION
Refactored the metrics endpoint tests by introducing reusable helper functions. This reduces duplication and improves maintainability across both tests.

Motivated by: https://github.com/operator-framework/operator-controller/issues/1712