### PR TITLE
:sparkles: Update releaser to use env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,10 @@ coverage
 cover.out
 
 # Release output
-dist/**
-operator-controller.yaml
-install.sh
-catalogd.yaml
+/dist/**
+/operator-controller.yaml
+/default-catalogs.yaml
+/install.sh
 
 # vendored files
 vendor/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,9 +124,9 @@ release:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
   mode: replace
   extra_files:
-    - glob: 'operator-controller.yaml'
-    - glob: './config/catalogs/clustercatalogs/default-catalogs.yaml'
-    - glob: 'install.sh'
+    - glob: '{{ .Env.RELEASE_MANIFEST }}'
+    - glob: '{{ .Env.RELEASE_INSTALL }}'
+    - glob: '{{ .Env.RELEASE_CATALOGS }}'
   header: |
     ## Installation
 


### PR DESCRIPTION
In anticipation of config changes.
Use environment variables for the release values.
Update the Makefile to use the same variables.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
