### PR TITLE
:seedling: Make target namespaces optional

### DIFF
--- a/internal/operator-controller/rukpak/convert/registryv1.go
+++ b/internal/operator-controller/rukpak/convert/registryv1.go
@@ -261,7 +261,7 @@ func (c Converter) Convert(rv1 render.RegistryV1, installNamespace string, targe
 		return nil, fmt.Errorf("webhookDefinitions are not supported")
 	}
 
-	objs, err := c.BundleRenderer.Render(rv1, installNamespace, targetNamespaces)
+	objs, err := c.BundleRenderer.Render(rv1, installNamespace, render.WithTargetNamespaces(targetNamespaces...))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

This PR updates the BundleRenderer's Render method signature by removing the targetNamespaces parameter as a required parameter in favor of making it an option. It also adds additional unit tests around options and fixes an NPE caused by passing nil as the options parameter.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
