### PR TITLE
:bug: Revert ":bug: Client go version metrics endpoint test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ test: manifests generate fmt lint test-unit test-e2e #HELP Run all tests.
 
 .PHONY: e2e
 e2e: #EXHELP Run the e2e tests.
-	go test -count=1 -v -run "$(if $(TEST_FILTER),$(TEST_FILTER),.)" ./test/e2e/...
+	go test -count=1 -v ./test/e2e/...
 
 E2E_REGISTRY_NAME := docker-registry
 E2E_REGISTRY_NAMESPACE := operator-controller-e2e
@@ -202,10 +202,7 @@ test-ext-dev-e2e: $(OPERATOR_SDK) $(KUSTOMIZE) $(KIND) #HELP Run extension creat
 	test/extension-developer-e2e/setup.sh $(OPERATOR_SDK) $(CONTAINER_RUNTIME) $(KUSTOMIZE) $(KIND) $(KIND_CLUSTER_NAME) $(E2E_REGISTRY_NAMESPACE)
 	go test -count=1 -v ./test/extension-developer-e2e/...
 
-# Define TEST_PKGS to be either user-specified or a default set of packages:
-ifeq ($(origin TEST_PKGS), undefined)
-TEST_PKGS := $(shell go list ./... | grep -v /test/)
-endif
+UNIT_TEST_DIRS := $(shell go list ./... | grep -v /test/)
 COVERAGE_UNIT_DIR := $(ROOT_DIR)/coverage/unit
 
 .PHONY: envtest-k8s-bins #HELP Uses setup-envtest to download and install the binaries required to run ENVTEST-test based locally at the project/bin directory.
@@ -221,8 +218,7 @@ test-unit: $(SETUP_ENVTEST) envtest-k8s-bins #HELP Run the unit tests
                 -tags '$(GO_BUILD_TAGS)' \
                 -cover -coverprofile ${ROOT_DIR}/coverage/unit.out \
                 -count=1 -race -short \
-                -run "$(if $(TEST_FILTER),$(TEST_FILTER),.)" \
-                $(TEST_PKGS) \
+                $(UNIT_TEST_DIRS) \
                 -test.gocoverdir=$(COVERAGE_UNIT_DIR)
 
 .PHONY: image-registry

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	globalConfig *rest.Config
-	globalClient client.Client
+	cfg *rest.Config
+	c   client.Client
 )
 
 const (
@@ -29,11 +29,11 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	globalConfig = ctrl.GetConfigOrDie()
+	cfg = ctrl.GetConfigOrDie()
 
 	var err error
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
-	globalClient, err = client.New(globalConfig, client.Options{Scheme: scheme.Scheme})
+	c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	utilruntime.Must(err)
 
 	os.Exit(m.Run())
@@ -61,7 +61,7 @@ func createTestCatalog(ctx context.Context, name string, imageRef string) (*ocv1
 		},
 	}
 
-	err := globalClient.Create(ctx, catalog)
+	err := c.Create(ctx, catalog)
 	return catalog, err
 }
 
