### PR TITLE
:sparkles: (hack) Add auto rbac generation with approval

### DIFF
--- a/api/v1/clustercatalog_types.go
+++ b/api/v1/clustercatalog_types.go
@@ -36,7 +36,9 @@ const (
 	AvailabilityModeUnavailable AvailabilityMode = "Unavailable"
 
 	// Condition types
-	TypeServing = "Serving"
+	TypeServing                       = "Serving"
+	TypeArbackulationApprovalRequired = "ArbackulationApprovalRequired"
+	TypeArbackulationApprovalGranted  = "ArbackulationApprovalGranted"
 
 	// Serving Reasons
 	ReasonAvailable                = "Available"

--- a/api/v1/clusterextension_types.go
+++ b/api/v1/clusterextension_types.go
@@ -25,6 +25,8 @@ var ClusterExtensionKind = "ClusterExtension"
 type (
 	UpgradeConstraintPolicy     string
 	CRDUpgradeSafetyEnforcement string
+
+	DeploymentApprovalPolicy string
 )
 
 const (
@@ -39,6 +41,9 @@ const (
 	// Use with caution as this can lead to unknown and potentially
 	// disastrous results such as data loss.
 	UpgradeConstraintPolicySelfCertified UpgradeConstraintPolicy = "SelfCertified"
+
+	DeploymentApprovalPolicyAutomatic DeploymentApprovalPolicy = "Automatic"
+	DeploymentApprovalPolicyManual    DeploymentApprovalPolicy = "Manual"
 )
 
 // ClusterExtensionSpec defines the desired state of ClusterExtension
@@ -92,6 +97,13 @@ type ClusterExtensionSpec struct {
 	//
 	// +optional
 	Install *ClusterExtensionInstallConfig `json:"install,omitempty"`
+
+	// how to handle operator lifecycle rbac requirements
+	// Automatic: assign necessary rbac to service account
+	// Manual:
+	// +kubebuilder:default:=Manual
+	// +optional
+	DeploymentApprovalPolicy DeploymentApprovalPolicy `json:"deploymentApprovalPolicy,omitempty"`
 }
 
 const SourceTypeCatalog = "Catalog"

--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -21,9 +21,10 @@ const (
 	TypeProgressing = "Progressing"
 
 	// Progressing reasons
-	ReasonSucceeded = "Succeeded"
-	ReasonRetrying  = "Retrying"
-	ReasonBlocked   = "Blocked"
+	ReasonSucceeded                     = "Succeeded"
+	ReasonRetrying                      = "Retrying"
+	ReasonBlocked                       = "Blocked"
+	ReasonArbackulationApprovalRequired = "ArbackulationApprovalRequired"
 
 	// Terminal reasons
 	ReasonDeprecated = "Deprecated"

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -424,6 +424,9 @@ func run() error {
 		Preflights:          preflights,
 		BundleToHelmChartFn: convert.RegistryV1ToHelmChart,
 		PreAuthorizer:       preAuth,
+		Arbackulator: &applier.Arbackulator{
+			Client: cl,
+		},
 	}
 
 	cm := contentmanager.NewManager(clientRestConfigMapper, mgr.GetConfig(), mgr.GetRESTMapper())

--- a/config/base/operator-controller/crd/bases/olm.operatorframework.io_clusterextensions.yaml
+++ b/config/base/operator-controller/crd/bases/olm.operatorframework.io_clusterextensions.yaml
@@ -56,6 +56,13 @@ spec:
             description: spec is an optional field that defines the desired state
               of the ClusterExtension.
             properties:
+              deploymentApprovalPolicy:
+                default: Manual
+                description: |-
+                  how to handle operator lifecycle rbac requirements
+                  Automatic: assign necessary rbac to service account
+                  Manual:
+                type: string
               install:
                 description: |-
                   install is an optional field used to configure the installation options

--- a/config/base/operator-controller/rbac/role.yaml
+++ b/config/base/operator-controller/rbac/role.yaml
@@ -11,6 +11,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/internal/operator-controller/applier/rbacker.go
+++ b/internal/operator-controller/applier/rbacker.go
@@ -1,0 +1,126 @@
+package applier
+
+import (
+	"context"
+	"fmt"
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type Arbackulator struct {
+	Client client.Client
+}
+
+func (t *Arbackulator) GrantPassage(ctx context.Context, cExt *ocv1.ClusterExtension, perms []authorization.ScopedPolicyRules) error {
+	permMap := map[string][]rbacv1.PolicyRule{}
+	for _, perm := range perms {
+		permMap[perm.Namespace] = append(permMap[perm.Namespace], perm.MissingRules...)
+	}
+
+	for ns, rules := range permMap {
+		switch ns {
+		case "":
+			if err := t.updateClusterPerms(ctx, cExt, rules); err != nil {
+				return err
+			}
+		default:
+			if err := t.updateNamespacedPerms(ctx, cExt, ns, rules); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *Arbackulator) updateClusterPerms(ctx context.Context, cExt *ocv1.ClusterExtension, rules []rbacv1.PolicyRule) error {
+	clusterRoleName := fmt.Sprintf("%s-mananaged-cluster-role", cExt.Name)
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleName,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, t.Client, role, func() error {
+		role.Rules = append(role.Rules, rules...)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	clusterRoleBindingName := fmt.Sprintf("%s-mananaged-cluster-rolebinding", cExt.Name)
+	roleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      cExt.Spec.ServiceAccount.Name,
+				Namespace: cExt.Spec.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, t.Client, roleBinding, func() error {
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Arbackulator) updateNamespacedPerms(ctx context.Context, cExt *ocv1.ClusterExtension, namespace string, rules []rbacv1.PolicyRule) error {
+	roleName := fmt.Sprintf("%s-mananaged-role", cExt.Name)
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: namespace,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, t.Client, role, func() error {
+		role.Rules = append(role.Rules, rules...)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	roleBindingName := fmt.Sprintf("%s-mananaged-rolebinding", cExt.Name)
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      cExt.Spec.ServiceAccount.Name,
+				Namespace: cExt.Spec.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, t.Client, roleBinding, func() error {
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

Another hack for fun:
 - must have PreflightPermissions enabled
 - add approval request condition if service account does not have needed perms
 - when approval condition is added, olm will give rbac to service account
 - installation completes

[![asciicast](https://asciinema.org/a/ypekqOssPkzK233Off3d7Y272.svg)](https://asciinema.org/a/ypekqOssPkzK233Off3d7Y272)

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
