### PR TITLE
:sparkles: Add registry+v1 bundle validation framework

### DIFF
--- a/internal/operator-controller/rukpak/convert/validator.go
+++ b/internal/operator-controller/rukpak/convert/validator.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -9,23 +10,21 @@ import (
 
 type BundleValidator []func(v1 *RegistryV1) []error
 
-func (v BundleValidator) Validate(rv1 *RegistryV1) []error {
+func (v BundleValidator) Validate(rv1 *RegistryV1) error {
 	var errs []error
 	for _, validator := range v {
 		errs = append(errs, validator(rv1)...)
 	}
-	return errs
+	return errors.Join(errs...)
 }
 
-func NewBundleValidator() BundleValidator {
+var RegistryV1BundleValidator = BundleValidator{
 	// NOTE: if you update this list, Test_BundleValidatorHasAllValidationFns will fail until
 	// you bring the same changes over to that test. This helps ensure all validation rules are executed
 	// while giving us the flexibility to test each validation function individually
-	return BundleValidator{
-		CheckDeploymentSpecUniqueness,
-		CheckCRDResourceUniqueness,
-		CheckOwnedCRDExistence,
-	}
+	CheckDeploymentSpecUniqueness,
+	CheckCRDResourceUniqueness,
+	CheckOwnedCRDExistence,
 }
 
 // CheckDeploymentSpecUniqueness checks that each strategy deployment spec in the csv has a unique name.

--- a/internal/operator-controller/rukpak/convert/validator.go
+++ b/internal/operator-controller/rukpak/convert/validator.go
@@ -1,0 +1,90 @@
+package convert
+
+import (
+	"fmt"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type BundleValidator []func(v1 *RegistryV1) []error
+
+func (v BundleValidator) Validate(rv1 *RegistryV1) []error {
+	var errs []error
+	for _, validator := range v {
+		errs = append(errs, validator(rv1)...)
+	}
+	return errs
+}
+
+func NewBundleValidator() BundleValidator {
+	// NOTE: if you update this list, Test_BundleValidatorHasAllValidationFns will fail until
+	// you bring the same changes over to that test. This helps ensure all validation rules are executed
+	// while giving us the flexibility to test each validation function individually
+	return BundleValidator{
+		CheckDeploymentSpecUniqueness,
+		CheckCRDResourceUniqueness,
+		CheckOwnedCRDExistence,
+	}
+}
+
+// CheckDeploymentSpecUniqueness checks that each strategy deployment spec in the csv has a unique name.
+// Errors are sorted by deployment name.
+func CheckDeploymentSpecUniqueness(rv1 *RegistryV1) []error {
+	deploymentNameSet := sets.Set[string]{}
+	duplicateDeploymentNames := sets.Set[string]{}
+	for _, dep := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		if deploymentNameSet.Has(dep.Name) {
+			duplicateDeploymentNames.Insert(dep.Name)
+		}
+		deploymentNameSet.Insert(dep.Name)
+	}
+
+	//nolint:prealloc
+	var errs []error
+	for _, d := range slices.Sorted(slices.Values(duplicateDeploymentNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("cluster service version contains duplicate strategy deployment spec '%s'", d))
+	}
+	return errs
+}
+
+// CheckOwnedCRDExistence checks bundle owned custom resource definitions declared in the csv exist in the bundle
+func CheckOwnedCRDExistence(rv1 *RegistryV1) []error {
+	crdsNames := sets.Set[string]{}
+	for _, crd := range rv1.CRDs {
+		crdsNames.Insert(crd.Name)
+	}
+
+	//nolint:prealloc
+	var errs []error
+	missingCRDNames := sets.Set[string]{}
+	for _, crd := range rv1.CSV.Spec.CustomResourceDefinitions.Owned {
+		if !crdsNames.Has(crd.Name) {
+			missingCRDNames.Insert(crd.Name)
+		}
+	}
+
+	for _, crdName := range slices.Sorted(slices.Values(missingCRDNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("cluster service definition references owned custom resource definition '%s' not found in bundle", crdName))
+	}
+	return errs
+}
+
+// CheckCRDResourceUniqueness checks that the bundle CRD names are unique
+func CheckCRDResourceUniqueness(rv1 *RegistryV1) []error {
+	crdsNames := sets.Set[string]{}
+	duplicateCRDNames := sets.Set[string]{}
+	for _, crd := range rv1.CRDs {
+		if crdsNames.Has(crd.Name) {
+			duplicateCRDNames.Insert(crd.Name)
+		}
+		crdsNames.Insert(crd.Name)
+	}
+
+	//nolint:prealloc
+	var errs []error
+	for _, crdName := range slices.Sorted(slices.Values(duplicateCRDNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("bundle contains duplicate custom resource definition '%s'", crdName))
+	}
+	return errs
+}

--- a/internal/operator-controller/rukpak/convert/validator_test.go
+++ b/internal/operator-controller/rukpak/convert/validator_test.go
@@ -1,0 +1,224 @@
+package convert_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/convert"
+)
+
+func Test_BundleValidatorHasAllValidationFns(t *testing.T) {
+	expectedValidationFns := []func(v1 *convert.RegistryV1) []error{
+		convert.CheckDeploymentSpecUniqueness,
+		convert.CheckCRDResourceUniqueness,
+		convert.CheckOwnedCRDExistence,
+	}
+	actualValidationFns := convert.NewBundleValidator()
+
+	require.Equal(t, len(expectedValidationFns), len(actualValidationFns))
+	for i := range expectedValidationFns {
+		require.Equal(t, reflect.ValueOf(expectedValidationFns[i]).Pointer(), reflect.ValueOf(actualValidationFns[i]).Pointer(), "bundle validator has unexpected validation function")
+	}
+}
+
+func Test_BundleValidatorCallsAllValidationFnsInOrder(t *testing.T) {
+	actual := ""
+	validator := convert.BundleValidator{
+		func(v1 *convert.RegistryV1) []error {
+			actual += "h"
+			return nil
+		},
+		func(v1 *convert.RegistryV1) []error {
+			actual += "i"
+			return nil
+		},
+	}
+	require.Empty(t, validator.Validate(nil))
+	require.Equal(t, "hi", actual)
+}
+
+func Test_CheckDeploymentSpecUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *convert.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with unique deployment strategy spec names",
+			bundle: &convert.RegistryV1{
+				CSV: MakeCSV(
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+					),
+				),
+			},
+		}, {
+			name: "rejects bundles with duplicate deployment strategy spec names",
+			bundle: &convert.RegistryV1{
+				CSV: MakeCSV(
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					),
+				),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-one'"),
+			},
+		}, {
+			name: "errors are ordered by deployment strategy spec name",
+			bundle: &convert.RegistryV1{
+				CSV: MakeCSV(
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-a"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-b"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-c"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-b"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-a"},
+					),
+				),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-a'"),
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-b'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := convert.CheckDeploymentSpecUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_CRDResourceUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *convert.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with unique custom resource definition resources",
+			bundle: &convert.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b.crd.something"}},
+				},
+			},
+		}, {
+			name: "rejects bundles with duplicate custom resource definition resources",
+			bundle: &convert.RegistryV1{CRDs: []apiextensionsv1.CustomResourceDefinition{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+			}},
+			expectedErrs: []error{
+				errors.New("bundle contains duplicate custom resource definition 'a.crd.something'"),
+			},
+		}, {
+			name: "errors are ordered by custom resource definition name",
+			bundle: &convert.RegistryV1{CRDs: []apiextensionsv1.CustomResourceDefinition{
+				{ObjectMeta: metav1.ObjectMeta{Name: "c.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "c.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+			}},
+			expectedErrs: []error{
+				errors.New("bundle contains duplicate custom resource definition 'a.crd.something'"),
+				errors.New("bundle contains duplicate custom resource definition 'c.crd.something'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := convert.CheckCRDResourceUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, err)
+		})
+	}
+}
+
+func Test_CheckOwnedCRDExistence(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *convert.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with existing owned custom resource definition resources",
+			bundle: &convert.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b.crd.something"}},
+				},
+				CSV: MakeCSV(
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "a.crd.something"},
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					),
+				),
+			},
+		}, {
+			name: "rejects bundles with missing owned custom resource definition resources",
+			bundle: &convert.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{},
+				CSV: MakeCSV(
+					WithOwnedCRDs(v1alpha1.CRDDescription{Name: "a.crd.something"}),
+				),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service definition references owned custom resource definition 'a.crd.something' not found in bundle"),
+			},
+		}, {
+			name: "errors are ordered by owned custom resource definition name",
+			bundle: &convert.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{},
+				CSV: MakeCSV(
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "a.crd.something"},
+						v1alpha1.CRDDescription{Name: "c.crd.something"},
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					),
+				),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service definition references owned custom resource definition 'a.crd.something' not found in bundle"),
+				errors.New("cluster service definition references owned custom resource definition 'b.crd.something' not found in bundle"),
+				errors.New("cluster service definition references owned custom resource definition 'c.crd.something' not found in bundle"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := convert.CheckOwnedCRDExistence(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+type CSVOption func(version *v1alpha1.ClusterServiceVersion)
+
+func WithStrategyDeploymentSpecs(strategyDeploymentSpecs ...v1alpha1.StrategyDeploymentSpec) CSVOption {
+	return func(csv *v1alpha1.ClusterServiceVersion) {
+		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs = strategyDeploymentSpecs
+	}
+}
+
+func WithOwnedCRDs(crdDesc ...v1alpha1.CRDDescription) CSVOption {
+	return func(csv *v1alpha1.ClusterServiceVersion) {
+		csv.Spec.CustomResourceDefinitions.Owned = crdDesc
+	}
+}
+
+func MakeCSV(opts ...CSVOption) v1alpha1.ClusterServiceVersion {
+	csv := v1alpha1.ClusterServiceVersion{}
+	for _, opt := range opts {
+		opt(&csv)
+	}
+	return csv
+}

--- a/test/convert/generate-manifests.go
+++ b/test/convert/generate-manifests.go
@@ -67,7 +67,7 @@ func generateManifests(outputPath, bundleDir, installNamespace, watchNamespace s
 	}
 
 	// Convert RegistryV1 to plain manifests
-	plain, err := convert.Convert(regv1, installNamespace, []string{watchNamespace})
+	plain, err := convert.PlainConverter.Convert(regv1, installNamespace, []string{watchNamespace})
 	if err != nil {
 		return fmt.Errorf("error converting registry+v1 bundle: %w", err)
 	}


### PR DESCRIPTION
# Description

Closes #1883  #1884

Adds a small registry+v1 bundle validation framework composed of individual validation functions. It is extensible by adding new validation functions. Note that the validation framework is _not_ currently used. This will happen in a follow up PR because some refactoring will be needed of the convert/rukpak package and I didn't want to bloat the PR.


## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
