### PR TITLE
🌱 (fix) .goreleaser.yml update release notes when release is created via GitHub UI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -122,6 +122,7 @@ changelog:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
 release:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
+  mode: replace
   extra_files:
     - glob: 'operator-controller.yaml'
     - glob: './config/catalogs/clustercatalogs/default-catalogs.yaml'


### PR DESCRIPTION
f the release is created via the GitHub UI, GoReleaser fails because it detects that the release already exists. It should be configured to allow GoReleaser to update the existing release instead of failing.

Closes: https://github.com/operator-framework/operator-controller/issues/1591

More info: https://goreleaser.com/customization/release/#github