### PR TITLE
🐛 fix: don't template registry+v1 manifests

### DIFF
--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -377,6 +377,12 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 					assert.NotEmpty(ct, clusterExtension.Status.Install.Bundle)
 				}
 			}, pollDuration, pollInterval)
+
+			t.Log("By verifying that no templating occurs for registry+v1 bundle manifests")
+			cm := corev1.ConfigMap{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: ns.Name, Name: "test-configmap"}, &cm))
+			require.Contains(t, cm.Annotations, "shouldNotTemplate")
+			require.Contains(t, cm.Annotations["shouldNotTemplate"], "{{ $labels.namespace }}")
 		})
 	}
 }

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-configmap
+  annotations:
+    shouldNotTemplate: >
+      The namespace is {{ $labels.namespace }}. The templated
+      $labels.namespace is NOT expected to be processed by OLM's
+      rendering engine for registry+v1 bundles.
 data:
   version: "v1.0.0"
   name: "test-configmap"


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Some registry+v1 manifests may actually contain Go Template strings that are meant to survive and actually persist into etcd (e.g. to be used as a templated configuration for another component). In order to avoid applying templating logic to registry+v1's static manifests, we create the manifests as Files, and then template those files via simple Templates.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
