### PR TITLE
🌱 fix demo-update script to support mac os envs

### DIFF
--- a/catalogd/Makefile
+++ b/catalogd/Makefile
@@ -206,7 +206,8 @@ cert-manager:
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MGR_VERSION}/cert-manager.yaml
 	kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
 
-.PHONY: demo-update
+# The demo script requires to install asciinema with: brew install asciinema to run on mac os envs.
+.PHONY: demo-update #HELP build demo
 demo-update:
 	hack/scripts/generate-asciidemo.sh
 

--- a/catalogd/hack/scripts/generate-asciidemo.sh
+++ b/catalogd/hack/scripts/generate-asciidemo.sh
@@ -36,7 +36,7 @@ while getopts 'h' flag; do
 done
 set -u
 
-WKDIR=$(mktemp -td generate-asciidemo.XXXXX)
+WKDIR=$(mktemp -d -t generate-asciidemo.XXXXX)
 if [ ! -d ${WKDIR} ]
 then
     echo "unable to create temporary workspace"


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Currently, the script does not work for mac env.
The change here ensure that it can work for linux and mac
See:

```
View the recording at:

    https://asciinema.org/a/R4bFB4cTQaJSytvePHqLl8pNu

This asciinema CLI hasn't been linked to any asciinema.org account.

Recordings uploaded from unrecognized systems, such as this one, are automatically
deleted 7 days after upload.

If you want to preserve all recordings uploaded from this machine,
authenticate this CLI with your asciinema.org account by opening the following link:

    https://asciinema.org/connect/054dd205-c559-4711-80ae-a01034074c79
```


Before the change made:

```
 $ make demo-update
hack/scripts/generate-asciidemo.sh
hack/scripts/generate-asciidemo.sh: line 40: [: /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/d.EqBWI4NlpY: binary operator expected
unable to find prerequisite: asciinema
hack/scripts/generate-asciidemo.sh: line 17: [: /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/d.EqBWI4NlpY: binary operator expected
make: *** [demo-update] Error 1
```

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
