### PR TITLE
:sparkles: Add package name validation function

### DIFF
--- a/internal/operator-controller/applier/helm_test.go
+++ b/internal/operator-controller/applier/helm_test.go
@@ -101,7 +101,8 @@ func (mag *mockActionGetter) Reconcile(rel *release.Release) error {
 var (
 	// required for unmockable call to convert.RegistryV1ToHelmChart
 	validFS = fstest.MapFS{
-		"metadata/annotations.yaml": &fstest.MapFile{Data: []byte("{}")},
+		"metadata/annotations.yaml": &fstest.MapFile{Data: []byte(`annotations:
+  operators.operatorframework.io.bundle.package.v1: my-package`)},
 		"manifests": &fstest.MapFile{Data: []byte(`apiVersion: operators.operatorframework.io/v1alpha1
 kind: ClusterServiceVersion
 metadata:


### PR DESCRIPTION
# Description

Adds a bundle validation check against the package name to ensure it is defined in the RegistryV1 bundle structure. And does some tidying adding array pre-allocations

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
