### PR TITLE
🐛 (catalogd) `serveJSON` lines instead of `http.serverContent` for no-params

### DIFF
--- a/catalogd/internal/storage/localdir.go
+++ b/catalogd/internal/storage/localdir.go
@@ -243,8 +243,7 @@ func (s *LocalDirV1) handleV1Query(w http.ResponseWriter, r *http.Request) {
 
 	if schema == "" && pkg == "" && name == "" {
 		// If no parameters are provided, return the entire catalog (this is the same as /api/v1/all)
-		w.Header().Add("Content-Type", "application/jsonl")
-		http.ServeContent(w, r, "", catalogStat.ModTime(), catalogFile)
+		serveJSONLines(w, r, catalogFile)
 		return
 	}
 	idx, err := s.getIndex(catalog)


### PR DESCRIPTION
The metas endpoint was using `serverJSONLines` for serving queries that are parameterized, which copies content from a reader to the response writer under the hood. As a result no-parameterized query responses don't have range request support.

The endpoint was however using `http.ServeContent` for cases when no parameters were provided, which does have range request support.

This PR switches the `http.ServeContent` out for `serveJSONLines` to make sure metas endpoint is consistent in it's lack of support for range requests.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
