### PR TITLE
🐛 fix: Ensure logger is initialized before logging errors

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -156,6 +156,8 @@ func init() {
 
 	//add feature gate flags to flagset
 	features.OperatorControllerFeatureGate.AddFlag(flags)
+
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 }
 func validateMetricsFlags() error {
 	if (cfg.certFile != "" && cfg.keyFile == "") || (cfg.certFile == "" && cfg.keyFile != "") {


### PR DESCRIPTION
Fix scenario where setupLogger is not logging because it was not initialized. 

Closes: https://github.com/operator-framework/operator-controller/issues/1556

# Description

Before this PR:

```
./bin/operator-controller --metrics-bind-address :8080
Error: metrics-bind-address requires tls-cert and tls-key flags to be set
 ( longer was not init yet)
```

After


```
$ $ ./bin/operator-controller --metrics-bind-address :8080
E0214 14:58:32.884029   55973 main.go:171] "metrics-bind-address requires tls-cert and tls-key flags to be set" err="invalid metrics configuration" logger="setup" metricsAddr=":8080" certFile="" keyFile=""
Error: metrics-bind-address requires tls-cert and tls-key flags to be set
```
## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
