### PR TITLE
:bug: fix install and upgrade e2es

### DIFF
--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
@@ -2,11 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-configmap
-  annotations:
-    shouldNotTemplate: >
-      The namespace is {{ $labels.namespace }}. The templated
-      $labels.namespace is NOT expected to be processed by OLM's
-      rendering engine for registry+v1 bundles.
 data:
   version: "v1.0.0"
   name: "test-configmap"

--- a/testdata/images/bundles/test-operator/v2.0.0/manifests/bundle.configmap.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/manifests/bundle.configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  annotations:
+    shouldNotTemplate: >
+      The namespace is {{ $labels.namespace }}. The templated
+      $labels.namespace is NOT expected to be processed by OLM's
+      rendering engine for registry+v1 bundles.
+data:
+  version: "v2.0.0"
+  name: "test-configmap"

--- a/testdata/images/bundles/test-operator/v2.0.0/manifests/olm.operatorframework.com_olme2etest.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/manifests/olm.operatorframework.com_olme2etest.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: olme2etests.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: OLME2ETest
+    listKind: OLME2ETestList
+    plural: olme2etests
+    singular: olme2etest
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                testField:
+                  type: string

--- a/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.clusterserviceversion.yaml
@@ -1,0 +1,141 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "olme2etests.olm.operatorframework.io/v1",
+          "kind": "OLME2ETests",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "test"
+            },
+            "name": "test-sample"
+          },
+          "spec": null
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2024-10-24T19:21:40Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: testoperator.v2.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+  owned:
+    - description: Configures subsections of Alertmanager configuration specific to each namespace
+      displayName: OLME2ETest
+      kind: OLME2ETest
+      name: olme2etests.olm.operatorframework.io
+      version: v1
+  description: OLM E2E Testing Operator
+  displayName: test-operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments:
+      - label:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/name: test-operator
+          app.kubernetes.io/version: 2.0.0
+        name: test-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: olme2etest
+          template:
+            metadata:
+              labels:
+                app: olme2etest
+            spec:
+              terminationGracePeriodSeconds: 0
+              containers:
+              - name: busybox
+                image: busybox
+                command:
+                - 'sleep'
+                - '1000'
+                securityContext:
+                  runAsUser: 1000
+                  runAsNonRoot: true
+                serviceAccountName: simple-bundle-manager
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: simple-bundle-manager
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: simple-bundle-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - registry
+  links:
+  - name: simple-bundle
+    url: https://simple-bundle.domain
+  maintainers:
+  - email: main#simple-bundle.domain
+    name: Simple Bundle
+  maturity: beta
+  provider:
+    name: Simple Bundle
+    url: https://simple-bundle.domain
+  version: 2.0.0

--- a/testdata/images/bundles/test-operator/v2.0.0/metadata/annotations.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: test
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown

--- a/testdata/images/catalogs/test-catalog/v2/configs/catalog.yaml
+++ b/testdata/images/catalogs/test-catalog/v2/configs/catalog.yaml
@@ -13,7 +13,7 @@ entries:
 schema: olm.bundle
 name: test-operator.2.0.0
 package: test
-image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/test-operator:v1.0.0
+image: docker-registry.operator-controller-e2e.svc.cluster.local:5000/bundles/registry-v1/test-operator:v2.0.0
 properties:
   - type: olm.package
     value:

--- a/testdata/push/push.go
+++ b/testdata/push/push.go
@@ -45,11 +45,15 @@ func main() {
 	}
 	// Push the images
 	for name, image := range bundles {
-		if err := crane.Push(image, fmt.Sprintf("%s/%s", registryAddr, name)); err != nil {
+		dest := fmt.Sprintf("%s/%s", registryAddr, name)
+		log.Printf("pushing bundle %s to %s", name, dest)
+		if err := crane.Push(image, dest); err != nil {
 			log.Fatalf("failed to push bundle images: %s", err.Error())
 		}
 	}
 	for name, image := range catalogs {
+		dest := fmt.Sprintf("%s/%s", registryAddr, name)
+		log.Printf("pushing catalog %s to %s", name, dest)
 		if err := crane.Push(image, fmt.Sprintf("%s/%s", registryAddr, name)); err != nil {
 			log.Fatalf("failed to push catalog images: %s", err.Error())
 		}


### PR DESCRIPTION
Follow-up on #1979:

- make upgrade-e2e pass again
- fix ClusterExtensionInstallReResolvesWhenCatalogIsPatched

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
