### PR TITLE
🌱 e2e: make pods exit faster with `terminationGracePeriodSeconds: 0`

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -125,6 +125,7 @@ func (c *MetricsTestConfig) createCurlMetricsPod() {
 		"--restart=Never",
 		"--overrides", `{
 			"spec": {
+				"terminationGradePeriodSeconds": 0,
 				"containers": [{
 					"name": "curl",
 					"image": "curlimages/curl",

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
@@ -55,6 +55,7 @@ spec:
               labels:
                 app: olme2etest
             spec:
+              terminationGracePeriodSeconds: 0
               containers:
               - name: busybox
                 image: busybox


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

We can make our e2e's significantly faster by making sure pods stop immediately. Setting `terminationGracePeriodSeconds: 0` means that kubelet will send the kill signal immediately.

This is okay in our tests because:
1. For test bundles, we're setting it in the bundle (this is not something OLM itself is doing)
2. For the metrics pod, we are fine to kill it immediately because we already have the info we need from the `kubectl exec` call that has already completed.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