@@ -71,7 +71,7 @@ func createTestCatalog(ctx context.Context, name string, imageRef string) (*ocv1
 func patchTestCatalog(ctx context.Context, name string, newImageRef string) error {
 	// Fetch the existing ClusterCatalog
 	catalog := &ocv1.ClusterCatalog{}
-	err := globalClient.Get(ctx, client.ObjectKey{Name: name}, catalog)
+	err := c.Get(ctx, client.ObjectKey{Name: name}, catalog)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func patchTestCatalog(ctx context.Context, name string, newImageRef string) erro
 	catalog.Spec.Source.Image.Ref = newImageRef
 
 	// Patch the ClusterCatalog
-	err = globalClient.Update(ctx, catalog)
+	err = c.Update(ctx, catalog)
 	if err != nil {
 		return err
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+)
+
+// FindK8sClient returns the first available Kubernetes CLI client from the system,
+// It checks for the existence of each client by running `version --client`.
+// If no suitable client is found, the function terminates the test with a failure.
+func FindK8sClient(t *testing.T) string {
+	t.Logf("Finding kubectl client")
+	clients := []string{"kubectl", "oc"}
+	for _, c := range clients {
+		// Would prefer to use `command -v`, but even that may not be installed!
+		if err := exec.Command(c, "version", "--client").Run(); err == nil {
+			t.Logf("Using %q as k8s client", c)
+			return c
+		}
+	}
+	t.Fatal("k8s client not found")
+	return ""
+}
+
+func ReadTestCatalogServerContents(ctx context.Context, catalog *ocv1.ClusterCatalog, kubeClient kubernetes.Interface) ([]byte, error) {
+	if catalog == nil {
+		return nil, fmt.Errorf("cannot read nil catalog")
+	}
+	if catalog.Status.URLs == nil {
+		return nil, fmt.Errorf("catalog %q has no catalog urls", catalog.Name)
+	}
+	url, err := url.Parse(catalog.Status.URLs.Base)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing clustercatalog url %q: %v", catalog.Status.URLs.Base, err)
+	}
+	// url is expected to be in the format of
+	// http://{service_name}.{namespace}.svc/catalogs/{catalog_name}/
+	// so to get the namespace and name of the service we grab only
+	// the hostname and split it on the '.' character
+	ns := strings.Split(url.Hostname(), ".")[1]
+	name := strings.Split(url.Hostname(), ".")[0]
+	port := url.Port()
+	// the ProxyGet() call below needs an explicit port value, so if
+	// value from url.Port() is empty, we assume port 443.
+	if port == "" {
+		if url.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	resp := kubeClient.CoreV1().Services(ns).ProxyGet(url.Scheme, name, port, url.JoinPath("api", "v1", "all").Path, map[string]string{})
+	rc, err := resp.Stream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	return io.ReadAll(rc)
+}


### PR DESCRIPTION
Reverts operator-framework/operator-controller#1821
Why:

Shows that broke downstream sync:
- PR to isolate: https://github.com/openshift/operator-framework-operator-controller/pull/293
- Issue: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_operator-framework-operator-controller/293/pull-ci-openshift-operator-framework-operator-controller-main-openshift-e2e-aws/1901934653003010048

```
Container test exited with code 2, reason Error
---
AtLYimWkz7DCOeuqaA7PrCJS-wbhXQmD8O1rXmdeLmiqDOBD3_ozJIEpthKERXszTlhIvwTHnGzNBTQ0A_8NBOuk0cjndJSjAS81DyAihuS6ZrfASnlygdJeHaEmGiy2o_tIaEEPMoT64gComue4IVvVHkgPnUBn2XeW38xlymDNsOC8jFWml_3bmfA3_rQa9eN1YJjAyg7Ggy_jeV7KU9v-fnDoQGWlsnQV8kXy6FYAbIb1WUGXkuSF8GmpQPGGxDKFvNwhwyjTEz-CN_X1hc2x0t3Iq8BpqBzmfNopbMwFfCFnfaSu5YxTUN95Nmgupchtw6-Q3VqwgA8uDvvETQcdzM8TLQshFOnI8ee0lf0gAHRaFlvZsE5Ubu4ecM8NG1eN-lHD3QivBUQDFFqImNx7M6O7rbYAyil_O4Tk5PUphyqBAc4nSOPseHI4SlReF85L_9dpLPEhocxx0VaoQ\r\n> \r\n{ [5 bytes data]\n* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):\n{ [122 bytes data]\n* Request completely sent off\n{ [5 bytes data]\n< HTTP/1.1 500 Internal Server Error\r\n< Content-Type: text/plain; charset=utf-8\r\n< X-Content-Type-Options: nosniff\r\n< Date: Tue, 18 Mar 2025 11:13:20 GMT\r\n< Content-Length: 22\r\n< \r\n{ [22 bytes data]\n\r100    22  100    22    0     0    738      0 --:--:-- --:--:-- --:--:--   733\r100    22  100    22    0     0    735      0 --:--:-- --:--:-- --:--:--   733\n* Connection #0 to host catalogd-service.openshift-catalogd.svc.cluster.local left intact\n" does not contain "200 OK"
        	Test:       	TestCatalogdMetricsExportedEndpoint
        	Messages:   	Metrics endpoint did not return 200 OK
    metrics_test.go:297: Cleaning up resources
    metrics_test.go:333: ClusterRoleBinding "catalogd-metrics-binding" deleted
    metrics_test.go:358: Pod "catalogd-curl-metrics" deleted
--- FAIL: TestCatalogdMetricsExportedEndpoint (6.35s)
FAIL
FAIL	github.com/operator-framework/operator-controller/test/e2e	152.432s
```