### PR TITLE
:seedling: Allow override of go-verdiff result via label

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -11,4 +11,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check golang version
-      run: hack/tools/check-go-version.sh "${{ github.event.pull_request.base.sha }}"
+      run: |
+        export LABELS="$(gh api repos/$OWNER/$REPO/pulls/$PR --jq '.labels.[].name')"
+        hack/tools/check-go-version.sh -b "${{ github.event.pull_request.base.sha }}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+        PR: ${{ github.event.pull_request.number }}

--- a/hack/tools/check-go-version.sh
+++ b/hack/tools/check-go-version.sh
@@ -1,7 +1,39 @@
 #!/bin/bash
 
-BASE_REF=${1:-main}
-GO_VER=$(sed -En 's/^go (.*)$/\1/p' "go.mod")
+U_FLAG='false'
+B_FLAG=''
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 [-b <git-ref>] [-h] [-u]
+
+Reports on golang mod file version updates, returns an error when a go.mod
+file exceeds the root go.mod file (used as a threshold).
+
+Options:
+  -b <git-ref>  git reference (branch or SHA) to use as a baseline.
+                Defaults to 'main'.
+  -h            Help (this text).
+  -u            Error on any update, even below the threshold.
+EOF
+}
+
+while getopts 'b:hu' f; do
+    case "${f}" in
+        b) B_FLAG="${OPTARG}" ;;
+        h) usage
+           exit 0 ;;
+        u) U_FLAG='true' ;;
+        *) echo "Unknown flag ${f}"
+           usage
+           exit 1 ;;
+    esac
+done
+
+BASE_REF=${B_FLAG:-main}
+ROOT_GO_MOD="./go.mod"
+GO_VER=$(sed -En 's/^go (.*)$/\1/p' "${ROOT_GO_MOD}")
 OLDIFS="${IFS}"
 IFS='.' MAX_VER=(${GO_VER})
 IFS="${OLDIFS}"
@@ -14,6 +46,7 @@ fi
 GO_MAJOR=${MAX_VER[0]}
 GO_MINOR=${MAX_VER[1]}
 GO_PATCH=${MAX_VER[2]}
+OVERRIDE_LABEL="override-go-verdiff"
 
 RETCODE=0
 
@@ -72,9 +105,32 @@ for f in $(find . -name "*.mod"); do
         continue
     fi
     if [ "${new}" != "${old}" ]; then
-        echo "${f}: ${v}: Updated golang version from ${old}"
-        RETCODE=1
+        # We NEED to report on changes in the root go.mod, regardless of the U_FLAG
+        if [ "${f}" == "${ROOT_GO_MOD}" ]; then
+            echo "${f}: ${v}: Updated ROOT golang version from ${old}"
+            RETCODE=1
+            continue
+        fi
+        if ${U_FLAG}; then
+            echo "${f}: ${v}: Updated golang version from ${old}"
+            RETCODE=1
+        fi
     fi
 done
+
+for l in ${LABELS}; do
+    if [ "$l" == "${OVERRIDE_LABEL}" ]; then
+        if [ ${RETCODE} -eq 1 ]; then
+            echo ""
+            echo "Found ${OVERRIDE_LABEL} label, overriding failed results."
+            RETCODE=0
+        fi
+    fi
+done
+
+if [ ${RETCODE} -eq 1 ]; then
+    echo ""
+    echo "This test result may be overridden by applying the (${OVERRIDE_LABEL}) label to this PR and re-running the CI job."
+fi
 
 exit ${RETCODE}


### PR DESCRIPTION
Rather than disabling the go-verdiff CI to allow it to pass when there is a legitimate golang version change, use a label to override the test results.

The label is `(override-go-verdiff)`.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
