### PR TITLE
:bug: Fix webhook service rotation to renew within 24h of expiry

### DIFF
--- a/internal/operator-controller/rukpak/render/certproviders/certmanager.go
+++ b/internal/operator-controller/rukpak/render/certproviders/certmanager.go
@@ -20,6 +20,7 @@ import (
 const (
 	certManagerInjectCAAnnotation = "cert-manager.io/inject-ca-from"
 	olmv0RotationPeriod           = 730 * 24 * time.Hour // 2 year rotation
+	olmv0RenewBefore              = 24 * time.Hour       // renew certificate within 24h of expiry
 )
 
 var _ render.CertificateProvider = (*CertManagerCertificateProvider)(nil)
@@ -55,6 +56,7 @@ func (p CertManagerCertificateProvider) AdditionalObjects(cfg render.Certificate
 	// OLMv0 parity:
 	// - self-signed issuer
 	// - 2 year rotation period
+	// - renew 24h before expiry
 	// - CN: argocd-operator-controller-manager-service.argocd (<deploymentName>-service.<namespace>)
 	// - CA: false
 	// - DNS:argocd-operator-controller-manager-service.argocd, DNS:argocd-operator-controller-manager-service.argocd.svc, DNS:argocd-operator-controller-manager-service.argocd.svc.cluster.local
@@ -164,6 +166,9 @@ func (p CertManagerCertificateProvider) AdditionalObjects(cfg render.Certificate
 			},
 			Duration: &metav1.Duration{
 				Duration: olmv0RotationPeriod,
+			},
+			RenewBefore: &metav1.Duration{
+				Duration: olmv0RenewBefore,
 			},
 		},
 	}

--- a/internal/operator-controller/rukpak/render/certproviders/certmanager_test.go
+++ b/internal/operator-controller/rukpak/render/certproviders/certmanager_test.go
@@ -143,6 +143,10 @@ func Test_CertManagerProvider_AdditionalObjects(t *testing.T) {
 					// OLMv0 has a 2 year certificate rotation period
 					Duration: 730 * 24 * time.Hour,
 				},
+				RenewBefore: &metav1.Duration{
+					// OLMv0 reviews 24h before expiry
+					Duration: 24 * time.Hour,
+				},
 			},
 		}),
 	}, objs)


### PR DESCRIPTION
# Description

Currently, the generated webhook certificate is set to rotate 1 year before expiry. In this PR we set it to 24h to keep parity with OLMv0 behavior.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
