### PR TITLE
🐛bugfix for operator-controller not outputting the right commit ID in the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,8 @@ VERSION := $(shell git describe --tags --always --dirty)
 endif
 export VERSION
 
+GIT_COMMIT := $(if $(SOURCE_GIT_COMMIT),$(SOURCE_GIT_COMMIT),$(shell git rev-parse HEAD))
+
 ifeq ($(origin CGO_ENABLED), undefined)
 CGO_ENABLED := 0
 endif
@@ -321,6 +323,7 @@ export GO_BUILD_GCFLAGS := all=-trimpath=$(PWD)
 export GO_BUILD_FLAGS :=
 export GO_BUILD_LDFLAGS := -s -w \
     -X '$(VERSION_PATH).version=$(VERSION)' \
+-X "$(VERSION_PATH).gitCommit=$(GIT_COMMIT)" \
 
 BINARIES=operator-controller catalogd
 

--- a/Makefile
+++ b/Makefile
@@ -308,8 +308,6 @@ VERSION := $(shell git describe --tags --always --dirty)
 endif
 export VERSION
 
-GIT_COMMIT := $(if $(SOURCE_GIT_COMMIT),$(SOURCE_GIT_COMMIT),$(shell git rev-parse HEAD))
-
 ifeq ($(origin CGO_ENABLED), undefined)
 CGO_ENABLED := 0
 endif
@@ -323,7 +321,7 @@ export GO_BUILD_GCFLAGS := all=-trimpath=$(PWD)
 export GO_BUILD_FLAGS :=
 export GO_BUILD_LDFLAGS := -s -w \
     -X '$(VERSION_PATH).version=$(VERSION)' \
--X "$(VERSION_PATH).gitCommit=$(GIT_COMMIT)" \
+    -X '$(VERSION_PATH).gitCommit=$(GIT_COMMIT)' \
 
 BINARIES=operator-controller catalogd
 

--- a/internal/shared/version/version.go
+++ b/internal/shared/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	gitCommit  = "unknown"
+	gitCommit  = ""
 	commitDate = "unknown"
 	repoState  = "unknown"
 	version    = "unknown"
@@ -29,7 +29,9 @@ func init() {
 	for _, setting := range info.Settings {
 		switch setting.Key {
 		case "vcs.revision":
-			gitCommit = setting.Value
+			if gitCommit == "" {
+				gitCommit = setting.Value
+			}
 		case "vcs.time":
 			commitDate = setting.Value
 		case "vcs.modified":

--- a/internal/shared/version/version.go
+++ b/internal/shared/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	gitCommit  = ""
+	gitCommit  = "unknown"
 	commitDate = "unknown"
 	repoState  = "unknown"
 	version    = "unknown"
@@ -29,7 +29,7 @@ func init() {
 	for _, setting := range info.Settings {
 		switch setting.Key {
 		case "vcs.revision":
-			if gitCommit == "" {
+			if gitCommit == "unknown" {
 				gitCommit = setting.Value
 			}
 		case "vcs.time":


### PR DESCRIPTION
# Description
The `--version` doesn't output the source code commit ID. It refers to "vcs-ref" in the image instead of "io.openshift.build.commit.id". 

Setting the `GIT_COMMIT` value to `SOURCE_GIT_COMMIT` if empty (which is a corresponding downstream variable) will ensure that the version outputs the right commit ID as the code from this repo gets copied to another repo for building purposes. 

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
