### PR TITLE
:seedling: Ease CI requirements for codecov patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,10 @@ coverage:
       default:
         target: auto
         threshold: 2%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
   paths:
     - "api/"
     - "cmd/"


### PR DESCRIPTION
Update codecov patch threshold

We often see +/- very small changes to the patch threashold which end up reporting as a failure. Set the threshold to 1% so these -0.05% changes don't impact us as much.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
