### PR TITLE
:bug: Fix: overwrites the CA directory only when pullCasDir is not empty

### DIFF
--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -272,9 +272,10 @@ func main() {
 	unpacker := &source.ContainersImageRegistry{
 		BaseCachePath: unpackCacheBasePath,
 		SourceContextFunc: func(logger logr.Logger) (*types.SystemContext, error) {
-			srcContext := &types.SystemContext{
-				DockerCertPath: pullCasDir,
-				OCICertPath:    pullCasDir,
+			srcContext := &types.SystemContext{}
+			if pullCasDir != "" {
+				srcContext.DockerCertPath = pullCasDir
+				srcContext.OCICertPath = pullCasDir
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -309,9 +309,10 @@ func main() {
 	unpacker := &source.ContainersImageRegistry{
 		BaseCachePath: filepath.Join(cachePath, "unpack"),
 		SourceContextFunc: func(logger logr.Logger) (*types.SystemContext, error) {
-			srcContext := &types.SystemContext{
-				DockerCertPath: pullCasDir,
-				OCICertPath:    pullCasDir,
+			srcContext := &types.SystemContext{}
+			if pullCasDir != "" {
+				srcContext.DockerCertPath = pullCasDir
+				srcContext.OCICertPath = pullCasDir
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

If pullCasDir is `""`, then `DockerCertPath` and `OCICertPath` are explicitly set to `""`, which causes `containers/image` not to read `/etc/docker/certs.d/`. So, overwrites the CA directory only when pullCasDir is not empty.
```console
srcContext := &types.SystemContext{
    DockerCertPath: pullCasDir,  // pullCasDir = ""
    OCICertPath:    pullCasDir,
}
```
Test pass, see downstream PR: https://github.com/openshift/operator-framework-operator-controller/pull/264 


## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
