### PR TITLE
:seedling: Update certpoolwatcher log levels

### DIFF
--- a/internal/shared/util/http/certlog.go
+++ b/internal/shared/util/http/certlog.go
@@ -34,7 +34,7 @@ func LogDockerCertificates(path string, log logr.Logger) {
 			continue
 		}
 		if !fi.IsDir() {
-			log.V(defaultLogLevel+1).Info("not a directory", "directory", path)
+			log.V(defaultLogLevel).Info("not a directory", "directory", path)
 			continue
 		}
 		dirEntries, err := os.ReadDir(path)
@@ -50,7 +50,7 @@ func LogDockerCertificates(path string, log logr.Logger) {
 				continue
 			}
 			if !fi.IsDir() {
-				log.V(defaultLogLevel+1).Info("ignoring non-directory", "path", hostPath)
+				log.V(defaultLogLevel).Info("ignoring non-directory", "path", hostPath)
 				continue
 			}
 			logPath(hostPath, "dump docker certs", log)
@@ -103,7 +103,7 @@ func logPath(path, action string, log logr.Logger) {
 			continue
 		}
 		if fi.IsDir() {
-			log.V(defaultLogLevel+1).Info("ignoring subdirectory", "directory", file)
+			log.V(defaultLogLevel).Info("ignoring subdirectory", "directory", file)
 			continue
 		}
 		logFile(e.Name(), path, action, log)

--- a/internal/shared/util/http/certutil.go
+++ b/internal/shared/util/http/certutil.go
@@ -32,10 +32,10 @@ func NewCertPool(caDir string, log logr.Logger) (*x509.CertPool, error) {
 			return nil, err
 		}
 		if fi.IsDir() {
-			log.V(defaultLogLevel+1).Info("skip directory", "name", e.Name())
+			log.V(defaultLogLevel).Info("skip directory", "name", e.Name())
 			continue
 		}
-		log.V(defaultLogLevel+1).Info("load certificate", "name", e.Name())
+		log.V(defaultLogLevel).Info("load certificate", "name", e.Name(), "size", fi.Size(), "modtime", fi.ModTime())
 		data, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("error reading cert file %q: %w", file, err)


### PR DESCRIPTION
Some log levels were defaultLogLevel+1 (5), change those to defaultLogLevel (4)

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
