### PR TITLE
:bug: Initialize logging at correct time

### DIFF
--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -146,6 +146,7 @@ func init() {
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(catalogdv1.AddToScheme(scheme))
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 }
 
 func main() {
@@ -189,7 +190,6 @@ func validateConfig(cfg *config) error {
 }
 
 func run(ctx context.Context) error {
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 	if klog.V(4).Enabled() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -147,15 +147,14 @@ func init() {
 	operatorControllerCmd.AddCommand(versionCommand)
 
 	klog.InitFlags(flag.CommandLine)
-	if klog.V(4).Enabled() {
-		logrus.SetLevel(logrus.DebugLevel)
-	}
 
 	//add klog flags to flagset
 	flags.AddGoFlagSet(flag.CommandLine)
 
 	//add feature gate flags to flagset
 	features.OperatorControllerFeatureGate.AddFlag(flags)
+
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 }
 func validateMetricsFlags() error {
 	if (cfg.certFile != "" && cfg.keyFile == "") || (cfg.certFile == "" && cfg.keyFile != "") {
@@ -178,7 +177,9 @@ func validateMetricsFlags() error {
 	return nil
 }
 func run() error {
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	if klog.V(4).Enabled() {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 
 	setupLog.Info("starting up the controller", "version info", version.String())
 


### PR DESCRIPTION
Do ctrl.SetLogger() in init()
Check klog.V(4).Enabled() in run() (after flags have been parsed)

Closes: https://github.com/operator-framework/operator-controller/issues/1556

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
