### PR TITLE
:bug: Ease CI requirements for go-verdiff and codecov

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -1,9 +1,6 @@
 name: go-verdiff
 on:
   pull_request:
-    paths:
-    - '**.mod'
-    - '.github/workflows/go-verdiff.yaml'
     branches:
     - main
 jobs:

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,11 @@ codecov:
 # Configure the paths to include in coverage reports.
 # Exclude documentation, YAML configurations, and test files.
 coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
   paths:
     - "api/"
     - "cmd/"


### PR DESCRIPTION
1) Remove path from now-required go-verdiff CI

We're experiencing a weird behavior with this CI being required, and running only on certain paths.

2) Add a 2% threshold for codecov


<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
