### PR TITLE
🐛 fix catalogd binary version output.

### DIFF
--- a/catalogd/Makefile
+++ b/catalogd/Makefile
@@ -121,7 +121,7 @@ VERSION := $(shell git describe --tags --always --dirty)
 endif
 export VERSION
 
-export VERSION_PKG     := $(shell go list -mod=mod ./internal/version)
+export VERSION_PKG     := $(shell go list -m)/internal/version
 
 export GIT_COMMIT      := $(shell git rev-parse HEAD)
 export GIT_VERSION     := $(shell git describe --tags --always --dirty)


### PR DESCRIPTION
Follow up of: https://github.com/operator-framework/operator-controller/pull/1728

Issue (before change)

```
make build

/Library/Developer/CommandLineTools/usr/bin/make -C catalogd generate
stat /Users/camilam/go/src/github/operator-framework/operator-controller/catalogd/internal/version: directory not found
  Aft
```

After change:

The version has been obtained properly:

```
go build -tags 'containers_image_openpgp' -ldflags '-s -w -X "github.com/operator-framework/operator-controller/internal/version.gitVersion=v1.2.0-rc4-24-gd72e551-dirty" -X "github.com/operator-framework/operator-controller/internal/version.gitCommit=d72e5518c1605bde9359f643c44934c9885fdadf" -X "github.com/operator-framework/operator-controller/internal/version.gitTreeState=dirty" -X "github.com/operator-framework/operator-controller/internal/version.commitDate=2025-02-07T14:09:09Z"' -gcflags 'all=-trimpath=/Users/camilam/go/src/github/operator-framework/operator-controller/catalogd' -asmflags 'all=-trimpath=/Users/camilam/go/src/github/operator-framework/operator-controller/catalogd' -o bin/catalogd ./cmd/catalogd

 $ ./bin/catalogd --version
"version: \"(devel)\", commit: \"d72e5518c1605bde9359f643c44934c9885fdadf\", date: \"2025-02-07T14:09:09Z\", state: \"dirty\""
```
