### PR TITLE
WIP: 🌱 [Monorepo]: Move build-container and kind-load targets to root Makefile and remove unused values from catalogd/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ e2e-coverage:
 .PHONY: kind-load
 kind-load: $(KIND) #EXHELP Loads the currently constructed images into the KIND cluster.
 	$(CONTAINER_RUNTIME) save $(IMG) | $(KIND) load image-archive /dev/stdin --name $(KIND_CLUSTER_NAME)
-	IMAGE_REPO=$(CATALOG_IMAGE_REPO) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) $(MAKE) -C catalogd kind-load
+	$(CONTAINER_RUNTIME) save $(CATALOGD_IMG) | $(KIND) load image-archive /dev/stdin --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-deploy
 kind-deploy: export MANIFEST := ./operator-controller.yaml
@@ -348,7 +348,7 @@ wait:
 .PHONY: docker-build
 docker-build: build-linux  #EXHELP Build docker image for operator-controller and catalog with GOOS=linux and local GOARCH.
 	$(CONTAINER_RUNTIME) build -t $(IMG) -f Dockerfile ./bin/linux
-	IMAGE_REPO=$(CATALOG_IMAGE_REPO) $(MAKE) -C catalogd build-container
+	$(CONTAINER_RUNTIME) build -f catalogd/Dockerfile -t $(CATALOG_IMAGE_REPO) ./catalogd/bin/linux
 
 #SECTION Release
 ifeq ($(origin ENABLE_RELEASE_PIPELINE), undefined)

--- a/catalogd/Makefile
+++ b/catalogd/Makefile
@@ -3,18 +3,6 @@
 SHELL := /usr/bin/env bash -o pipefail
 .SHELLFLAGS := -ec
 
-ifeq ($(origin IMAGE_REPO), undefined)
-IMAGE_REPO := quay.io/operator-framework/catalogd
-endif
-export IMAGE_REPO
-
-ifeq ($(origin IMAGE_TAG), undefined)
-IMAGE_TAG := devel
-endif
-export IMAGE_TAG
-
-IMAGE := $(IMAGE_REPO):$(IMAGE_TAG)
-
 ifneq (, $(shell command -v docker 2>/dev/null))
 CONTAINER_RUNTIME := docker
 else ifneq (, $(shell command -v podman 2>/dev/null))
@@ -25,15 +13,6 @@ endif
 
 # bingo manages consistent tooling versions for things like kind, kustomize, etc.
 include ./../.bingo/Variables.mk
-
-# Dependencies
-export CERT_MGR_VERSION := v1.15.3
-ENVTEST_SERVER_VERSION := $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.x/')
-
-# Cluster configuration
-ifeq ($(origin KIND_CLUSTER_NAME), undefined)
-KIND_CLUSTER_NAME := catalogd
-endif
 
 ##@ General
 
@@ -109,14 +88,6 @@ go-build-linux: $(LINUX_BINARIES)
 $(LINUX_BINARIES): BUILDBIN = bin/linux
 $(LINUX_BINARIES):
 	GOOS=linux $(BUILDCMD)
-
-.PHONY: build-container
-build-container: build-linux ## Build docker image for catalogd.
-	$(CONTAINER_RUNTIME) build -f Dockerfile -t $(IMAGE) ./bin/linux
-
-.PHONY: kind-load
-kind-load: $(KIND) ## Load the built images onto the local cluster
-	$(CONTAINER_RUNTIME) save $(IMAGE) | $(KIND) load image-archive /dev/stdin --name $(KIND_CLUSTER_NAME)
 
 ##@ Deploy
 


### PR DESCRIPTION

Partial cleanup/combine the Makefile: https://github.com/operator-framework/operator-controller/issues/1340

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
