### PR TITLE
🐛 util/image: unset PAXRecords and Xattrs when applying files

### DIFF
--- a/internal/shared/util/image/filters.go
+++ b/internal/shared/util/image/filters.go
@@ -23,6 +23,8 @@ func forceOwnershipRWX() archive.Filter {
 		h.Uid = uid
 		h.Gid = gid
 		h.Mode |= 0700
+		h.PAXRecords = nil
+		h.Xattrs = nil //nolint:staticcheck
 		return true, nil
 	}
 }

--- a/internal/shared/util/image/filters_test.go
+++ b/internal/shared/util/image/filters_test.go
@@ -2,10 +2,38 @@ package image
 
 import (
 	"archive/tar"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
+
+func TestForceOwnershipRWX(t *testing.T) {
+	h := tar.Header{
+		Name: "foo/bar",
+		Mode: 0000,
+		Uid:  rand.Int(),
+		Gid:  rand.Int(),
+		Xattrs: map[string]string{ //nolint:staticcheck
+			"foo": "bar",
+		},
+		PAXRecords: map[string]string{
+			"fizz": "buzz",
+		},
+	}
+	ok, err := forceOwnershipRWX()(&h)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Equal(t, "foo/bar", h.Name)
+	assert.Equal(t, int64(0700), h.Mode)
+	assert.Equal(t, os.Getuid(), h.Uid)
+	assert.Equal(t, os.Getgid(), h.Gid)
+	assert.Nil(t, h.PAXRecords)
+	assert.Nil(t, h.Xattrs) //nolint:staticcheck
+}
 
 func TestOnlyPath(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

If a catalog or bundle image contains files with xattrs, that can cause the controller to fail to unpack the image. This PR unsets those attributes to avoid permission errors when writing files to disk.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
