### PR TITLE
✨ Add named for controller to distinguish components in logs

### DIFF
--- a/internal/catalogd/controllers/core/clustercatalog_controller.go
+++ b/internal/catalogd/controllers/core/clustercatalog_controller.go
@@ -152,6 +152,7 @@ func (r *ClusterCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ocv1.ClusterCatalog{}).
+		Named("catalogd-clustercatalog-controller").
 		Complete(r)
 }
 

--- a/internal/catalogd/controllers/core/pull_secret_controller.go
+++ b/internal/catalogd/controllers/core/pull_secret_controller.go
@@ -64,6 +64,7 @@ func (r *PullSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *PullSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
+		Named("catalogd-pull-secret-controller").
 		WithEventFilter(newSecretPredicate(r.SecretKey)).
 		Build(r)
 

--- a/internal/operator-controller/controllers/clustercatalog_controller.go
+++ b/internal/operator-controller/controllers/clustercatalog_controller.go
@@ -93,6 +93,7 @@ func (r *ClusterCatalogReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterCatalogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, err := ctrl.NewControllerManagedBy(mgr).
+		Named("controller-operator-clustercatalog-controller").
 		For(&ocv1.ClusterCatalog{}).
 		Build(r)
 

--- a/internal/operator-controller/controllers/clusterextension_controller.go
+++ b/internal/operator-controller/controllers/clusterextension_controller.go
@@ -407,6 +407,7 @@ func SetDeprecationStatus(ext *ocv1.ClusterExtension, bundleName string, depreca
 func (r *ClusterExtensionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controller, err := ctrl.NewControllerManagedBy(mgr).
 		For(&ocv1.ClusterExtension{}).
+		Named("controller-operator-cluster-extension-controller").
 		Watches(&ocv1.ClusterCatalog{},
 			crhandler.EnqueueRequestsFromMapFunc(clusterExtensionRequestsForCatalog(mgr.GetClient(), mgr.GetLogger())),
 			builder.WithPredicates(predicate.Funcs{

--- a/internal/operator-controller/controllers/pull_secret_controller.go
+++ b/internal/operator-controller/controllers/pull_secret_controller.go
@@ -63,6 +63,7 @@ func (r *PullSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PullSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_, err := ctrl.NewControllerManagedBy(mgr).
+		Named("controller-operator-pull-secret-controller").
 		For(&corev1.Secret{}).
 		WithEventFilter(newSecretPredicate(r.SecretKey)).
 		Build(r)


### PR DESCRIPTION
This change ensures that catalogd and operator-controller components have distinct controller names (e.g., for clustercatalog). It improves metric aggregation and troubleshooting by clarifying which controller is outputting logs, reducing reliance on user-provided context.


It is related to (Motivated by):

- https://github.com/operator-framework/operator-controller/issues/1607
- https://github.com/operator-framework/operator-controller/issues/1040
- https://github.com/operator-framework/operator-controller/issues/920
