### PR TITLE
🌱 (cleanup): remove catalogd/testdata

### DIFF
--- a/catalogd/testdata/catalogs/test-catalog.Dockerfile
+++ b/catalogd/testdata/catalogs/test-catalog.Dockerfile
@@ -1,5 +1,0 @@
-FROM scratch
-
-# Set DC-specific label for the location of the DC root directory
-# in the image
-LABEL operators.operatorframework.io.index.configs.v1=/configs


### PR DESCRIPTION
We no longer use it.
Now, catalogd e2e tests are executed with operator-controller one and we are using its testdata instead.