### PR TITLE
🌱 (catalogd) serveFile for all endpoint instead of serveContent

### DIFF
--- a/catalogd/internal/storage/localdir.go
+++ b/catalogd/internal/storage/localdir.go
@@ -210,13 +210,8 @@ func (s *LocalDirV1) handleV1All(w http.ResponseWriter, r *http.Request) {
 	defer s.m.RUnlock()
 
 	catalog := r.PathValue("catalog")
-	catalogFile, catalogStat, err := s.catalogData(catalog)
-	if err != nil {
-		httpError(w, err)
-		return
-	}
 	w.Header().Add("Content-Type", "application/jsonl")
-	http.ServeContent(w, r, "", catalogStat.ModTime(), catalogFile)
+	http.ServeFile(w, r, catalogFilePath(s.catalogDir(catalog)))
 }
 
 func (s *LocalDirV1) handleV1Query(w http.ResponseWriter, r *http.Request) {

--- a/catalogd/internal/storage/localdir_test.go
+++ b/catalogd/internal/storage/localdir_test.go
@@ -238,7 +238,7 @@ func TestLocalDirServerHandler(t *testing.T) {
 		{
 			name:               "Server returns 404 when non-existent catalog is queried",
 			expectedStatusCode: http.StatusNotFound,
-			expectedContent:    "404 Not Found",
+			expectedContent:    "404 page not found",
 			URLPath:            "/catalogs/non-existent-catalog/api/v1/all",
 		},
 		{


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
