### PR TITLE
✨ Add flag to allow usage of pprof in operator-controller (disabled by default) as it is available for catalogd

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -83,6 +83,7 @@ var (
 
 type config struct {
 	metricsAddr          string
+	pprofAddr            string
 	certFile             string
 	keyFile              string
 	enableLeaderElection bool
@@ -131,6 +132,7 @@ func init() {
 	//create flagset, the collection of flags for this command
 	flags := operatorControllerCmd.Flags()
 	flags.StringVar(&cfg.metricsAddr, "metrics-bind-address", "", "The address for the metrics endpoint. Requires tls-cert and tls-key. (Default: ':8443')")
+	flags.StringVar(&cfg.pprofAddr, "pprof-bind-address", "0", "The address the pprof endpoint binds to. an empty string or 0 disables pprof")
 	flags.StringVar(&cfg.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flags.StringVar(&cfg.catalogdCasDir, "catalogd-cas-dir", "", "The directory of TLS certificate authorities to use for verifying HTTPS connections to the Catalogd web service.")
 	flags.StringVar(&cfg.pullCasDir, "pull-cas-dir", "", "The directory of TLS certificate authorities to use for verifying HTTPS connections to image registries.")
@@ -265,6 +267,7 @@ func run() error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                        scheme.Scheme,
 		Metrics:                       metricsServerOptions,
+		PprofBindAddress:              cfg.pprofAddr,
 		HealthProbeBindAddress:        cfg.probeAddr,
 		LeaderElection:                cfg.enableLeaderElection,
 		LeaderElectionID:              "9c4404e7.operatorframework.io",


### PR DESCRIPTION
# Description

In this PR we just add the option to use pprof as it exists for catalogd.
The documentation which describes how to use them is in its specific PR: https://github.com/operator-framework/operator-controller/pull/1876/files

It is related to (Motivated by):

- https://github.com/operator-framework/operator-controller/issues/1607
- https://github.com/operator-framework/operator-controller/issues/1040
- https://github.com/operator-framework/operator-controller/issues/920
