### PR TITLE
🐛(fix) Remove "Serving" condition type from ConditionSets

### DIFF
--- a/api/v1/clustercatalog_types.go
+++ b/api/v1/clustercatalog_types.go
@@ -34,6 +34,14 @@ const (
 
 	AvailabilityModeAvailable   AvailabilityMode = "Available"
 	AvailabilityModeUnavailable AvailabilityMode = "Unavailable"
+
+	// Condition types
+	TypeServing = "Serving"
+
+	// Serving Reasons
+	ReasonAvailable                = "Available"
+	ReasonUnavailable              = "Unavailable"
+	ReasonUserSpecifiedUnavailable = "UserSpecifiedUnavailable"
 )
 
 //+kubebuilder:object:root=true

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -19,7 +19,6 @@ package v1
 const (
 	TypeInstalled   = "Installed"
 	TypeProgressing = "Progressing"
-	TypeServing     = "Serving"
 
 	// Progressing reasons
 	ReasonSucceeded = "Succeeded"
@@ -29,9 +28,4 @@ const (
 	// Terminal reasons
 	ReasonDeprecated = "Deprecated"
 	ReasonFailed     = "Failed"
-
-	// Serving reasons
-	ReasonAvailable                = "Available"
-	ReasonUnavailable              = "Unavailable"
-	ReasonUserSpecifiedUnavailable = "UserSpecifiedUnavailable"
 )

--- a/internal/operator-controller/conditionsets/conditionsets.go
+++ b/internal/operator-controller/conditionsets/conditionsets.go
@@ -31,7 +31,6 @@ var ConditionTypes = []string{
 	ocv1.TypeChannelDeprecated,
 	ocv1.TypeBundleDeprecated,
 	ocv1.TypeProgressing,
-	ocv1.TypeServing,
 }
 
 var ConditionReasons = []string{
@@ -40,7 +39,4 @@ var ConditionReasons = []string{
 	ocv1.ReasonFailed,
 	ocv1.ReasonBlocked,
 	ocv1.ReasonRetrying,
-	ocv1.ReasonAvailable,
-	ocv1.ReasonUnavailable,
-	ocv1.ReasonUserSpecifiedUnavailable,
 }


### PR DESCRIPTION
conditionset.ConditionTypes was being used by the CluterExtension controller to `ensureAllConditionsWithReason` whenever a particular reason needed to be set for all of the ClusterExention's conditions. However, the `ConditionTypes` included a Condition Type `Serving`, which is not a ClusterExtension Condition(it is a ClusterCatalog condition).

This is causing the `Serving` condition to show up when a resolution fails, which is incorrect to begin with, and is then never cleared when the resolution succeeds at a later stage.

```
try to upgrade ClusterExtension to a non-exist version
$ kubectl patch ClusterExtension extension-77972 -p '{"spec":{"source":{"catalog":{"version":"0.2.0"}}}}' --type=merge
clusterextension.olm.operatorframework.io/extension-77972 patched

- lastTransitionTime: "2025-03-04T07:16:27Z"
    message: 'error upgrading from currently installed version "0.1.0": no bundles
      found for package "nginx77972" matching version "0.2.0"'
    observedGeneration: 2
    reason: Retrying
    status: "True"
    type: Progressing
  - lastTransitionTime: "2025-03-04T07:16:35Z"
    message: 'error upgrading from currently installed version "0.1.0": no bundles
      found for package "nginx77972" matching version "0.2.0"'
    observedGeneration: 2
    reason: Failed
    status: "False"
    type: Serving
  install:
    bundle:
      name: nginx77972.v0.1.0
      version: 0.1.0
```

This PR removes the `Serving` condition type from `conditonSets.ConditionType`

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
