### PR TITLE
:warning: OPRUN-3954: Update CRD generator to support experimental CRDs

### DIFF
--- a/api/v1/clustercatalog_types_test.go
+++ b/api/v1/clustercatalog_types_test.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const crdFilePath = "../../config/base/catalogd/crd/bases/olm.operatorframework.io_clustercatalogs.yaml"
+const crdFilePath = "../../config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml"
 
 func TestImageSourceCELValidationRules(t *testing.T) {
 	validators := fieldValidatorsFromFile(t, crdFilePath)

--- a/config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml
@@ -1,0 +1,442 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: experimental
+  name: clustercatalogs.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterCatalog
+    listKind: ClusterCatalogList
+    plural: clustercatalogs
+    singular: clustercatalog
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastUnpacked
+      name: LastUnpacked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Serving")].status
+      name: Serving
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
+          For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              spec is the desired state of the ClusterCatalog.
+              spec is required.
+              The controller will work to ensure that the desired
+              catalog is unpacked and served over the catalog content HTTP server.
+            properties:
+              availabilityMode:
+                default: Available
+                description: |-
+                  availabilityMode allows users to define how the ClusterCatalog is made available to clients on the cluster.
+                  availabilityMode is optional.
+
+                  Allowed values are "Available" and "Unavailable" and omitted.
+
+                  When omitted, the default value is "Available".
+
+                  When set to "Available", the catalog contents will be unpacked and served over the catalog content HTTP server.
+                  Setting the availabilityMode to "Available" tells clients that they should consider this ClusterCatalog
+                  and its contents as usable.
+
+                  When set to "Unavailable", the catalog contents will no longer be served over the catalog content HTTP server.
+                  When set to this availabilityMode it should be interpreted the same as the ClusterCatalog not existing.
+                  Setting the availabilityMode to "Unavailable" can be useful in scenarios where a user may not want
+                  to delete the ClusterCatalog all together, but would still like it to be treated as if it doesn't exist.
+                enum:
+                - Unavailable
+                - Available
+                type: string
+              priority:
+                default: 0
+                description: |-
+                  priority allows the user to define a priority for a ClusterCatalog.
+                  priority is optional.
+
+                  A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+                  A higher number means higher priority.
+
+                  It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
+                  When deciding how to break the tie in this scenario, it is recommended that clients prompt their users for additional input.
+
+                  When omitted, the default priority is 0 because that is the zero value of integers.
+
+                  Negative numbers can be used to specify a priority lower than the default.
+                  Positive numbers can be used to specify a priority higher than the default.
+
+                  The lowest possible value is -2147483648.
+                  The highest possible value is 2147483647.
+                format: int32
+                type: integer
+              source:
+                description: |-
+                  source allows a user to define the source of a catalog.
+                  A "catalog" contains information on content that can be installed on a cluster.
+                  Providing a catalog source makes the contents of the catalog discoverable and usable by
+                  other on-cluster components.
+                  These on-cluster components may do a variety of things with this information, such as
+                  presenting the content in a GUI dashboard or installing content from the catalog on the cluster.
+                  The catalog source must contain catalog metadata in the File-Based Catalog (FBC) format.
+                  For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs.
+                  source is a required field.
+
+                  Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
+
+                   source:
+                     type: Image
+                     image:
+                       ref: quay.io/operatorhubio/catalog:latest
+                properties:
+                  image:
+                    description: |-
+                      image is used to configure how catalog contents are sourced from an OCI image.
+                      This field is required when type is Image, and forbidden otherwise.
+                    properties:
+                      pollIntervalMinutes:
+                        description: |-
+                          pollIntervalMinutes allows the user to set the interval, in minutes, at which the image source should be polled for new content.
+                          pollIntervalMinutes is optional.
+                          pollIntervalMinutes can not be specified when ref is a digest-based reference.
+
+                          When omitted, the image will not be polled for new content.
+                        minimum: 1
+                        type: integer
+                      ref:
+                        description: |-
+                          ref allows users to define the reference to a container image containing Catalog contents.
+                          ref is required.
+                          ref can not be more than 1000 characters.
+
+                          A reference can be broken down into 3 parts - the domain, name, and identifier.
+
+                          The domain is typically the registry where an image is located.
+                          It must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                          Hyphenation is allowed, but the domain must start and end with alphanumeric characters.
+                          Specifying a port to use is also allowed by adding the ":" character followed by numeric values.
+                          The port must be the last value in the domain.
+                          Some examples of valid domain values are "registry.mydomain.io", "quay.io", "my-registry.io:8080".
+
+                          The name is typically the repository in the registry where an image is located.
+                          It must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                          Multiple names can be concatenated with the "/" character.
+                          The domain and name are combined using the "/" character.
+                          Some examples of valid name values are "operatorhubio/catalog", "catalog", "my-catalog.prod".
+                          An example of the domain and name parts of a reference being combined is "quay.io/operatorhubio/catalog".
+
+                          The identifier is typically the tag or digest for an image reference and is present at the end of the reference.
+                          It starts with a separator character used to distinguish the end of the name and beginning of the identifier.
+                          For a digest-based reference, the "@" character is the separator.
+                          For a tag-based reference, the ":" character is the separator.
+                          An identifier is required in the reference.
+
+                          Digest-based references must contain an algorithm reference immediately after the "@" separator.
+                          The algorithm reference must be followed by the ":" character and an encoded string.
+                          The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                          Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
+                          The encoded string following the algorithm must be hex digits (a-f, A-F, 0-9) and must be a minimum of 32 characters.
+
+                          Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
+                          The tag must not be longer than 127 characters.
+
+                          An example of a valid digest-based image reference is "quay.io/operatorhubio/catalog@sha256:200d4ddb2a73594b91358fe6397424e975205bfbe44614f5846033cad64b3f05"
+                          An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
+                        maxLength: 1000
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must start with a valid domain. valid domains must
+                            be alphanumeric characters (lowercase and uppercase) separated
+                            by the "." character.
+                          rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                        - message: a valid name is required. valid names must contain
+                            lowercase alphanumeric characters separated only by the
+                            ".", "_", "__", "-" characters.
+                          rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                            != ""
+                        - message: must end with a digest or a tag
+                          rule: self.find('(@.*:)') != "" || self.find(':.*$') !=
+                            ""
+                        - message: tag is invalid. the tag must not be more than 127
+                            characters
+                          rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'')
+                            != "" ? self.find('':.*$'').substring(1).size() <= 127
+                            : true) : true'
+                        - message: tag is invalid. valid tags must begin with a word
+                            character (alphanumeric + "_") followed by word characters
+                            or ".", and "-" characters
+                          rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'')
+                            != "" ? self.find('':.*$'').matches('':[\\w][\\w.-]*$'')
+                            : true) : true'
+                        - message: digest algorithm is not valid. valid algorithms
+                            must start with an uppercase or lowercase alpha character
+                            followed by alphanumeric characters and may contain the
+                            "-", "_", "+", and "." characters.
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'')
+                            : true'
+                        - message: digest is not valid. the encoded string must be
+                            at least 32 characters
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size()
+                            >= 32 : true'
+                        - message: digest is not valid. the encoded string must only
+                            contain hex characters (A-F, a-f, 0-9)
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'')
+                            : true'
+                    required:
+                    - ref
+                    type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify pollIntervalMinutes while using digest-based
+                        image
+                      rule: 'self.ref.find(''(@.*:)'') != "" ? !has(self.pollIntervalMinutes)
+                        : true'
+                  type:
+                    description: |-
+                      type is a reference to the type of source the catalog is sourced from.
+                      type is required.
+
+                      The only allowed value is "Image".
+
+                      When set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+                      When using an image source, the image field must be set and must be the only field defined for this type.
+                    enum:
+                    - Image
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: image is required when source type is Image, and forbidden
+                    otherwise
+                  rule: 'has(self.type) && self.type == ''Image'' ? has(self.image)
+                    : !has(self.image)'
+            required:
+            - source
+            type: object
+          status:
+            description: |-
+              status contains information about the state of the ClusterCatalog such as:
+                - Whether or not the catalog contents are being served via the catalog content HTTP server
+                - Whether or not the ClusterCatalog is progressing to a new state
+                - A reference to the source from which the catalog contents were retrieved
+            properties:
+              conditions:
+                description: |-
+                  conditions is a representation of the current state for this ClusterCatalog.
+
+                  The current condition types are Serving and Progressing.
+
+                  The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
+                  When it has a status of True and a reason of Available, the contents of the catalog are being served.
+                  When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
+                  When it has a status of False and a reason of UserSpecifiedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
+
+                  The Progressing condition is used to represent whether or not the ClusterCatalog is progressing or is ready to progress towards a new state.
+                  When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
+                  When it has a status of True and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+                  When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
+
+                  In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
+                  catalog contents are still being served via the HTTP(S) web server while we are progressing towards serving a new version of the catalog
+                  contents. This could occur when we've initially fetched the latest contents from the source for this catalog and when polling for changes
+                  to the contents we identify that there are updates to the contents.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastUnpacked:
+                description: |-
+                  lastUnpacked represents the last time the contents of the
+                  catalog were extracted from their source format. As an example,
+                  when using an Image source, the OCI image will be pulled and the
+                  image layers written to a file-system backed cache. We refer to the
+                  act of this extraction from the source format as "unpacking".
+                format: date-time
+                type: string
+              resolvedSource:
+                description: resolvedSource contains information about the resolved
+                  source based on the source type.
+                properties:
+                  image:
+                    description: |-
+                      image is a field containing resolution information for a catalog sourced from an image.
+                      This field must be set when type is Image, and forbidden otherwise.
+                    properties:
+                      ref:
+                        description: |-
+                          ref contains the resolved image digest-based reference.
+                          The digest format is used so users can use other tooling to fetch the exact
+                          OCI manifests that were used to extract the catalog contents.
+                        maxLength: 1000
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must start with a valid domain. valid domains must
+                            be alphanumeric characters (lowercase and uppercase) separated
+                            by the "." character.
+                          rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                        - message: a valid name is required. valid names must contain
+                            lowercase alphanumeric characters separated only by the
+                            ".", "_", "__", "-" characters.
+                          rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                            != ""
+                        - message: must end with a digest
+                          rule: self.find('(@.*:)') != ""
+                        - message: digest algorithm is not valid. valid algorithms
+                            must start with an uppercase or lowercase alpha character
+                            followed by alphanumeric characters and may contain the
+                            "-", "_", "+", and "." characters.
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'')
+                            : true'
+                        - message: digest is not valid. the encoded string must be
+                            at least 32 characters
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size()
+                            >= 32 : true'
+                        - message: digest is not valid. the encoded string must only
+                            contain hex characters (A-F, a-f, 0-9)
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'')
+                            : true'
+                    required:
+                    - ref
+                    type: object
+                  type:
+                    description: |-
+                      type is a reference to the type of source the catalog is sourced from.
+                      type is required.
+
+                      The only allowed value is "Image".
+
+                      When set to "Image", information about the resolved image source will be set in the 'image' field.
+                    enum:
+                    - Image
+                    type: string
+                required:
+                - image
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: image is required when source type is Image, and forbidden
+                    otherwise
+                  rule: 'has(self.type) && self.type == ''Image'' ? has(self.image)
+                    : !has(self.image)'
+              urls:
+                description: urls contains the URLs that can be used to access the
+                  catalog.
+                properties:
+                  base:
+                    description: |-
+                      base is a cluster-internal URL that provides endpoints for
+                      accessing the content of the catalog.
+
+                      It is expected that clients append the path for the endpoint they wish
+                      to access.
+
+                      Currently, only a single endpoint is served and is accessible at the path
+                      /api/v1.
+
+                      The endpoints served for the v1 API are:
+                        - /all - this endpoint returns the entirety of the catalog contents in the FBC format
+
+                      As the needs of users and clients of the evolve, new endpoints may be added.
+                    maxLength: 525
+                    type: string
+                    x-kubernetes-validations:
+                    - message: must be a valid URL
+                      rule: isURL(self)
+                    - message: scheme must be either http or https
+                      rule: 'isURL(self) ? (url(self).getScheme() == "http" || url(self).getScheme()
+                        == "https") : true'
+                required:
+                - base
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/catalogd/crd/kustomization.yaml
+++ b/config/base/catalogd/crd/kustomization.yaml
@@ -2,5 +2,5 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/olm.operatorframework.io_clustercatalogs.yaml
+- standard/olm.operatorframework.io_clustercatalogs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: standard
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
+++ b/config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: experimental
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/base/operator-controller/crd/kustomization.yaml
+++ b/config/base/operator-controller/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/olm.operatorframework.io_clusterextensions.yaml
+- standard/olm.operatorframework.io_clusterextensions.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml
+++ b/config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml
@@ -1,0 +1,590 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: standard
+  name: clusterextensions.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterExtension
+    listKind: ClusterExtensionList
+    plural: clusterextensions
+    singular: clusterextension
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.install.bundle.name
+      name: Installed Bundle
+      type: string
+    - jsonPath: .status.install.bundle.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Installed')].status
+      name: Installed
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExtension is the Schema for the clusterextensions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is an optional field that defines the desired state
+              of the ClusterExtension.
+            properties:
+              install:
+                description: |-
+                  install is an optional field used to configure the installation options
+                  for the ClusterExtension such as the pre-flight check configuration.
+                properties:
+                  preflight:
+                    description: |-
+                      preflight is an optional field that can be used to configure the checks that are
+                      run before installation or upgrade of the content for the package specified in the packageName field.
+
+                      When specified, it replaces the default preflight configuration for install/upgrade actions.
+                      When not specified, the default configuration will be used.
+                    properties:
+                      crdUpgradeSafety:
+                        description: |-
+                          crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+                          checks that run prior to upgrades of installed content.
+
+                          The CRD Upgrade Safety pre-flight check safeguards from unintended
+                          consequences of upgrading a CRD, such as data loss.
+                        properties:
+                          enforcement:
+                            description: |-
+                              enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
+
+                              Allowed values are "None" or "Strict". The default value is "Strict".
+
+                              When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
+                              when performing an upgrade operation. This should be used with caution as
+                              unintended consequences such as data loss can occur.
+
+                              When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
+                              performing an upgrade operation.
+                            enum:
+                            - None
+                            - Strict
+                            type: string
+                        required:
+                        - enforcement
+                        type: object
+                    required:
+                    - crdUpgradeSafety
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of [crdUpgradeSafety] are required when
+                        preflight is specified
+                      rule: has(self.crdUpgradeSafety)
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of [preflight] are required when install is
+                    specified
+                  rule: has(self.preflight)
+              namespace:
+                description: |-
+                  namespace is a reference to a Kubernetes namespace.
+                  This is the namespace in which the provided ServiceAccount must exist.
+                  It also designates the default namespace where namespace-scoped resources
+                  for the extension are applied to the cluster.
+                  Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+                  This namespace must exist.
+
+                  namespace is required, immutable, and follows the DNS label standard
+                  as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                  start and end with an alphanumeric character, and be no longer than 63 characters
+
+                  [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                maxLength: 63
+                type: string
+                x-kubernetes-validations:
+                - message: namespace is immutable
+                  rule: self == oldSelf
+                - message: namespace must be a valid DNS1123 label
+                  rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+              serviceAccount:
+                description: |-
+                  serviceAccount is a reference to a ServiceAccount used to perform all interactions
+                  with the cluster that are required to manage the extension.
+                  The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+                  The ServiceAccount must exist in the namespace referenced in the spec.
+                  serviceAccount is required.
+                properties:
+                  name:
+                    description: |-
+                      name is a required, immutable reference to the name of the ServiceAccount
+                      to be used for installation and management of the content for the package
+                      specified in the packageName field.
+
+                      This ServiceAccount must exist in the installNamespace.
+
+                      name follows the DNS subdomain standard as defined in [RFC 1123].
+                      It must contain only lowercase alphanumeric characters,
+                      hyphens (-) or periods (.), start and end with an alphanumeric character,
+                      and be no longer than 253 characters.
+
+                      Some examples of valid values are:
+                        - some-serviceaccount
+                        - 123-serviceaccount
+                        - 1-serviceaccount-2
+                        - someserviceaccount
+                        - some.serviceaccount
+
+                      Some examples of invalid values are:
+                        - -some-serviceaccount
+                        - some-serviceaccount-
+
+                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                    - message: name must be a valid DNS1123 subdomain. It must contain
+                        only lowercase alphanumeric characters, hyphens (-) or periods
+                        (.), start and end with an alphanumeric character, and be
+                        no longer than 253 characters
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                required:
+                - name
+                type: object
+              source:
+                description: |-
+                  source is a required field which selects the installation source of content
+                  for this ClusterExtension. Selection is performed by setting the sourceType.
+
+                  Catalog is currently the only implemented sourceType, and setting the
+                  sourcetype to "Catalog" requires the catalog field to also be defined.
+
+                  Below is a minimal example of a source definition (in yaml):
+
+                  source:
+                    sourceType: Catalog
+                    catalog:
+                      packageName: example-package
+                properties:
+                  catalog:
+                    description: |-
+                      catalog is used to configure how information is sourced from a catalog.
+                      This field is required when sourceType is "Catalog", and forbidden otherwise.
+                    properties:
+                      channels:
+                        description: |-
+                          channels is an optional reference to a set of channels belonging to
+                          the package specified in the packageName field.
+
+                          A "channel" is a package-author-defined stream of updates for an extension.
+
+                          Each channel in the list must follow the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters. No more than 256 channels can be specified.
+
+                          When specified, it is used to constrain the set of installable bundles and
+                          the automated upgrade path. This constraint is an AND operation with the
+                          version field. For example:
+                            - Given channel is set to "foo"
+                            - Given version is set to ">=1.0.0, <1.5.0"
+                            - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+                            - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+
+                          When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+
+                          Some examples of valid values are:
+                            - 1.1.x
+                            - alpha
+                            - stable
+                            - stable-v1
+                            - v1-stable
+                            - dev-preview
+                            - preview
+                            - community
+
+                          Some examples of invalid values are:
+                            - -some-channel
+                            - some-channel-
+                            - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+                            - original_40
+                            - --default-channel
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        items:
+                          maxLength: 253
+                          type: string
+                          x-kubernetes-validations:
+                          - message: channels entries must be valid DNS1123 subdomains
+                            rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        maxItems: 256
+                        type: array
+                      packageName:
+                        description: |-
+                          packageName is a reference to the name of the package to be installed
+                          and is used to filter the content from catalogs.
+
+                          packageName is required, immutable, and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+
+                          Some examples of valid values are:
+                            - some-package
+                            - 123-package
+                            - 1-package-2
+                            - somepackage
+
+                          Some examples of invalid values are:
+                            - -some-package
+                            - some-package-
+                            - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+                            - some.package
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        maxLength: 253
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName is immutable
+                          rule: self == oldSelf
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      selector:
+                        description: |-
+                          selector is an optional field that can be used
+                          to filter the set of ClusterCatalogs used in the bundle
+                          selection process.
+
+                          When unspecified, all ClusterCatalogs will be used in
+                          the bundle selection process.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      upgradeConstraintPolicy:
+                        default: CatalogProvided
+                        description: |-
+                          upgradeConstraintPolicy is an optional field that controls whether
+                          the upgrade path(s) defined in the catalog are enforced for the package
+                          referenced in the packageName field.
+
+                          Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
+
+                          When this field is set to "CatalogProvided", automatic upgrades will only occur
+                          when upgrade constraints specified by the package author are met.
+
+                          When this field is set to "SelfCertified", the upgrade constraints specified by
+                          the package author are ignored. This allows for upgrades and downgrades to
+                          any version of the package. This is considered a dangerous operation as it
+                          can lead to unknown and potentially disastrous outcomes, such as data
+                          loss. It is assumed that users have independently verified changes when
+                          using this option.
+
+                          When this field is omitted, the default value is "CatalogProvided".
+                        enum:
+                        - CatalogProvided
+                        - SelfCertified
+                        type: string
+                      version:
+                        description: |-
+                          version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+
+                          Acceptable version ranges are no longer than 64 characters.
+                          Version ranges are composed of comma- or space-delimited values and one or
+                          more comparison operators, known as comparison strings. Additional
+                          comparison strings can be added using the OR operator (||).
+
+                          # Range Comparisons
+
+                          To specify a version range, you can use a comparison string like ">=3.0,
+                          <3.6". When specifying a range, automatic updates will occur within that
+                          range. The example comparison string means "install any version greater than
+                          or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+                          upgrades are available within the version range after initial installation,
+                          those upgrades should be automatically performed.
+
+                          # Pinned Versions
+
+                          To specify an exact version to install you can use a version range that
+                          "pins" to a specific version. When pinning to a specific version, no
+                          automatic updates will occur. An example of a pinned version range is
+                          "0.6.0", which means "only install version 0.6.0 and never
+                          upgrade from this version".
+
+                          # Basic Comparison Operators
+
+                          The basic comparison operators and their meanings are:
+                            - "=", equal (not aliased to an operator)
+                            - "!=", not equal
+                            - "<", less than
+                            - ">", greater than
+                            - ">=", greater than OR equal to
+                            - "<=", less than OR equal to
+
+                          # Wildcard Comparisons
+
+                          You can use the "x", "X", and "*" characters as wildcard characters in all
+                          comparison operations. Some examples of using the wildcard characters:
+                            - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+                            - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+                            - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+                            - "x", "X", and "*" is equivalent to ">= 0.0.0"
+
+                          # Patch Release Comparisons
+
+                          When you want to specify a minor version up to the next major version you
+                          can use the "~" character to perform patch comparisons. Some examples:
+                            - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+                            - "~1" and "~1.x" is equivalent to ">=1, <2"
+                            - "~2.3" is equivalent to ">=2.3, <2.4"
+                            - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+
+                          # Major Release Comparisons
+
+                          You can use the "^" character to make major release comparisons after a
+                          stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+                            - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+                            - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+                            - "^2.3" is equivalent to ">=2.3, <3"
+                            - "^2.x" is equivalent to ">=2.0.0, <3"
+                            - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+                            - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+                            - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+                            - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+                            - "^0" is equivalent to ">=0.0.0, <1.0.0"
+
+                          # OR Comparisons
+                          You can use the "||" character to represent an OR operation in the version
+                          range. Some examples:
+                            - ">=1.2.3, <2.0.0 || >3.0.0"
+                            - "^0 || ^3 || ^5"
+
+                          For more information on semver, please see https://semver.org/
+                        maxLength: 64
+                        type: string
+                        x-kubernetes-validations:
+                        - message: invalid version expression
+                          rule: self.matches("^(\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|[x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*]))?(\\.(0|[1-9]\\d*|x|X|\\*))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)((?:\\s+|,\\s*|\\s*\\|\\|\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*))?(\\.(0|[1-9]\\d*|x|X|\\*]))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)*$")
+                    required:
+                    - packageName
+                    type: object
+                  sourceType:
+                    description: |-
+                      sourceType is a required reference to the type of install source.
+
+                      Allowed values are "Catalog"
+
+                      When this field is set to "Catalog", information for determining the
+                      appropriate bundle of content to install will be fetched from
+                      ClusterCatalog resources existing on the cluster.
+                      When using the Catalog sourceType, the catalog field must also be set.
+                    enum:
+                    - Catalog
+                    type: string
+                required:
+                - sourceType
+                type: object
+                x-kubernetes-validations:
+                - message: catalog is required when sourceType is Catalog, and forbidden
+                    otherwise
+                  rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ?
+                    has(self.catalog) : !has(self.catalog)'
+            required:
+            - namespace
+            - serviceAccount
+            - source
+            type: object
+          status:
+            description: status is an optional field that defines the observed state
+              of the ClusterExtension.
+            properties:
+              conditions:
+                description: |-
+                  The set of condition types which apply to all spec.source variations are Installed and Progressing.
+
+                  The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+                  When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+                  When Installed is False and the Reason is Failed, the bundle has failed to install.
+
+                  The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+                  When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                  When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
+                  When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+
+                  When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+                  These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+                  BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+                  ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+                  PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+                  Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              install:
+                description: install is a representation of the current installation
+                  status for this ClusterExtension.
+                properties:
+                  bundle:
+                    description: |-
+                      bundle is a required field which represents the identifying attributes of a bundle.
+
+                      A "bundle" is a versioned set of content that represents the resources that
+                      need to be applied to a cluster to install a package.
+                    properties:
+                      name:
+                        description: |-
+                          name is required and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      version:
+                        description: |-
+                          version is a required field and is a reference to the version that this bundle represents
+                          version follows the semantic versioning standard as defined in https://semver.org/.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: version must be well-formed semver
+                          rule: self.matches("^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
+                    required:
+                    - name
+                    - version
+                    type: object
+                required:
+                - bundle
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	k8s.io/kubernetes v1.32.3
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/controller-tools v0.17.3
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -99,7 +100,7 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
-	github.com/fatih/color v1.16.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
@@ -119,6 +120,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
+	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
-github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
-github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=
@@ -204,6 +204,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=
+github.com/gobuffalo/flect v1.0.3/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -390,8 +392,12 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
@@ -767,6 +773,8 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -817,6 +825,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1 h1:uOuSLOMBWkJH0
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.1/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
+sigs.k8s.io/controller-tools v0.17.3 h1:lwFPLicpBKLgIepah+c8ikRBubFW5kOQyT88r3EwfNw=
+sigs.k8s.io/controller-tools v0.17.3/go.mod h1:1ii+oXcYZkxcBXzwv3YZBlzjt1fvkrCGjVF73blosJI=
 sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
 sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/hack/tools/crd-generator/README.md
+++ b/hack/tools/crd-generator/README.md
@@ -1,0 +1,53 @@
+# Guide to Operator-Controller CRD extensions
+
+All operator-controller (`opcon` for short) extensions to CRDs are part of the
+comments to fields within the APIs. The fields look like XML tags, to distinguish
+them from kubebuilder tags.
+
+All tags start with `<opcon:`, end with `>` and have additional fields in between.
+Usually the second field is `experimental`. Some tags may have an end tag (like XML)
+that starts with `</`.
+
+## Experimental Field
+
+* Tag: `<opcon:experimental>`
+
+The field that follows is experimental, and is not included in the standard CRD. It *is* included
+in the experimental CRD.
+
+## Experimental Validation
+
+* Tag: `<opcon:standard:validation:VALIDATION>`
+* Tag: `<opcon:experimental:validation:VALIDATION>`
+
+A standard and/or experimental validation which may differ from one another. For example, where the
+experimental CRD has extra enumerations.
+
+Where `VALIDATION` is one of:
+
+* `Enum=list;of;enums`
+
+A semi-colon separated list of enumerations, similar to the `+kubebuilder:validation:Enum` scheme.
+
+* `XValidation:message="something",rule="something"`
+
+An XValidation scheme, similar to the `+kubebuilder:validation:XValidation` scheme, but more limited.
+
+## Experimental Description
+
+* Start Tag: `<opcon:experimental:description>`
+* End Tag: `</opcon:experimental:description>`
+
+Descriptive text that is only included as part of the field description within the experimental CRD.
+All text between the tags is included in the experimental CRD, but removed from the standard CRD.
+
+This is only useful if the field is included in the standard CRD, but there's additional meaning in
+the experimental CRD when feature gates are enabled.
+
+## Exclude from CRD Description
+
+* Start Tag: `<opcon:util:excludeFromCRD>`
+* End Tag: `</opcon:util:excludeFromCRD>`
+
+Descriptive text that is excluded from the CRD description. This is similar to the use of `---`, except
+the three hypens excludes *all* following text.

--- a/hack/tools/crd-generator/main.go
+++ b/hack/tools/crd-generator/main.go
@@ -70,8 +70,6 @@ func runGenerator(args ...string) {
 		crdRoot = args[2]
 	}
 
-	log.Printf("crdRoot: %s", crdRoot)
-
 	roots, err := loader.LoadRoots(
 		"k8s.io/apimachinery/pkg/runtime/schema", // Needed to parse generated register functions.
 		crdRoot,
@@ -96,7 +94,6 @@ func runGenerator(args ...string) {
 
 	crd.AddKnownTypes(parser)
 	for _, r := range roots {
-		log.Printf("Looking at package %v", r)
 		parser.NeedPackage(r)
 	}
 
@@ -144,7 +141,6 @@ func runGenerator(args ...string) {
 
 			conv, err := crd.AsVersion(*channelCrd, apiextensionsv1.SchemeGroupVersion)
 			if err != nil {
-				log.Printf("CRD: %v", *channelCrd)
 				log.Fatalf("failed to convert CRD: %s", err)
 			}
 
@@ -173,8 +169,6 @@ func runGenerator(args ...string) {
 			if !bytes.HasPrefix(out, breakLine) {
 				out = append(breakLine, out...)
 			}
-
-			log.Printf("writing %v bytes", len(out))
 
 			fileName := fmt.Sprintf("%s/%s/%s_%s.yaml", outputDir, channel, crdRaw.Spec.Group, crdRaw.Spec.Names.Plural)
 			err = os.WriteFile(fileName, out, 0o600)
@@ -216,8 +210,6 @@ func opconTweaks(channel string, name string, jsonProps apiextensionsv1.JSONSche
 	numExpressions := strings.Count(jsonProps.Description, validationPrefix)
 	numValid := 0
 	if numExpressions > 0 {
-		log.Printf("found validations")
-
 		enumRe := regexp.MustCompile(validationPrefix + "Enum=([A-Za-z;]*)>")
 		enumMatches := enumRe.FindAllStringSubmatch(jsonProps.Description, 64)
 		for _, enumMatch := range enumMatches {
@@ -248,7 +240,6 @@ func opconTweaks(channel string, name string, jsonProps apiextensionsv1.JSONSche
 	}
 
 	if numValid < numExpressions {
-		fmt.Printf("Description: %s\n", jsonProps.Description)
 		log.Fatalf("Found %d Opcon validation expressions, but only %d were valid", numExpressions, numValid)
 	}
 
@@ -274,7 +265,6 @@ func formatDescription(description string, channel string, name string) string {
 			log.Fatalf("Invalid <opcon:experimental:description> tag for %s", name)
 		}
 		description = re.ReplaceAllString(description, "\n\n")
-		log.Printf("found experimental:description")
 	} else {
 		description = strings.ReplaceAll(description, startTag, "")
 		description = strings.ReplaceAll(description, endTag, "")
@@ -292,7 +282,6 @@ func formatDescription(description string, channel string, name string) string {
 			log.Fatalf("Invalid <opcon:util:excludeFromCRD> tag for %s", name)
 		}
 		description = re.ReplaceAllString(description, "\n\n\n")
-		log.Printf("found excludeFromCRD")
 	}
 
 	opconRe := regexp.MustCompile(`<opcon:.*>`)

--- a/hack/tools/crd-generator/main.go
+++ b/hack/tools/crd-generator/main.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-tools/pkg/crd"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// FeatureSetAnnotation is the annotation key used in the Operator-Controller API CRDs to specify
+	// the installed Operator-Controller API channel.
+	FeatureSetAnnotation = "olm.operatorframework.io/feature-set"
+	VersionAnnotation    = "controller-gen.kubebuilder.io/version"
+	StandardChannel      = "standard"
+	ExperimentalChannel  = "experimental"
+)
+
+var standardKinds = map[string]bool{
+	"ClusterExtension": true,
+	"ClusterCatalog":   true,
+}
+
+// This generation code is largely copied from below into operator-controller
+// github.com/kubernetes-sigs/gateway-api/blob/b7d2c5788bf38fc2c18085de524e204034c69a14/pkg/generator/main.go
+// This generation code is largely copied from below into gateway-api
+// github.com/kubernetes-sigs/controller-tools/blob/ab52f76cc7d167925b2d5942f24bf22e30f49a02/pkg/crd/gen.go
+func main() {
+	runGenerator(os.Args[1:]...)
+}
+
+func runGenerator(args ...string) {
+	outputDir := "config/crd"
+	ctVer := ""
+	if len(args) >= 1 {
+		// Get the output directory
+		outputDir = args[0]
+	}
+	if len(args) >= 2 {
+		// get the controller-tools version
+		ctVer = args[1]
+	}
+
+	roots, err := loader.LoadRoots(
+		"k8s.io/apimachinery/pkg/runtime/schema", // Needed to parse generated register functions.
+		"github.com/operator-framework/operator-controller/api/v1",
+	)
+	if err != nil {
+		log.Fatalf("failed to load package roots: %s", err)
+	}
+
+	generator := &crd.Generator{}
+
+	parser := &crd.Parser{
+		Collector: &markers.Collector{Registry: &markers.Registry{}},
+		Checker: &loader.TypeChecker{
+			NodeFilters: []loader.NodeFilter{generator.CheckFilter()},
+		},
+	}
+
+	err = generator.RegisterMarkers(parser.Collector.Registry)
+	if err != nil {
+		log.Fatalf("failed to register markers: %s", err)
+	}
+
+	crd.AddKnownTypes(parser)
+	for _, r := range roots {
+		parser.NeedPackage(r)
+	}
+
+	metav1Pkg := crd.FindMetav1(roots)
+	if metav1Pkg == nil {
+		log.Fatalf("no objects in the roots, since nothing imported metav1")
+	}
+
+	kubeKinds := crd.FindKubeKinds(parser, metav1Pkg)
+	if len(kubeKinds) == 0 {
+		log.Fatalf("no objects in the roots")
+	}
+
+	channels := []string{StandardChannel, ExperimentalChannel}
+	for _, channel := range channels {
+		for _, groupKind := range kubeKinds {
+			if channel == StandardChannel && !standardKinds[groupKind.Kind] {
+				continue
+			}
+
+			log.Printf("generating %s CRD for %v\n", channel, groupKind)
+
+			parser.NeedCRDFor(groupKind, nil)
+			crdRaw := parser.CustomResourceDefinitions[groupKind]
+
+			// Inline version of "addAttribution(&crdRaw)" ...
+			if crdRaw.ObjectMeta.Annotations == nil {
+				crdRaw.ObjectMeta.Annotations = map[string]string{}
+			}
+			crdRaw.ObjectMeta.Annotations[FeatureSetAnnotation] = channel
+			if ctVer != "" {
+				crdRaw.ObjectMeta.Annotations[VersionAnnotation] = ctVer
+			}
+
+			// Prevent the top level metadata for the CRD to be generated regardless of the intention in the arguments
+			crd.FixTopLevelMetadata(crdRaw)
+
+			channelCrd := crdRaw.DeepCopy()
+			for i, version := range channelCrd.Spec.Versions {
+				if channel == StandardChannel && strings.Contains(version.Name, "alpha") {
+					channelCrd.Spec.Versions[i].Served = false
+				}
+				version.Schema.OpenAPIV3Schema.Properties = opconTweaksMap(channel, version.Schema.OpenAPIV3Schema.Properties)
+			}
+
+			conv, err := crd.AsVersion(*channelCrd, apiextensionsv1.SchemeGroupVersion)
+			if err != nil {
+				log.Fatalf("failed to convert CRD: %s", err)
+			}
+
+			out, err := yaml.Marshal(conv)
+			if err != nil {
+				log.Fatalf("failed to marshal CRD: %s", err)
+			}
+
+			// Do some filtering of the resulting YAML
+			var yamlData map[string]any
+			err = yaml.Unmarshal(out, &yamlData)
+			if err != nil {
+				log.Fatalf("failed to unmarshal data: %s", err)
+			}
+
+			scrapYaml(yamlData, "status")
+			scrapYaml(yamlData, "metadata", "creationTimestamp")
+
+			out, err = yaml.Marshal(yamlData)
+			if err != nil {
+				log.Fatalf("failed to re-marshal CRD: %s", err)
+			}
+
+			// If missing, add a break at the beginning of the file
+			breakLine := []byte("---\n")
+			if !bytes.HasPrefix(out, breakLine) {
+				out = append(breakLine, out...)
+			}
+
+			fileName := fmt.Sprintf("%s/%s/%s_%s.yaml", outputDir, channel, crdRaw.Spec.Group, crdRaw.Spec.Names.Plural)
+			err = os.WriteFile(fileName, out, 0o600)
+			if err != nil {
+				log.Fatalf("failed to write CRD: %s", err)
+			}
+		}
+	}
+}
+
+func opconTweaksMap(channel string, props map[string]apiextensionsv1.JSONSchemaProps) map[string]apiextensionsv1.JSONSchemaProps {
+	for name := range props {
+		jsonProps := props[name]
+		p := opconTweaks(channel, name, jsonProps)
+		if p == nil {
+			delete(props, name)
+		} else {
+			props[name] = *p
+		}
+	}
+	return props
+}
+
+// Custom Opcon API Tweaks for tags prefixed with `<opcon:` that get past
+// the limitations of Kubebuilder annotations.
+func opconTweaks(channel string, name string, jsonProps apiextensionsv1.JSONSchemaProps) *apiextensionsv1.JSONSchemaProps {
+	if channel == StandardChannel {
+		if strings.Contains(jsonProps.Description, "<opcon:experimental>") {
+			return nil
+		}
+	}
+
+	// TODO(robscott): Figure out why crdgen switched this to "object"
+	if jsonProps.Format == "date-time" {
+		jsonProps.Type = "string"
+	}
+
+	validationPrefix := fmt.Sprintf("<opcon:%s:validation:", channel)
+	numExpressions := strings.Count(jsonProps.Description, validationPrefix)
+	numValid := 0
+	if numExpressions > 0 {
+		enumRe := regexp.MustCompile(validationPrefix + "Enum=([A-Za-z;]*)>")
+		enumMatches := enumRe.FindAllStringSubmatch(jsonProps.Description, 64)
+		for _, enumMatch := range enumMatches {
+			if len(enumMatch) != 2 {
+				log.Fatalf("Invalid %s Enum tag for %s", validationPrefix, name)
+			}
+
+			numValid++
+			jsonProps.Enum = []apiextensionsv1.JSON{}
+			for _, val := range strings.Split(enumMatch[1], ";") {
+				jsonProps.Enum = append(jsonProps.Enum, apiextensionsv1.JSON{Raw: []byte("\"" + val + "\"")})
+			}
+		}
+
+		celRe := regexp.MustCompile(validationPrefix + "XValidation:message=\"([^\"]*)\",rule=\"([^\"]*)\">")
+		celMatches := celRe.FindAllStringSubmatch(jsonProps.Description, 64)
+		for _, celMatch := range celMatches {
+			if len(celMatch) != 3 {
+				log.Fatalf("Invalid %s CEL tag for %s", validationPrefix, name)
+			}
+
+			numValid++
+			jsonProps.XValidations = append(jsonProps.XValidations, apiextensionsv1.ValidationRule{
+				Message: celMatch[1],
+				Rule:    celMatch[2],
+			})
+		}
+	}
+
+	if numValid < numExpressions {
+		fmt.Printf("Description: %s\n", jsonProps.Description)
+		log.Fatalf("Found %d Opcon validation expressions, but only %d were valid", numExpressions, numValid)
+	}
+
+	jsonProps.Description = formatDescription(jsonProps.Description, channel, name)
+
+	if len(jsonProps.Properties) > 0 {
+		jsonProps.Properties = opconTweaksMap(channel, jsonProps.Properties)
+	} else if jsonProps.Items != nil && jsonProps.Items.Schema != nil {
+		jsonProps.Items.Schema = opconTweaks(channel, name, *jsonProps.Items.Schema)
+	}
+
+	return &jsonProps
+}
+
+func formatDescription(description string, channel string, name string) string {
+	startTag := "<opcon:experimental:description>"
+	endTag := "</opcon:experimental:description>"
+	if channel == StandardChannel && strings.Contains(description, startTag) {
+		regexPattern := `\n*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `\n*`
+		re := regexp.MustCompile(regexPattern)
+		match := re.FindStringSubmatch(description)
+		if len(match) != 2 {
+			log.Fatalf("Invalid <opcon:experimental:description> tag for %s", name)
+		}
+		description = re.ReplaceAllString(description, "\n\n")
+	} else {
+		description = strings.ReplaceAll(description, startTag, "")
+		description = strings.ReplaceAll(description, endTag, "")
+	}
+
+	// Comments within "opcon:util:excludeFromCRD" tag are not included in the generated CRD and all trailing \n operators before
+	// and after the tags are removed and replaced with three \n operators.
+	startTag = "<opcon:util:excludeFromCRD>"
+	endTag = "</opcon:util:excludeFromCRD>"
+	if strings.Contains(description, startTag) {
+		regexPattern := `\n*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `\n*`
+		re := regexp.MustCompile(regexPattern)
+		match := re.FindStringSubmatch(description)
+		if len(match) != 2 {
+			log.Fatalf("Invalid <opcon:util:excludeFromCRD> tag for %s", name)
+		}
+		description = re.ReplaceAllString(description, "\n\n\n")
+	}
+
+	opconRe := regexp.MustCompile(`<opcon:.*>`)
+	description = opconRe.ReplaceAllLiteralString(description, "")
+
+	// Remove anything following three hyphens
+	regexPattern := `(?s)---.*`
+	re := regexp.MustCompile(regexPattern)
+	description = re.ReplaceAllString(description, "")
+
+	// Remove any extra \n (more than 2 and all trailing at the end)
+	regexPattern = `\n\n+`
+	re = regexp.MustCompile(regexPattern)
+	description = re.ReplaceAllString(description, "\n\n")
+	description = strings.Trim(description, "\n")
+
+	return description
+}
+
+// delete a field in unstructured YAML
+func scrapYaml(data map[string]any, fields ...string) {
+	if len(fields) == 0 {
+		return
+	}
+	if len(fields) == 1 {
+		delete(data, fields[0])
+		return
+	}
+	if f, ok := data[fields[0]]; ok {
+		if f2, ok := f.(map[string]any); ok {
+			scrapYaml(f2, fields[1:]...)
+		}
+	}
+}

--- a/hack/tools/crd-generator/main_test.go
+++ b/hack/tools/crd-generator/main_test.go
@@ -11,9 +11,12 @@ import (
 )
 
 func TestRunGenerator(t *testing.T) {
-	// Get to repo root
-	err := os.Chdir("../../..")
+	here, err := os.Getwd()
 	require.NoError(t, err)
+	// Get to repo root
+	err = os.Chdir("../../..")
+	require.NoError(t, err)
+	defer os.Chdir(here)
 	dir, err := os.MkdirTemp("", "crd-generate-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -21,23 +24,47 @@ func TestRunGenerator(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "experimental"), 0o700))
 	runGenerator(dir, "v0.17.3")
 
-	f1 := filepath.Join(dir, "/standard/olm.operatorframework.io_clusterextensions.yaml")
+	f1 := filepath.Join(dir, "standard/olm.operatorframework.io_clusterextensions.yaml")
 	f2 := "config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml"
 	fmt.Printf("comparing: %s to %s\n", f1, f2)
 	compareFiles(t, f1, f2)
 
-	f1 = filepath.Join(dir, "/standard/olm.operatorframework.io_clustercatalogs.yaml")
+	f1 = filepath.Join(dir, "standard/olm.operatorframework.io_clustercatalogs.yaml")
 	f2 = "config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml"
 	fmt.Printf("comparing: %s to %s\n", f1, f2)
 	compareFiles(t, f1, f2)
 
-	f1 = filepath.Join(dir, "/experimental/olm.operatorframework.io_clusterextensions.yaml")
+	f1 = filepath.Join(dir, "experimental/olm.operatorframework.io_clusterextensions.yaml")
 	f2 = "config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml"
 	fmt.Printf("comparing: %s to %s\n", f1, f2)
 	compareFiles(t, f1, f2)
 
-	f1 = filepath.Join(dir, "/experimental/olm.operatorframework.io_clustercatalogs.yaml")
+	f1 = filepath.Join(dir, "experimental/olm.operatorframework.io_clustercatalogs.yaml")
 	f2 = "config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+}
+
+func TestTags(t *testing.T) {
+	here, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir("testdata")
+	defer os.Chdir(here)
+	require.NoError(t, err)
+	dir, err := os.MkdirTemp("", "crd-generate-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "standard"), 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "experimental"), 0o700))
+	runGenerator(dir, "v0.17.3", "github.com/operator-framework/operator-controller/hack/tools/crd-generator/testdata/api/v1")
+
+	f1 := filepath.Join(dir, "standard/olm.operatorframework.io_clusterextensions.yaml")
+	f2 := "output/standard/olm.operatorframework.io_clusterextensions.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+
+	f1 = filepath.Join(dir, "experimental/olm.operatorframework.io_clusterextensions.yaml")
+	f2 = "output/experimental/olm.operatorframework.io_clusterextensions.yaml"
 	fmt.Printf("comparing: %s to %s\n", f1, f2)
 	compareFiles(t, f1, f2)
 }

--- a/hack/tools/crd-generator/main_test.go
+++ b/hack/tools/crd-generator/main_test.go
@@ -16,7 +16,9 @@ func TestRunGenerator(t *testing.T) {
 	// Get to repo root
 	err = os.Chdir("../../..")
 	require.NoError(t, err)
-	defer os.Chdir(here)
+	defer func() {
+		_ = os.Chdir(here)
+	}()
 	dir, err := os.MkdirTemp("", "crd-generate-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -49,7 +51,9 @@ func TestTags(t *testing.T) {
 	here, err := os.Getwd()
 	require.NoError(t, err)
 	err = os.Chdir("testdata")
-	defer os.Chdir(here)
+	defer func() {
+		_ = os.Chdir(here)
+	}()
 	require.NoError(t, err)
 	dir, err := os.MkdirTemp("", "crd-generate-*")
 	require.NoError(t, err)
@@ -72,11 +76,15 @@ func TestTags(t *testing.T) {
 func compareFiles(t *testing.T, file1, file2 string) {
 	f1, err := os.Open(file1)
 	require.NoError(t, err)
-	defer f1.Close()
+	defer func() {
+		_ = f1.Close()
+	}()
 
 	f2, err := os.Open(file2)
 	require.NoError(t, err)
-	defer f2.Close()
+	defer func() {
+		_ = f2.Close()
+	}()
 
 	for {
 		b1 := make([]byte, 64000)

--- a/hack/tools/crd-generator/main_test.go
+++ b/hack/tools/crd-generator/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGenerator(t *testing.T) {
+	// Get to repo root
+	err := os.Chdir("../../..")
+	require.NoError(t, err)
+	dir, err := os.MkdirTemp("", "crd-generate-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "standard"), 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "experimental"), 0o700))
+	runGenerator(dir, "v0.17.3")
+
+	f1 := filepath.Join(dir, "/standard/olm.operatorframework.io_clusterextensions.yaml")
+	f2 := "config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+
+	f1 = filepath.Join(dir, "/standard/olm.operatorframework.io_clustercatalogs.yaml")
+	f2 = "config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+
+	f1 = filepath.Join(dir, "/experimental/olm.operatorframework.io_clusterextensions.yaml")
+	f2 = "config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+
+	f1 = filepath.Join(dir, "/experimental/olm.operatorframework.io_clustercatalogs.yaml")
+	f2 = "config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml"
+	fmt.Printf("comparing: %s to %s\n", f1, f2)
+	compareFiles(t, f1, f2)
+}
+
+func compareFiles(t *testing.T, file1, file2 string) {
+	f1, err := os.Open(file1)
+	require.NoError(t, err)
+	defer f1.Close()
+
+	f2, err := os.Open(file2)
+	require.NoError(t, err)
+	defer f2.Close()
+
+	for {
+		b1 := make([]byte, 64000)
+		b2 := make([]byte, 64000)
+		n1, err1 := f1.Read(b1)
+		n2, err2 := f2.Read(b2)
+
+		// Success if both have EOF at the same time
+		if err1 == io.EOF && err2 == io.EOF {
+			return
+		}
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.Equal(t, n1, n2)
+		require.Equal(t, b1, b2)
+	}
+}

--- a/hack/tools/crd-generator/testdata/api/v1/clusterextension_types.go
+++ b/hack/tools/crd-generator/testdata/api/v1/clusterextension_types.go
@@ -1,0 +1,524 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ClusterExtensionKind = "ClusterExtension"
+
+type (
+	UpgradeConstraintPolicy     string
+	CRDUpgradeSafetyEnforcement string
+)
+
+const (
+	// The extension will only upgrade if the new version satisfies
+	// the upgrade constraints set by the package author.
+	UpgradeConstraintPolicyCatalogProvided UpgradeConstraintPolicy = "CatalogProvided"
+
+	// Unsafe option which allows an extension to be
+	// upgraded or downgraded to any available version of the package and
+	// ignore the upgrade path designed by package authors.
+	// This assumes that users independently verify the outcome of the changes.
+	// Use with caution as this can lead to unknown and potentially
+	// disastrous results such as data loss.
+	UpgradeConstraintPolicySelfCertified UpgradeConstraintPolicy = "SelfCertified"
+)
+
+// ClusterExtensionSpec defines the desired state of ClusterExtension
+type ClusterExtensionSpec struct {
+	// namespace is a reference to a Kubernetes namespace.
+	// This is the namespace in which the provided ServiceAccount must exist.
+	// It also designates the default namespace where namespace-scoped resources
+	// for the extension are applied to the cluster.
+	// Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+	// This namespace must exist.
+	//
+	// namespace is required, immutable, and follows the DNS label standard
+	// as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+	// start and end with an alphanumeric character, and be no longer than 63 characters
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	// +kubebuilder:validation:MaxLength:=63
+	// <opcon:standard:validation:XValidation:rule="self == oldSelf",message="namespace is immutable">
+	// <opcon:experimental:validation:XValidation:rule="self == oldSelf",message="namespace really is immutable">
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\")",message="namespace must be a valid DNS1123 label"
+	// +kubebuilder:validation:Required
+	Namespace string `json:"namespace"`
+
+	// serviceAccount is a reference to a ServiceAccount used to perform all interactions
+	// with the cluster that are required to manage the extension.
+	// The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+	// The ServiceAccount must exist in the namespace referenced in the spec.
+	// serviceAccount is required.
+	//
+	// +kubebuilder:validation:Required
+	ServiceAccount ServiceAccountReference `json:"serviceAccount"`
+
+	// source is a required field which selects the installation source of content
+	// for this ClusterExtension. Selection is performed by setting the sourceType.
+	//
+	// Catalog is currently the only implemented sourceType, and setting the
+	// sourcetype to "Catalog" requires the catalog field to also be defined.
+	//
+	// Below is a minimal example of a source definition (in yaml):
+	//
+	// source:
+	//   sourceType: Catalog
+	//   catalog:
+	//     packageName: example-package
+	//
+	// +kubebuilder:validation:Required
+	Source SourceConfig `json:"source"`
+
+	// install is an optional field used to configure the installation options
+	// for the ClusterExtension such as the pre-flight check configuration.
+	//
+	// +optional
+	Install *ClusterExtensionInstallConfig `json:"install,omitempty"`
+}
+
+const SourceTypeCatalog = "Catalog"
+
+// SourceConfig is a discriminated union which selects the installation source.
+//
+// +union
+// +kubebuilder:validation:XValidation:rule="has(self.sourceType) && self.sourceType == 'Catalog' ? has(self.catalog) : !has(self.catalog)",message="catalog is required when sourceType is Catalog, and forbidden otherwise"
+type SourceConfig struct {
+	// sourceType is a required reference to the type of install source.
+	//
+	// Allowed values are "Catalog"
+	//
+	// When this field is set to "Catalog", information for determining the
+	// appropriate bundle of content to install will be fetched from
+	// ClusterCatalog resources existing on the cluster.
+	// When using the Catalog sourceType, the catalog field must also be set.
+	//
+	// +unionDiscriminator
+	// <opcon:standard:validation:Enum=Catalog>
+	// <opcon:experimental:validation:Enum=Catalog;NotCatalog>
+	// +kubebuilder:validation:Required
+	SourceType string `json:"sourceType"`
+
+	// catalog is used to configure how information is sourced from a catalog.
+	// This field is required when sourceType is "Catalog", and forbidden otherwise.
+	//
+	// <opcon:experimental:description>
+	// This is the experimental description for Catalog
+	// </opcon:experimental:description>
+	//
+	// <opcon:util:excludeFromCRD>
+	// No one should see this!
+	// </opcon:util:excludeFromCRD>
+	//
+	// +optional
+	Catalog *CatalogFilter `json:"catalog,omitempty"`
+
+	// test is a required parameter
+	// <opcon:experimental>
+	Test string `json:"test"`
+}
+
+// ClusterExtensionInstallConfig is a union which selects the clusterExtension installation config.
+// ClusterExtensionInstallConfig requires the namespace and serviceAccount which should be used for the installation of packages.
+//
+// +kubebuilder:validation:XValidation:rule="has(self.preflight)",message="at least one of [preflight] are required when install is specified"
+// +union
+type ClusterExtensionInstallConfig struct {
+	// preflight is an optional field that can be used to configure the checks that are
+	// run before installation or upgrade of the content for the package specified in the packageName field.
+	//
+	// When specified, it replaces the default preflight configuration for install/upgrade actions.
+	// When not specified, the default configuration will be used.
+	//
+	// +optional
+	Preflight *PreflightConfig `json:"preflight,omitempty"`
+}
+
+// CatalogFilter defines the attributes used to identify and filter content from a catalog.
+type CatalogFilter struct {
+	// packageName is a reference to the name of the package to be installed
+	// and is used to filter the content from catalogs.
+	//
+	// packageName is required, immutable, and follows the DNS subdomain standard
+	// as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+	// hyphens (-) or periods (.), start and end with an alphanumeric character,
+	// and be no longer than 253 characters.
+	//
+	// Some examples of valid values are:
+	//   - some-package
+	//   - 123-package
+	//   - 1-package-2
+	//   - somepackage
+	//
+	// Some examples of invalid values are:
+	//   - -some-package
+	//   - some-package-
+	//   - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+	//   - some.package
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	// +kubebuilder:validation.Required
+	// +kubebuilder:validation:MaxLength:=253
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="packageName is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")",message="packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters"
+	// +kubebuilder:validation:Required
+	PackageName string `json:"packageName"`
+
+	// version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+	//
+	// Acceptable version ranges are no longer than 64 characters.
+	// Version ranges are composed of comma- or space-delimited values and one or
+	// more comparison operators, known as comparison strings. Additional
+	// comparison strings can be added using the OR operator (||).
+	//
+	// # Range Comparisons
+	//
+	// To specify a version range, you can use a comparison string like ">=3.0,
+	// <3.6". When specifying a range, automatic updates will occur within that
+	// range. The example comparison string means "install any version greater than
+	// or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+	// upgrades are available within the version range after initial installation,
+	// those upgrades should be automatically performed.
+	//
+	// # Pinned Versions
+	//
+	// To specify an exact version to install you can use a version range that
+	// "pins" to a specific version. When pinning to a specific version, no
+	// automatic updates will occur. An example of a pinned version range is
+	// "0.6.0", which means "only install version 0.6.0 and never
+	// upgrade from this version".
+	//
+	// # Basic Comparison Operators
+	//
+	// The basic comparison operators and their meanings are:
+	//   - "=", equal (not aliased to an operator)
+	//   - "!=", not equal
+	//   - "<", less than
+	//   - ">", greater than
+	//   - ">=", greater than OR equal to
+	//   - "<=", less than OR equal to
+	//
+	// # Wildcard Comparisons
+	//
+	// You can use the "x", "X", and "*" characters as wildcard characters in all
+	// comparison operations. Some examples of using the wildcard characters:
+	//   - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+	//   - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+	//   - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+	//   - "x", "X", and "*" is equivalent to ">= 0.0.0"
+	//
+	// # Patch Release Comparisons
+	//
+	// When you want to specify a minor version up to the next major version you
+	// can use the "~" character to perform patch comparisons. Some examples:
+	//   - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+	//   - "~1" and "~1.x" is equivalent to ">=1, <2"
+	//   - "~2.3" is equivalent to ">=2.3, <2.4"
+	//   - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+	//
+	// # Major Release Comparisons
+	//
+	// You can use the "^" character to make major release comparisons after a
+	// stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+	//   - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+	//   - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+	//   - "^2.3" is equivalent to ">=2.3, <3"
+	//   - "^2.x" is equivalent to ">=2.0.0, <3"
+	//   - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+	//   - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+	//   - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+	//   - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+	//   - "^0" is equivalent to ">=0.0.0, <1.0.0"
+	//
+	// # OR Comparisons
+	// You can use the "||" character to represent an OR operation in the version
+	// range. Some examples:
+	//   - ">=1.2.3, <2.0.0 || >3.0.0"
+	//   - "^0 || ^3 || ^5"
+	//
+	// For more information on semver, please see https://semver.org/
+	//
+	// +kubebuilder:validation:MaxLength:=64
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^(\\\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|[x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)((?:\\\\s+|,\\\\s*|\\\\s*\\\\|\\\\|\\\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)*$\")",message="invalid version expression"
+	// +optional
+	Version string `json:"version,omitempty"`
+
+	// channels is an optional reference to a set of channels belonging to
+	// the package specified in the packageName field.
+	//
+	// A "channel" is a package-author-defined stream of updates for an extension.
+	//
+	// Each channel in the list must follow the DNS subdomain standard
+	// as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+	// hyphens (-) or periods (.), start and end with an alphanumeric character,
+	// and be no longer than 253 characters. No more than 256 channels can be specified.
+	//
+	// When specified, it is used to constrain the set of installable bundles and
+	// the automated upgrade path. This constraint is an AND operation with the
+	// version field. For example:
+	//   - Given channel is set to "foo"
+	//   - Given version is set to ">=1.0.0, <1.5.0"
+	//   - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+	//   - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+	//
+	// When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+	//
+	// Some examples of valid values are:
+	//   - 1.1.x
+	//   - alpha
+	//   - stable
+	//   - stable-v1
+	//   - v1-stable
+	//   - dev-preview
+	//   - preview
+	//   - community
+	//
+	// Some examples of invalid values are:
+	//   - -some-channel
+	//   - some-channel-
+	//   - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+	//   - original_40
+	//   - --default-channel
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	// +kubebuilder:validation:items:MaxLength:=253
+	// +kubebuilder:validation:MaxItems:=256
+	// +kubebuilder:validation:items:XValidation:rule="self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")",message="channels entries must be valid DNS1123 subdomains"
+	// +optional
+	Channels []string `json:"channels,omitempty"`
+
+	// selector is an optional field that can be used
+	// to filter the set of ClusterCatalogs used in the bundle
+	// selection process.
+	//
+	// When unspecified, all ClusterCatalogs will be used in
+	// the bundle selection process.
+	//
+	// +optional
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+
+	// upgradeConstraintPolicy is an optional field that controls whether
+	// the upgrade path(s) defined in the catalog are enforced for the package
+	// referenced in the packageName field.
+	//
+	// Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
+	//
+	// When this field is set to "CatalogProvided", automatic upgrades will only occur
+	// when upgrade constraints specified by the package author are met.
+	//
+	// When this field is set to "SelfCertified", the upgrade constraints specified by
+	// the package author are ignored. This allows for upgrades and downgrades to
+	// any version of the package. This is considered a dangerous operation as it
+	// can lead to unknown and potentially disastrous outcomes, such as data
+	// loss. It is assumed that users have independently verified changes when
+	// using this option.
+	//
+	// When this field is omitted, the default value is "CatalogProvided".
+	//
+	// +kubebuilder:validation:Enum:=CatalogProvided;SelfCertified
+	// +kubebuilder:default:=CatalogProvided
+	// +optional
+	UpgradeConstraintPolicy UpgradeConstraintPolicy `json:"upgradeConstraintPolicy,omitempty"`
+}
+
+// ServiceAccountReference identifies the serviceAccount used fo install a ClusterExtension.
+type ServiceAccountReference struct {
+	// name is a required, immutable reference to the name of the ServiceAccount
+	// to be used for installation and management of the content for the package
+	// specified in the packageName field.
+	//
+	// This ServiceAccount must exist in the installNamespace.
+	//
+	// name follows the DNS subdomain standard as defined in [RFC 1123].
+	// It must contain only lowercase alphanumeric characters,
+	// hyphens (-) or periods (.), start and end with an alphanumeric character,
+	// and be no longer than 253 characters.
+	//
+	// Some examples of valid values are:
+	//   - some-serviceaccount
+	//   - 123-serviceaccount
+	//   - 1-serviceaccount-2
+	//   - someserviceaccount
+	//   - some.serviceaccount
+	//
+	// Some examples of invalid values are:
+	//   - -some-serviceaccount
+	//   - some-serviceaccount-
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	// +kubebuilder:validation:MaxLength:=253
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")",message="name must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters"
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+}
+
+// PreflightConfig holds the configuration for the preflight checks.  If used, at least one preflight check must be non-nil.
+//
+// +kubebuilder:validation:XValidation:rule="has(self.crdUpgradeSafety)",message="at least one of [crdUpgradeSafety] are required when preflight is specified"
+type PreflightConfig struct {
+	// crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+	// checks that run prior to upgrades of installed content.
+	//
+	// The CRD Upgrade Safety pre-flight check safeguards from unintended
+	// consequences of upgrading a CRD, such as data loss.
+	CRDUpgradeSafety *CRDUpgradeSafetyPreflightConfig `json:"crdUpgradeSafety"`
+}
+
+// CRDUpgradeSafetyPreflightConfig is the configuration for CRD upgrade safety preflight check.
+type CRDUpgradeSafetyPreflightConfig struct {
+	// enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
+	//
+	// Allowed values are "None" or "Strict". The default value is "Strict".
+	//
+	// When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
+	// when performing an upgrade operation. This should be used with caution as
+	// unintended consequences such as data loss can occur.
+	//
+	// When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
+	// performing an upgrade operation.
+	//
+	// +kubebuilder:validation:Enum:="None";"Strict"
+	// +kubebuilder:validation:Required
+	Enforcement CRDUpgradeSafetyEnforcement `json:"enforcement"`
+}
+
+const (
+	// TypeDeprecated is a rollup condition that is present when
+	// any of the deprecated conditions are present.
+	TypeDeprecated        = "Deprecated"
+	TypePackageDeprecated = "PackageDeprecated"
+	TypeChannelDeprecated = "ChannelDeprecated"
+	TypeBundleDeprecated  = "BundleDeprecated"
+
+	// None will not perform CRD upgrade safety checks.
+	CRDUpgradeSafetyEnforcementNone CRDUpgradeSafetyEnforcement = "None"
+	// Strict will enforce the CRD upgrade safety check and block the upgrade if the CRD would not pass the check.
+	CRDUpgradeSafetyEnforcementStrict CRDUpgradeSafetyEnforcement = "Strict"
+)
+
+// BundleMetadata is a representation of the identifying attributes of a bundle.
+type BundleMetadata struct {
+	// name is required and follows the DNS subdomain standard
+	// as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+	// hyphens (-) or periods (.), start and end with an alphanumeric character,
+	// and be no longer than 253 characters.
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")",message="packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters"
+	Name string `json:"name"`
+
+	// version is a required field and is a reference to the version that this bundle represents
+	// version follows the semantic versioning standard as defined in https://semver.org/.
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self.matches(\"^([0-9]+)(\\\\.[0-9]+)?(\\\\.[0-9]+)?(-([-0-9A-Za-z]+(\\\\.[-0-9A-Za-z]+)*))?(\\\\+([-0-9A-Za-z]+(-\\\\.[-0-9A-Za-z]+)*))?\")",message="version must be well-formed semver"
+	Version string `json:"version"`
+}
+
+// ClusterExtensionStatus defines the observed state of a ClusterExtension.
+type ClusterExtensionStatus struct {
+	// The set of condition types which apply to all spec.source variations are Installed and Progressing.
+	//
+	// The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+	// When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+	// When Installed is False and the Reason is Failed, the bundle has failed to install.
+	//
+	// The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+	// When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+	// When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
+	// When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+	//
+	// When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+	// These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+	// BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+	// ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+	// PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+	// Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
+	//
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// install is a representation of the current installation status for this ClusterExtension.
+	//
+	// +optional
+	Install *ClusterExtensionInstallStatus `json:"install,omitempty"`
+}
+
+// ClusterExtensionInstallStatus is a representation of the status of the identified bundle.
+type ClusterExtensionInstallStatus struct {
+	// bundle is a required field which represents the identifying attributes of a bundle.
+	//
+	// A "bundle" is a versioned set of content that represents the resources that
+	// need to be applied to a cluster to install a package.
+	//
+	// +kubebuilder:validation:Required
+	Bundle BundleMetadata `json:"bundle"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Installed Bundle",type=string,JSONPath=`.status.install.bundle.name`
+// +kubebuilder:printcolumn:name=Version,type=string,JSONPath=`.status.install.bundle.version`
+// +kubebuilder:printcolumn:name="Installed",type=string,JSONPath=`.status.conditions[?(@.type=='Installed')].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=='Progressing')].status`
+// +kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
+
+// ClusterExtension is the Schema for the clusterextensions API
+type ClusterExtension struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// spec is an optional field that defines the desired state of the ClusterExtension.
+	// +optional
+	Spec ClusterExtensionSpec `json:"spec,omitempty"`
+
+	// status is an optional field that defines the observed state of the ClusterExtension.
+	// +optional
+	Status ClusterExtensionStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// ClusterExtensionList contains a list of ClusterExtension
+type ClusterExtensionList struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// items is a required list of ClusterExtension objects.
+	//
+	// +kubebuilder:validation:Required
+	Items []ClusterExtension `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&ClusterExtension{}, &ClusterExtensionList{})
+}

--- a/hack/tools/crd-generator/testdata/api/v1/groupversion_info.go
+++ b/hack/tools/crd-generator/testdata/api/v1/groupversion_info.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1 contains API Schema definitions for the olm v1 API group
+// +kubebuilder:object:generate=true
+// +groupName=olm.operatorframework.io
+package v1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "olm.operatorframework.io", Version: "v1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)

--- a/hack/tools/crd-generator/testdata/output/experimental/olm.operatorframework.io_clusterextensions.yaml
+++ b/hack/tools/crd-generator/testdata/output/experimental/olm.operatorframework.io_clusterextensions.yaml
@@ -1,0 +1,597 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: experimental
+  name: clusterextensions.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterExtension
+    listKind: ClusterExtensionList
+    plural: clusterextensions
+    singular: clusterextension
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.install.bundle.name
+      name: Installed Bundle
+      type: string
+    - jsonPath: .status.install.bundle.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Installed')].status
+      name: Installed
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExtension is the Schema for the clusterextensions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is an optional field that defines the desired state
+              of the ClusterExtension.
+            properties:
+              install:
+                description: |-
+                  install is an optional field used to configure the installation options
+                  for the ClusterExtension such as the pre-flight check configuration.
+                properties:
+                  preflight:
+                    description: |-
+                      preflight is an optional field that can be used to configure the checks that are
+                      run before installation or upgrade of the content for the package specified in the packageName field.
+
+                      When specified, it replaces the default preflight configuration for install/upgrade actions.
+                      When not specified, the default configuration will be used.
+                    properties:
+                      crdUpgradeSafety:
+                        description: |-
+                          crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+                          checks that run prior to upgrades of installed content.
+
+                          The CRD Upgrade Safety pre-flight check safeguards from unintended
+                          consequences of upgrading a CRD, such as data loss.
+                        properties:
+                          enforcement:
+                            description: |-
+                              enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
+
+                              Allowed values are "None" or "Strict". The default value is "Strict".
+
+                              When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
+                              when performing an upgrade operation. This should be used with caution as
+                              unintended consequences such as data loss can occur.
+
+                              When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
+                              performing an upgrade operation.
+                            enum:
+                            - None
+                            - Strict
+                            type: string
+                        required:
+                        - enforcement
+                        type: object
+                    required:
+                    - crdUpgradeSafety
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of [crdUpgradeSafety] are required when
+                        preflight is specified
+                      rule: has(self.crdUpgradeSafety)
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of [preflight] are required when install is
+                    specified
+                  rule: has(self.preflight)
+              namespace:
+                description: |-
+                  namespace is a reference to a Kubernetes namespace.
+                  This is the namespace in which the provided ServiceAccount must exist.
+                  It also designates the default namespace where namespace-scoped resources
+                  for the extension are applied to the cluster.
+                  Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+                  This namespace must exist.
+
+                  namespace is required, immutable, and follows the DNS label standard
+                  as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                  start and end with an alphanumeric character, and be no longer than 63 characters
+
+                  [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                maxLength: 63
+                type: string
+                x-kubernetes-validations:
+                - message: namespace must be a valid DNS1123 label
+                  rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+                - message: self == oldSelf
+                  rule: namespace really is immutable
+              serviceAccount:
+                description: |-
+                  serviceAccount is a reference to a ServiceAccount used to perform all interactions
+                  with the cluster that are required to manage the extension.
+                  The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+                  The ServiceAccount must exist in the namespace referenced in the spec.
+                  serviceAccount is required.
+                properties:
+                  name:
+                    description: |-
+                      name is a required, immutable reference to the name of the ServiceAccount
+                      to be used for installation and management of the content for the package
+                      specified in the packageName field.
+
+                      This ServiceAccount must exist in the installNamespace.
+
+                      name follows the DNS subdomain standard as defined in [RFC 1123].
+                      It must contain only lowercase alphanumeric characters,
+                      hyphens (-) or periods (.), start and end with an alphanumeric character,
+                      and be no longer than 253 characters.
+
+                      Some examples of valid values are:
+                        - some-serviceaccount
+                        - 123-serviceaccount
+                        - 1-serviceaccount-2
+                        - someserviceaccount
+                        - some.serviceaccount
+
+                      Some examples of invalid values are:
+                        - -some-serviceaccount
+                        - some-serviceaccount-
+
+                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                    - message: name must be a valid DNS1123 subdomain. It must contain
+                        only lowercase alphanumeric characters, hyphens (-) or periods
+                        (.), start and end with an alphanumeric character, and be
+                        no longer than 253 characters
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                required:
+                - name
+                type: object
+              source:
+                description: |-
+                  source is a required field which selects the installation source of content
+                  for this ClusterExtension. Selection is performed by setting the sourceType.
+
+                  Catalog is currently the only implemented sourceType, and setting the
+                  sourcetype to "Catalog" requires the catalog field to also be defined.
+
+                  Below is a minimal example of a source definition (in yaml):
+
+                  source:
+                    sourceType: Catalog
+                    catalog:
+                      packageName: example-package
+                properties:
+                  catalog:
+                    description: |-
+                      catalog is used to configure how information is sourced from a catalog.
+                      This field is required when sourceType is "Catalog", and forbidden otherwise.
+
+                      This is the experimental description for Catalog
+                    properties:
+                      channels:
+                        description: |-
+                          channels is an optional reference to a set of channels belonging to
+                          the package specified in the packageName field.
+
+                          A "channel" is a package-author-defined stream of updates for an extension.
+
+                          Each channel in the list must follow the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters. No more than 256 channels can be specified.
+
+                          When specified, it is used to constrain the set of installable bundles and
+                          the automated upgrade path. This constraint is an AND operation with the
+                          version field. For example:
+                            - Given channel is set to "foo"
+                            - Given version is set to ">=1.0.0, <1.5.0"
+                            - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+                            - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+
+                          When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+
+                          Some examples of valid values are:
+                            - 1.1.x
+                            - alpha
+                            - stable
+                            - stable-v1
+                            - v1-stable
+                            - dev-preview
+                            - preview
+                            - community
+
+                          Some examples of invalid values are:
+                            - -some-channel
+                            - some-channel-
+                            - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+                            - original_40
+                            - --default-channel
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        items:
+                          maxLength: 253
+                          type: string
+                          x-kubernetes-validations:
+                          - message: channels entries must be valid DNS1123 subdomains
+                            rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        maxItems: 256
+                        type: array
+                      packageName:
+                        description: |-
+                          packageName is a reference to the name of the package to be installed
+                          and is used to filter the content from catalogs.
+
+                          packageName is required, immutable, and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+
+                          Some examples of valid values are:
+                            - some-package
+                            - 123-package
+                            - 1-package-2
+                            - somepackage
+
+                          Some examples of invalid values are:
+                            - -some-package
+                            - some-package-
+                            - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+                            - some.package
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        maxLength: 253
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName is immutable
+                          rule: self == oldSelf
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      selector:
+                        description: |-
+                          selector is an optional field that can be used
+                          to filter the set of ClusterCatalogs used in the bundle
+                          selection process.
+
+                          When unspecified, all ClusterCatalogs will be used in
+                          the bundle selection process.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      upgradeConstraintPolicy:
+                        default: CatalogProvided
+                        description: |-
+                          upgradeConstraintPolicy is an optional field that controls whether
+                          the upgrade path(s) defined in the catalog are enforced for the package
+                          referenced in the packageName field.
+
+                          Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
+
+                          When this field is set to "CatalogProvided", automatic upgrades will only occur
+                          when upgrade constraints specified by the package author are met.
+
+                          When this field is set to "SelfCertified", the upgrade constraints specified by
+                          the package author are ignored. This allows for upgrades and downgrades to
+                          any version of the package. This is considered a dangerous operation as it
+                          can lead to unknown and potentially disastrous outcomes, such as data
+                          loss. It is assumed that users have independently verified changes when
+                          using this option.
+
+                          When this field is omitted, the default value is "CatalogProvided".
+                        enum:
+                        - CatalogProvided
+                        - SelfCertified
+                        type: string
+                      version:
+                        description: |-
+                          version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+
+                          Acceptable version ranges are no longer than 64 characters.
+                          Version ranges are composed of comma- or space-delimited values and one or
+                          more comparison operators, known as comparison strings. Additional
+                          comparison strings can be added using the OR operator (||).
+
+                          # Range Comparisons
+
+                          To specify a version range, you can use a comparison string like ">=3.0,
+                          <3.6". When specifying a range, automatic updates will occur within that
+                          range. The example comparison string means "install any version greater than
+                          or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+                          upgrades are available within the version range after initial installation,
+                          those upgrades should be automatically performed.
+
+                          # Pinned Versions
+
+                          To specify an exact version to install you can use a version range that
+                          "pins" to a specific version. When pinning to a specific version, no
+                          automatic updates will occur. An example of a pinned version range is
+                          "0.6.0", which means "only install version 0.6.0 and never
+                          upgrade from this version".
+
+                          # Basic Comparison Operators
+
+                          The basic comparison operators and their meanings are:
+                            - "=", equal (not aliased to an operator)
+                            - "!=", not equal
+                            - "<", less than
+                            - ">", greater than
+                            - ">=", greater than OR equal to
+                            - "<=", less than OR equal to
+
+                          # Wildcard Comparisons
+
+                          You can use the "x", "X", and "*" characters as wildcard characters in all
+                          comparison operations. Some examples of using the wildcard characters:
+                            - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+                            - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+                            - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+                            - "x", "X", and "*" is equivalent to ">= 0.0.0"
+
+                          # Patch Release Comparisons
+
+                          When you want to specify a minor version up to the next major version you
+                          can use the "~" character to perform patch comparisons. Some examples:
+                            - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+                            - "~1" and "~1.x" is equivalent to ">=1, <2"
+                            - "~2.3" is equivalent to ">=2.3, <2.4"
+                            - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+
+                          # Major Release Comparisons
+
+                          You can use the "^" character to make major release comparisons after a
+                          stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+                            - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+                            - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+                            - "^2.3" is equivalent to ">=2.3, <3"
+                            - "^2.x" is equivalent to ">=2.0.0, <3"
+                            - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+                            - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+                            - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+                            - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+                            - "^0" is equivalent to ">=0.0.0, <1.0.0"
+
+                          # OR Comparisons
+                          You can use the "||" character to represent an OR operation in the version
+                          range. Some examples:
+                            - ">=1.2.3, <2.0.0 || >3.0.0"
+                            - "^0 || ^3 || ^5"
+
+                          For more information on semver, please see https://semver.org/
+                        maxLength: 64
+                        type: string
+                        x-kubernetes-validations:
+                        - message: invalid version expression
+                          rule: self.matches("^(\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|[x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*]))?(\\.(0|[1-9]\\d*|x|X|\\*))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)((?:\\s+|,\\s*|\\s*\\|\\|\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*))?(\\.(0|[1-9]\\d*|x|X|\\*]))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)*$")
+                    required:
+                    - packageName
+                    type: object
+                  sourceType:
+                    description: |-
+                      sourceType is a required reference to the type of install source.
+
+                      Allowed values are "Catalog"
+
+                      When this field is set to "Catalog", information for determining the
+                      appropriate bundle of content to install will be fetched from
+                      ClusterCatalog resources existing on the cluster.
+                      When using the Catalog sourceType, the catalog field must also be set.
+                    enum:
+                    - Catalog
+                    - NotCatalog
+                    type: string
+                  test:
+                    description: test is a required parameter
+                    type: string
+                required:
+                - sourceType
+                - test
+                type: object
+                x-kubernetes-validations:
+                - message: catalog is required when sourceType is Catalog, and forbidden
+                    otherwise
+                  rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ?
+                    has(self.catalog) : !has(self.catalog)'
+            required:
+            - namespace
+            - serviceAccount
+            - source
+            type: object
+          status:
+            description: status is an optional field that defines the observed state
+              of the ClusterExtension.
+            properties:
+              conditions:
+                description: |-
+                  The set of condition types which apply to all spec.source variations are Installed and Progressing.
+
+                  The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+                  When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+                  When Installed is False and the Reason is Failed, the bundle has failed to install.
+
+                  The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+                  When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                  When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
+                  When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+
+                  When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+                  These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+                  BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+                  ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+                  PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+                  Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              install:
+                description: install is a representation of the current installation
+                  status for this ClusterExtension.
+                properties:
+                  bundle:
+                    description: |-
+                      bundle is a required field which represents the identifying attributes of a bundle.
+
+                      A "bundle" is a versioned set of content that represents the resources that
+                      need to be applied to a cluster to install a package.
+                    properties:
+                      name:
+                        description: |-
+                          name is required and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      version:
+                        description: |-
+                          version is a required field and is a reference to the version that this bundle represents
+                          version follows the semantic versioning standard as defined in https://semver.org/.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: version must be well-formed semver
+                          rule: self.matches("^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
+                    required:
+                    - name
+                    - version
+                    type: object
+                required:
+                - bundle
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/hack/tools/crd-generator/testdata/output/standard/olm.operatorframework.io_clusterextensions.yaml
+++ b/hack/tools/crd-generator/testdata/output/standard/olm.operatorframework.io_clusterextensions.yaml
@@ -1,0 +1,591 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: standard
+  name: clusterextensions.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterExtension
+    listKind: ClusterExtensionList
+    plural: clusterextensions
+    singular: clusterextension
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.install.bundle.name
+      name: Installed Bundle
+      type: string
+    - jsonPath: .status.install.bundle.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Installed')].status
+      name: Installed
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExtension is the Schema for the clusterextensions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is an optional field that defines the desired state
+              of the ClusterExtension.
+            properties:
+              install:
+                description: |-
+                  install is an optional field used to configure the installation options
+                  for the ClusterExtension such as the pre-flight check configuration.
+                properties:
+                  preflight:
+                    description: |-
+                      preflight is an optional field that can be used to configure the checks that are
+                      run before installation or upgrade of the content for the package specified in the packageName field.
+
+                      When specified, it replaces the default preflight configuration for install/upgrade actions.
+                      When not specified, the default configuration will be used.
+                    properties:
+                      crdUpgradeSafety:
+                        description: |-
+                          crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+                          checks that run prior to upgrades of installed content.
+
+                          The CRD Upgrade Safety pre-flight check safeguards from unintended
+                          consequences of upgrading a CRD, such as data loss.
+                        properties:
+                          enforcement:
+                            description: |-
+                              enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
+
+                              Allowed values are "None" or "Strict". The default value is "Strict".
+
+                              When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
+                              when performing an upgrade operation. This should be used with caution as
+                              unintended consequences such as data loss can occur.
+
+                              When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
+                              performing an upgrade operation.
+                            enum:
+                            - None
+                            - Strict
+                            type: string
+                        required:
+                        - enforcement
+                        type: object
+                    required:
+                    - crdUpgradeSafety
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of [crdUpgradeSafety] are required when
+                        preflight is specified
+                      rule: has(self.crdUpgradeSafety)
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of [preflight] are required when install is
+                    specified
+                  rule: has(self.preflight)
+              namespace:
+                description: |-
+                  namespace is a reference to a Kubernetes namespace.
+                  This is the namespace in which the provided ServiceAccount must exist.
+                  It also designates the default namespace where namespace-scoped resources
+                  for the extension are applied to the cluster.
+                  Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+                  This namespace must exist.
+
+                  namespace is required, immutable, and follows the DNS label standard
+                  as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                  start and end with an alphanumeric character, and be no longer than 63 characters
+
+                  [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                maxLength: 63
+                type: string
+                x-kubernetes-validations:
+                - message: namespace must be a valid DNS1123 label
+                  rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+                - message: self == oldSelf
+                  rule: namespace is immutable
+              serviceAccount:
+                description: |-
+                  serviceAccount is a reference to a ServiceAccount used to perform all interactions
+                  with the cluster that are required to manage the extension.
+                  The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+                  The ServiceAccount must exist in the namespace referenced in the spec.
+                  serviceAccount is required.
+                properties:
+                  name:
+                    description: |-
+                      name is a required, immutable reference to the name of the ServiceAccount
+                      to be used for installation and management of the content for the package
+                      specified in the packageName field.
+
+                      This ServiceAccount must exist in the installNamespace.
+
+                      name follows the DNS subdomain standard as defined in [RFC 1123].
+                      It must contain only lowercase alphanumeric characters,
+                      hyphens (-) or periods (.), start and end with an alphanumeric character,
+                      and be no longer than 253 characters.
+
+                      Some examples of valid values are:
+                        - some-serviceaccount
+                        - 123-serviceaccount
+                        - 1-serviceaccount-2
+                        - someserviceaccount
+                        - some.serviceaccount
+
+                      Some examples of invalid values are:
+                        - -some-serviceaccount
+                        - some-serviceaccount-
+
+                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                    - message: name must be a valid DNS1123 subdomain. It must contain
+                        only lowercase alphanumeric characters, hyphens (-) or periods
+                        (.), start and end with an alphanumeric character, and be
+                        no longer than 253 characters
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                required:
+                - name
+                type: object
+              source:
+                description: |-
+                  source is a required field which selects the installation source of content
+                  for this ClusterExtension. Selection is performed by setting the sourceType.
+
+                  Catalog is currently the only implemented sourceType, and setting the
+                  sourcetype to "Catalog" requires the catalog field to also be defined.
+
+                  Below is a minimal example of a source definition (in yaml):
+
+                  source:
+                    sourceType: Catalog
+                    catalog:
+                      packageName: example-package
+                properties:
+                  catalog:
+                    description: |-
+                      catalog is used to configure how information is sourced from a catalog.
+                      This field is required when sourceType is "Catalog", and forbidden otherwise.
+                    properties:
+                      channels:
+                        description: |-
+                          channels is an optional reference to a set of channels belonging to
+                          the package specified in the packageName field.
+
+                          A "channel" is a package-author-defined stream of updates for an extension.
+
+                          Each channel in the list must follow the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters. No more than 256 channels can be specified.
+
+                          When specified, it is used to constrain the set of installable bundles and
+                          the automated upgrade path. This constraint is an AND operation with the
+                          version field. For example:
+                            - Given channel is set to "foo"
+                            - Given version is set to ">=1.0.0, <1.5.0"
+                            - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+                            - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+
+                          When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+
+                          Some examples of valid values are:
+                            - 1.1.x
+                            - alpha
+                            - stable
+                            - stable-v1
+                            - v1-stable
+                            - dev-preview
+                            - preview
+                            - community
+
+                          Some examples of invalid values are:
+                            - -some-channel
+                            - some-channel-
+                            - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+                            - original_40
+                            - --default-channel
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        items:
+                          maxLength: 253
+                          type: string
+                          x-kubernetes-validations:
+                          - message: channels entries must be valid DNS1123 subdomains
+                            rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        maxItems: 256
+                        type: array
+                      packageName:
+                        description: |-
+                          packageName is a reference to the name of the package to be installed
+                          and is used to filter the content from catalogs.
+
+                          packageName is required, immutable, and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+
+                          Some examples of valid values are:
+                            - some-package
+                            - 123-package
+                            - 1-package-2
+                            - somepackage
+
+                          Some examples of invalid values are:
+                            - -some-package
+                            - some-package-
+                            - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+                            - some.package
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        maxLength: 253
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName is immutable
+                          rule: self == oldSelf
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      selector:
+                        description: |-
+                          selector is an optional field that can be used
+                          to filter the set of ClusterCatalogs used in the bundle
+                          selection process.
+
+                          When unspecified, all ClusterCatalogs will be used in
+                          the bundle selection process.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      upgradeConstraintPolicy:
+                        default: CatalogProvided
+                        description: |-
+                          upgradeConstraintPolicy is an optional field that controls whether
+                          the upgrade path(s) defined in the catalog are enforced for the package
+                          referenced in the packageName field.
+
+                          Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
+
+                          When this field is set to "CatalogProvided", automatic upgrades will only occur
+                          when upgrade constraints specified by the package author are met.
+
+                          When this field is set to "SelfCertified", the upgrade constraints specified by
+                          the package author are ignored. This allows for upgrades and downgrades to
+                          any version of the package. This is considered a dangerous operation as it
+                          can lead to unknown and potentially disastrous outcomes, such as data
+                          loss. It is assumed that users have independently verified changes when
+                          using this option.
+
+                          When this field is omitted, the default value is "CatalogProvided".
+                        enum:
+                        - CatalogProvided
+                        - SelfCertified
+                        type: string
+                      version:
+                        description: |-
+                          version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+
+                          Acceptable version ranges are no longer than 64 characters.
+                          Version ranges are composed of comma- or space-delimited values and one or
+                          more comparison operators, known as comparison strings. Additional
+                          comparison strings can be added using the OR operator (||).
+
+                          # Range Comparisons
+
+                          To specify a version range, you can use a comparison string like ">=3.0,
+                          <3.6". When specifying a range, automatic updates will occur within that
+                          range. The example comparison string means "install any version greater than
+                          or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+                          upgrades are available within the version range after initial installation,
+                          those upgrades should be automatically performed.
+
+                          # Pinned Versions
+
+                          To specify an exact version to install you can use a version range that
+                          "pins" to a specific version. When pinning to a specific version, no
+                          automatic updates will occur. An example of a pinned version range is
+                          "0.6.0", which means "only install version 0.6.0 and never
+                          upgrade from this version".
+
+                          # Basic Comparison Operators
+
+                          The basic comparison operators and their meanings are:
+                            - "=", equal (not aliased to an operator)
+                            - "!=", not equal
+                            - "<", less than
+                            - ">", greater than
+                            - ">=", greater than OR equal to
+                            - "<=", less than OR equal to
+
+                          # Wildcard Comparisons
+
+                          You can use the "x", "X", and "*" characters as wildcard characters in all
+                          comparison operations. Some examples of using the wildcard characters:
+                            - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+                            - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+                            - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+                            - "x", "X", and "*" is equivalent to ">= 0.0.0"
+
+                          # Patch Release Comparisons
+
+                          When you want to specify a minor version up to the next major version you
+                          can use the "~" character to perform patch comparisons. Some examples:
+                            - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+                            - "~1" and "~1.x" is equivalent to ">=1, <2"
+                            - "~2.3" is equivalent to ">=2.3, <2.4"
+                            - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+
+                          # Major Release Comparisons
+
+                          You can use the "^" character to make major release comparisons after a
+                          stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+                            - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+                            - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+                            - "^2.3" is equivalent to ">=2.3, <3"
+                            - "^2.x" is equivalent to ">=2.0.0, <3"
+                            - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+                            - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+                            - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+                            - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+                            - "^0" is equivalent to ">=0.0.0, <1.0.0"
+
+                          # OR Comparisons
+                          You can use the "||" character to represent an OR operation in the version
+                          range. Some examples:
+                            - ">=1.2.3, <2.0.0 || >3.0.0"
+                            - "^0 || ^3 || ^5"
+
+                          For more information on semver, please see https://semver.org/
+                        maxLength: 64
+                        type: string
+                        x-kubernetes-validations:
+                        - message: invalid version expression
+                          rule: self.matches("^(\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|[x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*]))?(\\.(0|[1-9]\\d*|x|X|\\*))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)((?:\\s+|,\\s*|\\s*\\|\\|\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*))?(\\.(0|[1-9]\\d*|x|X|\\*]))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)*$")
+                    required:
+                    - packageName
+                    type: object
+                  sourceType:
+                    description: |-
+                      sourceType is a required reference to the type of install source.
+
+                      Allowed values are "Catalog"
+
+                      When this field is set to "Catalog", information for determining the
+                      appropriate bundle of content to install will be fetched from
+                      ClusterCatalog resources existing on the cluster.
+                      When using the Catalog sourceType, the catalog field must also be set.
+                    enum:
+                    - Catalog
+                    type: string
+                required:
+                - sourceType
+                - test
+                type: object
+                x-kubernetes-validations:
+                - message: catalog is required when sourceType is Catalog, and forbidden
+                    otherwise
+                  rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ?
+                    has(self.catalog) : !has(self.catalog)'
+            required:
+            - namespace
+            - serviceAccount
+            - source
+            type: object
+          status:
+            description: status is an optional field that defines the observed state
+              of the ClusterExtension.
+            properties:
+              conditions:
+                description: |-
+                  The set of condition types which apply to all spec.source variations are Installed and Progressing.
+
+                  The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+                  When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+                  When Installed is False and the Reason is Failed, the bundle has failed to install.
+
+                  The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+                  When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                  When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
+                  When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+
+                  When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+                  These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+                  BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+                  ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+                  PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+                  Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              install:
+                description: install is a representation of the current installation
+                  status for this ClusterExtension.
+                properties:
+                  bundle:
+                    description: |-
+                      bundle is a required field which represents the identifying attributes of a bundle.
+
+                      A "bundle" is a versioned set of content that represents the resources that
+                      need to be applied to a cluster to install a package.
+                    properties:
+                      name:
+                        description: |-
+                          name is required and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                      version:
+                        description: |-
+                          version is a required field and is a reference to the version that this bundle represents
+                          version follows the semantic versioning standard as defined in https://semver.org/.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: version must be well-formed semver
+                          rule: self.matches("^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
+                    required:
+                    - name
+                    - version
+                    type: object
+                required:
+                - bundle
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/hack/tools/update-crds.sh
+++ b/hack/tools/update-crds.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# This uses a custom CRD generator to create "standard" and "experimental" CRDs
+
+# The names of the generated CRDs
+CE="olm.operatorframework.io_clusterextensions.yaml"
+CC="olm.operatorframework.io_clustercatalogs.yaml"
+
+# order for modules and crds must match
+# each item in crds must be unique, and should be associated with a module
+modules=("operator-controller" "catalogd")
+crds=("${CE}" "${CC}")
+
+# Channels must much those in the generator
+channels=("standard" "experimental")
+
+# Create the temp output directories
+CRD_TMP=$(mktemp -d)
+for c in ${channels[@]}; do
+    mkdir -p ${CRD_TMP}/${c}
+done
+
+# This calculates the controller-tools version, to keep the annotation correct
+CONTROLLER_TOOLS_VER=$(go list -m sigs.k8s.io/controller-tools | awk '{print $2}')
+
+# Generate the CRDs
+go run ./hack/tools/crd-generator ${CRD_TMP} ${CONTROLLER_TOOLS_VER}
+
+# Create the destination directories for each base/channel combo
+for c in ${channels[@]}; do
+    for b in ${modules[@]}; do
+        mkdir -p config/base/${b}/crd/${c}
+    done
+done
+
+# Copy the generated files
+for b in ${!modules[@]}; do
+    for c in ${channels[@]}; do
+        cp ${CRD_TMP}/${c}/${crds[${b}]} config/base/${modules[${b}]}/crd/${c}
+    done
+done
+
+# Clean up the temp output directories
+rm -rf ${CRD_TMP}

--- a/internal/operator-controller/controllers/suite_test.go
+++ b/internal/operator-controller/controllers/suite_test.go
@@ -138,7 +138,7 @@ var (
 func TestMain(m *testing.M) {
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "config", "base", "operator-controller", "crd", "bases"),
+			filepath.Join("..", "..", "..", "config", "base", "operator-controller", "crd", "standard"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -12,6 +12,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: standard
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -453,6 +454,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    olm.operatorframework.io/feature-set: standard
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io


### PR DESCRIPTION
Fix #2014

Add support for a new CRD generator. This generator will use `opcon`
tags to identify experimental features. A script runs the CRD
generation, and creates all the CRDs.

New experimental CRDs are now created.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
