### PR TITLE
:bug: Fix bundle to plain manifest conversion

### DIFF
--- a/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/02_clusterrole_argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p.yaml
+++ b/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/02_clusterrole_argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: argocd-operator.v0-22gmilmgp91wu25is5i2ec598hni8owq3l71bbkl7iz3
+  name: argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p
 rules:
 - apiGroups:
   - ""
@@ -35,3 +35,11 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/04_clusterrolebinding_argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p.yaml
+++ b/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/04_clusterrolebinding_argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: argocd-operator.v0-22gmilmgp91wu25is5i2ec598hni8owq3l71bbkl7iz3
+  name: argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: argocd-operator.v0-22gmilmgp91wu25is5i2ec598hni8owq3l71bbkl7iz3
+  name: argocd-operator.v0.-3gkm3u8zfarktdile5wekso69zs9bgzb988mhjm0y6p
 subjects:
 - kind: ServiceAccount
   name: argocd-operator-controller-manager

--- a/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/11_deployment_argocd-operator-controller-manager.yaml
+++ b/test/convert/expected-manifests/argocd-operator.v0.6.0/all-namespaces/11_deployment_argocd-operator-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: argocd-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/test/convert/expected-manifests/argocd-operator.v0.6.0/own-namespace/09_deployment_argocd-operator-controller-manager.yaml
+++ b/test/convert/expected-manifests/argocd-operator.v0.6.0/own-namespace/09_deployment_argocd-operator-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: argocd-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/test/convert/expected-manifests/argocd-operator.v0.6.0/single-namespace/09_deployment_argocd-operator-controller-manager.yaml
+++ b/test/convert/expected-manifests/argocd-operator.v0.6.0/single-namespace/09_deployment_argocd-operator-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: argocd-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
# Description

* Adds `dep.Spec.RevisionHistoryLimit = 1` to generated Deployment manifests to maintain OLMv0 compatibility [[link](https://github.com/operator-framework/operator-lifecycle-manager/blob/dfd0b2bea85038d3c0d65348bc812d297f16b8d2/pkg/controller/install/deployment.go#L181)]
* Fixes permissions in AllNamespaces mode. The namespace rules were not being added to the final set of rules.

Updates generated bundle resources to reflect these changes

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
