### PR TITLE
✨ contentmanager: use namespace-scoped informers

### DIFF
--- a/internal/operator-controller/contentmanager/cache/cache_test.go
+++ b/internal/operator-controller/contentmanager/cache/cache_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -27,6 +29,70 @@ func (mw *mockWatcher) Watch(source.Source) error {
 	return mw.err
 }
 
+type mockRESTMapper struct {
+	mappings map[schema.GroupVersionKind]*meta.RESTMapping
+}
+
+var _ meta.RESTMapper = (*mockRESTMapper)(nil)
+
+func (m *mockRESTMapper) KindFor(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	panic("unused")
+}
+
+func (m *mockRESTMapper) KindsFor(_ schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	panic("unused")
+}
+
+func (m *mockRESTMapper) ResourceFor(_ schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	panic("unused")
+}
+
+func (m *mockRESTMapper) ResourcesFor(_ schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	panic("unused")
+}
+
+func (m *mockRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	if len(versions) != 1 {
+		panic("always expect 1 version for mock rest mapping")
+	}
+	mapping, ok := m.mappings[gk.WithVersion(versions[0])]
+	if !ok {
+		return nil, &meta.NoKindMatchError{
+			GroupKind:        gk,
+			SearchedVersions: versions,
+		}
+	}
+	return mapping, nil
+}
+
+func (m *mockRESTMapper) RESTMappings(_ schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	panic("unused")
+}
+
+func (m *mockRESTMapper) ResourceSingularizer(_ string) (string, error) {
+	panic("unused")
+}
+
+var testRESTMapper = &mockRESTMapper{
+	mappings: map[schema.GroupVersionKind]*meta.RESTMapping{
+		corev1.SchemeGroupVersion.WithKind("Pod"): {
+			Resource:         corev1.SchemeGroupVersion.WithResource("pods"),
+			GroupVersionKind: corev1.SchemeGroupVersion.WithKind("Pod"),
+			Scope:            meta.RESTScopeNamespace,
+		},
+		corev1.SchemeGroupVersion.WithKind("Secret"): {
+			Resource:         corev1.SchemeGroupVersion.WithResource("secrets"),
+			GroupVersionKind: corev1.SchemeGroupVersion.WithKind("Secret"),
+			Scope:            meta.RESTScopeNamespace,
+		},
+		corev1.SchemeGroupVersion.WithKind("Namespace"): {
+			Resource:         corev1.SchemeGroupVersion.WithResource("namespaces"),
+			GroupVersionKind: corev1.SchemeGroupVersion.WithKind("Namespace"),
+			Scope:            meta.RESTScopeRoot,
+		},
+	},
+}
+
 type mockSourcerer struct {
 	err    error
 	source CloserSyncingSource
@@ -34,7 +100,7 @@ type mockSourcerer struct {
 
 var _ sourcerer = (*mockSourcerer)(nil)
 
-func (ms *mockSourcerer) Source(_ schema.GroupVersionKind, _ client.Object, _ func(context.Context)) (CloserSyncingSource, error) {
+func (ms *mockSourcerer) Source(_ string, _ schema.GroupVersionKind, _ client.Object, _ func(context.Context)) (CloserSyncingSource, error) {
 	if ms.err != nil {
 		return nil, ms.err
 	}
@@ -66,14 +132,33 @@ func TestCacheWatch(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
-	podGvk := corev1.SchemeGroupVersion.WithKind("Pod")
-	pod.SetGroupVersionKind(podGvk)
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+	pod.SetNamespace(rand.String(8))
 
 	require.NoError(t, c.Watch(context.Background(), &mockWatcher{}, pod))
-	require.Contains(t, c.(*cache).sources, podGvk, "sources", c.(*cache).sources)
+	require.Contains(t, c.(*cache).sources, sourceKey{pod.Namespace, pod.GroupVersionKind()}, "sources", c.(*cache).sources)
+}
+
+func TestCacheWatchClusterScopedIgnoresNamespace(t *testing.T) {
+	c := NewCache(
+		&mockSourcerer{
+			source: &mockSource{},
+		},
+		&ocv1.ClusterExtension{},
+		time.Second,
+		testRESTMapper,
+	)
+
+	ns := &corev1.Namespace{}
+	ns.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+	ns.SetNamespace(rand.String(8))
+
+	require.NoError(t, c.Watch(context.Background(), &mockWatcher{}, ns))
+	require.Contains(t, c.(*cache).sources, sourceKey{corev1.NamespaceAll, ns.GroupVersionKind()}, "sources", c.(*cache).sources)
 }
 
 func TestCacheWatchInvalidGVK(t *testing.T) {
@@ -83,6 +168,7 @@ func TestCacheWatchInvalidGVK(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
@@ -96,6 +182,7 @@ func TestCacheWatchSourcererError(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
@@ -111,6 +198,7 @@ func TestCacheWatchWatcherError(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
@@ -128,6 +216,7 @@ func TestCacheWatchSourceWaitForSyncError(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
@@ -144,12 +233,13 @@ func TestCacheWatchExistingSourceNotPanic(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
-	podGvk := corev1.SchemeGroupVersion.WithKind("Pod")
-	pod.SetGroupVersionKind(podGvk)
-	require.NoError(t, c.(*cache).addSource(podGvk, &mockSource{}))
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+	pod.SetNamespace(rand.String(8))
+	require.NoError(t, c.(*cache).addSource(sourceKey{pod.Namespace, pod.GroupVersionKind()}, &mockSource{}))
 
 	// In this case, a panic means there is a logic error somewhere in the
 	// cache.Watch() method. It should never hit the condition where it panics
@@ -164,21 +254,22 @@ func TestCacheWatchRemovesStaleSources(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
 	pod := &corev1.Pod{}
-	podGvk := corev1.SchemeGroupVersion.WithKind("Pod")
-	pod.SetGroupVersionKind(podGvk)
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+	pod.SetNamespace(rand.String(8))
 
 	require.NoError(t, c.Watch(context.Background(), &mockWatcher{}, pod))
-	require.Contains(t, c.(*cache).sources, podGvk)
+	require.Contains(t, c.(*cache).sources, sourceKey{pod.Namespace, pod.GroupVersionKind()})
 
 	secret := &corev1.Secret{}
-	secretGvk := corev1.SchemeGroupVersion.WithKind("Secret")
-	secret.SetGroupVersionKind(secretGvk)
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	secret.SetNamespace(rand.String(8))
 	require.NoError(t, c.Watch(context.Background(), &mockWatcher{}, secret))
-	require.Contains(t, c.(*cache).sources, secretGvk)
-	require.NotContains(t, c.(*cache).sources, podGvk)
+	require.Contains(t, c.(*cache).sources, sourceKey{secret.Namespace, secret.GroupVersionKind()})
+	require.NotContains(t, c.(*cache).sources, sourceKey{pod.Namespace, pod.GroupVersionKind()})
 }
 
 func TestCacheWatchRemovingStaleSourcesError(t *testing.T) {
@@ -188,15 +279,19 @@ func TestCacheWatchRemovingStaleSourcesError(t *testing.T) {
 		},
 		&ocv1.ClusterExtension{},
 		time.Second,
+		testRESTMapper,
 	)
 
-	podGvk := corev1.SchemeGroupVersion.WithKind("Pod")
-	require.NoError(t, c.(*cache).addSource(podGvk, &mockSource{
+	podSourceKey := sourceKey{
+		namespace: rand.String(8),
+		gvk:       corev1.SchemeGroupVersion.WithKind("Pod"),
+	}
+	require.NoError(t, c.(*cache).addSource(podSourceKey, &mockSource{
 		err: errors.New("error"),
 	}))
 
 	secret := &corev1.Secret{}
-	secretGvk := corev1.SchemeGroupVersion.WithKind("Secret")
-	secret.SetGroupVersionKind(secretGvk)
+	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+	secret.SetNamespace(rand.String(8))
 	require.Error(t, c.Watch(context.Background(), &mockWatcher{}, secret))
 }

--- a/internal/operator-controller/contentmanager/contentmanager.go
+++ b/internal/operator-controller/contentmanager/contentmanager.go
@@ -116,14 +116,14 @@ func (i *managerImpl) Get(ctx context.Context, ce *ocv1.ClusterExtension) (cmcac
 		// related to reusing an informer factory, we return a new informer
 		// factory every time to ensure we are not attempting to configure or
 		// start an already started informer
-		informerFactoryCreateFunc: func() dynamicinformer.DynamicSharedInformerFactory {
-			return dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Hour*10, metav1.NamespaceAll, func(lo *metav1.ListOptions) {
+		informerFactoryCreateFunc: func(namespace string) dynamicinformer.DynamicSharedInformerFactory {
+			return dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, time.Hour*10, namespace, func(lo *metav1.ListOptions) {
 				lo.LabelSelector = tgtLabels.AsSelector().String()
 			})
 		},
 		mapper: i.mapper,
 	}
-	cache = cmcache.NewCache(dynamicSourcerer, ce, i.syncTimeout)
+	cache = cmcache.NewCache(dynamicSourcerer, ce, i.syncTimeout, i.mapper)
 	i.caches[ce.Name] = cache
 	return cache, nil
 }

--- a/internal/operator-controller/contentmanager/sourcerer.go
+++ b/internal/operator-controller/contentmanager/sourcerer.go
@@ -21,11 +21,11 @@ import (
 )
 
 type dynamicSourcerer struct {
-	informerFactoryCreateFunc func() dynamicinformer.DynamicSharedInformerFactory
+	informerFactoryCreateFunc func(namespace string) dynamicinformer.DynamicSharedInformerFactory
 	mapper                    meta.RESTMapper
 }
 
-func (ds *dynamicSourcerer) Source(gvk schema.GroupVersionKind, owner client.Object, onPostSyncError func(context.Context)) (cache.CloserSyncingSource, error) {
+func (ds *dynamicSourcerer) Source(namespace string, gvk schema.GroupVersionKind, owner client.Object, onPostSyncError func(context.Context)) (cache.CloserSyncingSource, error) {
 	scheme, err := buildScheme(gvk)
 	if err != nil {
 		return nil, fmt.Errorf("building scheme: %w", err)
@@ -48,7 +48,7 @@ func (ds *dynamicSourcerer) Source(gvk schema.GroupVersionKind, owner client.Obj
 				GenericFunc: func(tge event.TypedGenericEvent[client.Object]) bool { return true },
 			},
 		},
-		DynamicInformerFactory: ds.informerFactoryCreateFunc(),
+		DynamicInformerFactory: ds.informerFactoryCreateFunc(namespace),
 		OnPostSyncError:        onPostSyncError,
 	})
 	return s, nil


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This PR changes operator-controller's contentmanager, which is used to establish watches for objects it is lifecycling, so that it uses namespace-scoped informers for namespace-scoped watches. Prior to this PR, contentmanager is using a cluster-scoped watch for all resources, regardless of their scoping.

This is beneficial because it means that the installer user can change its current cluster-wide list/watch permissions into namespace-scoped permissions for each resource in their extension's manifest.

It should be noted that the content manager manages a separate set of informers for each cluster extension due to the use of the cluster extension's service account. So switching from cluster-scoped informers to namespace-scoped informers, in most cases, will not increase the total number of informers that operator-controller has running at a given time. The only scenario where the number of informers increases is if the manifest for a particular cluster extension contains namespace-scoped resources in multiple namespaces.

On main, the number of informers for a cluster extension is: `<number of unique resource types>`
After this PR merges, the number of informers for a cluster extension is: `<number of unique resource type/namespace pairs>`.

In almost all cases, these numbers will be the same because extensions almost always install cluster-scoped objects and namespace-scoped objects in a single namespace.

The only case that this _would_ be an issue is if we supported MultiNamespace install mode because that would cause roles and role bindings to be included in the manifest for all of the watched namespaces. We do no support that install mode, and we do not plan to support that install mode, essentially for this exact reason.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
