### PR TITLE
:bug: (fix): update PSA versions to match Kubernetes API version

### DIFF
--- a/config/base/common/namespace.yaml
+++ b/config/base/common/namespace.yaml
@@ -4,5 +4,5 @@ metadata:
   labels:
     app.kubernetes.io/part-of: olm
     pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: "v1.32"
   name: system


### PR DESCRIPTION
Derive Kubernetes minor version from client-go for PSA label and combine the calls required to get the k8s version from go.mod

