### PR TITLE
:seedling: Bundle renderer refactor webhook service related function and attribute naming

### DIFF
--- a/internal/operator-controller/rukpak/render/certprovider.go
+++ b/internal/operator-controller/rukpak/render/certprovider.go
@@ -28,10 +28,10 @@ type CertSecretInfo struct {
 // CertificateProvisionerConfig contains the necessary information for a CertificateProvider
 // to correctly generate and modify object for certificate injection and automation
 type CertificateProvisionerConfig struct {
-	WebhookServiceName string
-	CertName           string
-	Namespace          string
-	CertProvider       CertificateProvider
+	ServiceName  string
+	CertName     string
+	Namespace    string
+	CertProvider CertificateProvider
 }
 
 // CertificateProvisioner uses a CertificateProvider to modify and generate objects based on its
@@ -70,9 +70,9 @@ func CertProvisionerFor(deploymentName string, opts Options) CertificateProvisio
 	certName := util.ObjectNameForBaseAndSuffix(webhookServiceName, "cert")
 
 	return CertificateProvisioner{
-		CertProvider:       opts.CertificateProvider,
-		WebhookServiceName: webhookServiceName,
-		Namespace:          opts.InstallNamespace,
-		CertName:           certName,
+		CertProvider: opts.CertificateProvider,
+		ServiceName:  webhookServiceName,
+		Namespace:    opts.InstallNamespace,
+		CertName:     certName,
 	}
 }

--- a/internal/operator-controller/rukpak/render/certprovider_test.go
+++ b/internal/operator-controller/rukpak/render/certprovider_test.go
@@ -16,10 +16,10 @@ import (
 
 func Test_CertificateProvisioner_WithoutCertProvider(t *testing.T) {
 	provisioner := &render.CertificateProvisioner{
-		WebhookServiceName: "webhook",
-		CertName:           "cert",
-		Namespace:          "namespace",
-		CertProvider:       nil,
+		ServiceName:  "webhook",
+		CertName:     "cert",
+		Namespace:    "namespace",
+		CertProvider: nil,
 	}
 
 	require.NoError(t, provisioner.InjectCABundle(&corev1.Secret{}))
@@ -50,10 +50,10 @@ func Test_CertificateProvisioner_WithCertProvider(t *testing.T) {
 		},
 	}
 	provisioner := &render.CertificateProvisioner{
-		WebhookServiceName: "webhook",
-		CertName:           "cert",
-		Namespace:          "namespace",
-		CertProvider:       fakeProvider,
+		ServiceName:  "webhook",
+		CertName:     "cert",
+		Namespace:    "namespace",
+		CertProvider: fakeProvider,
 	}
 
 	svc := &corev1.Service{}
@@ -83,10 +83,10 @@ func Test_CertificateProvisioner_Errors(t *testing.T) {
 		},
 	}
 	provisioner := &render.CertificateProvisioner{
-		WebhookServiceName: "webhook",
-		CertName:           "cert",
-		Namespace:          "namespace",
-		CertProvider:       fakeProvider,
+		ServiceName:  "webhook",
+		CertName:     "cert",
+		Namespace:    "namespace",
+		CertProvider: fakeProvider,
 	}
 
 	err := provisioner.InjectCABundle(&corev1.Service{})
@@ -107,7 +107,7 @@ func Test_CertProvisionerFor(t *testing.T) {
 	})
 
 	require.Equal(t, prov.CertProvider, fakeProvider)
-	require.Equal(t, "my-deployment-thing-service", prov.WebhookServiceName)
+	require.Equal(t, "my-deployment-thing-service", prov.ServiceName)
 	require.Equal(t, "my-deployment-thing-service-cert", prov.CertName)
 	require.Equal(t, "my-namespace", prov.Namespace)
 }
@@ -115,8 +115,8 @@ func Test_CertProvisionerFor(t *testing.T) {
 func Test_CertProvisionerFor_ExtraLargeName_MoreThan63Chars(t *testing.T) {
 	prov := render.CertProvisionerFor("my.object.thing.has.a.really.really.really.really.really.long.name", render.Options{})
 
-	require.Len(t, prov.WebhookServiceName, 63)
+	require.Len(t, prov.ServiceName, 63)
 	require.Len(t, prov.CertName, 63)
-	require.Equal(t, "my-object-thing-has-a-really-really-really-really-reall-service", prov.WebhookServiceName)
+	require.Equal(t, "my-object-thing-has-a-really-really-really-really-reall-service", prov.ServiceName)
 	require.Equal(t, "my-object-thing-has-a-really-really-really-really-reall-se-cert", prov.CertName)
 }

--- a/internal/operator-controller/rukpak/render/certproviders/certmanager.go
+++ b/internal/operator-controller/rukpak/render/certproviders/certmanager.go
@@ -151,13 +151,13 @@ func (p CertManagerCertificateProvider) AdditionalObjects(cfg render.Certificate
 		},
 		Spec: certmanagerv1.CertificateSpec{
 			SecretName: cfg.CertName,
-			CommonName: fmt.Sprintf("%s.%s", cfg.WebhookServiceName, cfg.Namespace),
+			CommonName: fmt.Sprintf("%s.%s", cfg.ServiceName, cfg.Namespace),
 			Usages:     []certmanagerv1.KeyUsage{certmanagerv1.UsageServerAuth},
 			IsCA:       false,
 			DNSNames: []string{
-				fmt.Sprintf("%s.%s", cfg.WebhookServiceName, cfg.Namespace),
-				fmt.Sprintf("%s.%s.svc", cfg.WebhookServiceName, cfg.Namespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local", cfg.WebhookServiceName, cfg.Namespace),
+				fmt.Sprintf("%s.%s", cfg.ServiceName, cfg.Namespace),
+				fmt.Sprintf("%s.%s.svc", cfg.ServiceName, cfg.Namespace),
+				fmt.Sprintf("%s.%s.svc.cluster.local", cfg.ServiceName, cfg.Namespace),
 			},
 			IssuerRef: certmanagermetav1.ObjectReference{
 				Name: issuer.GetName(),

--- a/internal/operator-controller/rukpak/render/certproviders/certmanager_test.go
+++ b/internal/operator-controller/rukpak/render/certproviders/certmanager_test.go
@@ -30,9 +30,9 @@ func Test_CertManagerProvider_InjectCABundle(t *testing.T) {
 			name: "injects certificate annotation in validating webhook configuration",
 			obj:  &admissionregistrationv1.ValidatingWebhookConfiguration{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
@@ -46,9 +46,9 @@ func Test_CertManagerProvider_InjectCABundle(t *testing.T) {
 			name: "injects certificate annotation in mutating webhook configuration",
 			obj:  &admissionregistrationv1.MutatingWebhookConfiguration{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
@@ -62,9 +62,9 @@ func Test_CertManagerProvider_InjectCABundle(t *testing.T) {
 			name: "injects certificate annotation in custom resource definition",
 			obj:  &apiextensionsv1.CustomResourceDefinition{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &apiextensionsv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
@@ -78,9 +78,9 @@ func Test_CertManagerProvider_InjectCABundle(t *testing.T) {
 			name: "ignores other objects",
 			obj:  &corev1.Service{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &corev1.Service{},
 		},
@@ -96,9 +96,9 @@ func Test_CertManagerProvider_InjectCABundle(t *testing.T) {
 func Test_CertManagerProvider_AdditionalObjects(t *testing.T) {
 	certProvier := certproviders.CertManagerCertificateProvider{}
 	objs, err := certProvier.AdditionalObjects(render.CertificateProvisionerConfig{
-		WebhookServiceName: "webhook-service",
-		Namespace:          "namespace",
-		CertName:           "cert-name",
+		ServiceName: "webhook-service",
+		Namespace:   "namespace",
+		CertName:    "cert-name",
 	})
 	require.NoError(t, err)
 	require.Equal(t, []unstructured.Unstructured{
@@ -151,9 +151,9 @@ func Test_CertManagerProvider_AdditionalObjects(t *testing.T) {
 func Test_CertManagerProvider_GetCertSecretInfo(t *testing.T) {
 	certProvier := certproviders.CertManagerCertificateProvider{}
 	certInfo := certProvier.GetCertSecretInfo(render.CertificateProvisionerConfig{
-		WebhookServiceName: "webhook-service",
-		Namespace:          "namespace",
-		CertName:           "cert-name",
+		ServiceName: "webhook-service",
+		Namespace:   "namespace",
+		CertName:    "cert-name",
 	})
 	require.Equal(t, render.CertSecretInfo{
 		SecretName:     "cert-name",

--- a/internal/operator-controller/rukpak/render/certproviders/openshift_serviceca_test.go
+++ b/internal/operator-controller/rukpak/render/certproviders/openshift_serviceca_test.go
@@ -25,9 +25,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 			name: "injects inject-cabundle annotation in validating webhook configuration",
 			obj:  &admissionregistrationv1.ValidatingWebhookConfiguration{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
@@ -41,9 +41,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 			name: "injects inject-cabundle annotation in mutating webhook configuration",
 			obj:  &admissionregistrationv1.MutatingWebhookConfiguration{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
@@ -57,9 +57,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 			name: "injects inject-cabundle annotation in custom resource definition",
 			obj:  &apiextensionsv1.CustomResourceDefinition{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &apiextensionsv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
@@ -73,9 +73,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 			name: "injects serving-cert-secret-name annotation in service resource referencing the certificate name",
 			obj:  &corev1.Service{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -89,9 +89,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 			name: "ignores other objects",
 			obj:  &corev1.Secret{},
 			cfg: render.CertificateProvisionerConfig{
-				WebhookServiceName: "webhook-service",
-				Namespace:          "namespace",
-				CertName:           "cert-name",
+				ServiceName: "webhook-service",
+				Namespace:   "namespace",
+				CertName:    "cert-name",
 			},
 			expectedObj: &corev1.Secret{},
 		},
@@ -107,9 +107,9 @@ func Test_OpenshiftServiceCAProvider_InjectCABundle(t *testing.T) {
 func Test_OpenshiftServiceCAProvider_AdditionalObjects(t *testing.T) {
 	certProvider := certproviders.OpenshiftServiceCaCertificateProvider{}
 	objs, err := certProvider.AdditionalObjects(render.CertificateProvisionerConfig{
-		WebhookServiceName: "webhook-service",
-		Namespace:          "namespace",
-		CertName:           "cert-name",
+		ServiceName: "webhook-service",
+		Namespace:   "namespace",
+		CertName:    "cert-name",
 	})
 	require.NoError(t, err)
 	require.Nil(t, objs)
@@ -118,9 +118,9 @@ func Test_OpenshiftServiceCAProvider_AdditionalObjects(t *testing.T) {
 func Test_OpenshiftServiceCAProvider_GetCertSecretInfo(t *testing.T) {
 	certProvider := certproviders.OpenshiftServiceCaCertificateProvider{}
 	certInfo := certProvider.GetCertSecretInfo(render.CertificateProvisionerConfig{
-		WebhookServiceName: "webhook-service",
-		Namespace:          "namespace",
-		CertName:           "cert-name",
+		ServiceName: "webhook-service",
+		Namespace:   "namespace",
+		CertName:    "cert-name",
 	})
 	require.Equal(t, render.CertSecretInfo{
 		SecretName:     "cert-name",

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
@@ -379,10 +379,10 @@ func BundleMutatingWebhookResourceGenerator(rv1 *bundle.RegistryV1, opts render.
 	return objs, nil
 }
 
-// BundleWebhookServiceResourceGenerator generates Service resources based that support the webhooks defined in
-// the bundle's cluster service version spec. The resource is modified by the CertificateProvider in opts
+// BundleDeploymentServiceResourceGenerator generates Service resources that support, e.g. the webhooks,
+// defined in the bundle's cluster service version spec. The resource is modified by the CertificateProvider in opts
 // to add any annotations or modifications necessary for certificate injection.
-func BundleWebhookServiceResourceGenerator(rv1 *bundle.RegistryV1, opts render.Options) ([]client.Object, error) {
+func BundleDeploymentServiceResourceGenerator(rv1 *bundle.RegistryV1, opts render.Options) ([]client.Object, error) {
 	if rv1 == nil {
 		return nil, fmt.Errorf("bundle cannot be nil")
 	}

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
@@ -241,7 +241,7 @@ func BundleCRDGenerator(rv1 *bundle.RegistryV1, opts render.Options) ([]client.O
 					ClientConfig: &apiextensionsv1.WebhookClientConfig{
 						Service: &apiextensionsv1.ServiceReference{
 							Namespace: opts.InstallNamespace,
-							Name:      certProvisioner.WebhookServiceName,
+							Name:      certProvisioner.ServiceName,
 							Path:      &conversionWebhookPath,
 							Port:      &cw.ContainerPort,
 						},
@@ -314,7 +314,7 @@ func BundleValidatingWebhookResourceGenerator(rv1 *bundle.RegistryV1, opts rende
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
 							Namespace: opts.InstallNamespace,
-							Name:      certProvisioner.WebhookServiceName,
+							Name:      certProvisioner.ServiceName,
 							Path:      wh.WebhookPath,
 							Port:      &wh.ContainerPort,
 						},
@@ -362,7 +362,7 @@ func BundleMutatingWebhookResourceGenerator(rv1 *bundle.RegistryV1, opts render.
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{
 						Service: &admissionregistrationv1.ServiceReference{
 							Namespace: opts.InstallNamespace,
-							Name:      certProvisioner.WebhookServiceName,
+							Name:      certProvisioner.ServiceName,
 							Path:      wh.WebhookPath,
 							Port:      &wh.ContainerPort,
 						},
@@ -415,7 +415,7 @@ func BundleWebhookServiceResourceGenerator(rv1 *bundle.RegistryV1, opts render.O
 
 		certProvisioner := render.CertProvisionerFor(deploymentSpec.Name, opts)
 		serviceResource := CreateServiceResource(
-			certProvisioner.WebhookServiceName,
+			certProvisioner.ServiceName,
 			opts.InstallNamespace,
 			WithServiceSpec(
 				corev1.ServiceSpec{

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
@@ -2000,7 +2000,7 @@ func Test_BundleMutatingWebhookResourceGenerator_FailsOnNil(t *testing.T) {
 	require.Contains(t, err.Error(), "bundle cannot be nil")
 }
 
-func Test_BundleWebhookServiceResourceGenerator_Succeeds(t *testing.T) {
+func Test_BundleDeploymentServiceResourceGenerator_Succeeds(t *testing.T) {
 	fakeProvider := FakeCertProvider{
 		InjectCABundleFn: func(obj client.Object, cfg render.CertificateProvisionerConfig) error {
 			obj.SetAnnotations(map[string]string{
@@ -2414,14 +2414,14 @@ func Test_BundleWebhookServiceResourceGenerator_Succeeds(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			objs, err := generators.BundleWebhookServiceResourceGenerator(tc.bundle, tc.opts)
+			objs, err := generators.BundleDeploymentServiceResourceGenerator(tc.bundle, tc.opts)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedResources, objs)
 		})
 	}
 }
 
-func Test_BundleWebhookServiceResourceGenerator_FailsOnNil(t *testing.T) {
+func Test_BundleDeploymentServiceResourceGenerator_FailsOnNil(t *testing.T) {
 	objs, err := generators.BundleMutatingWebhookResourceGenerator(nil, render.Options{})
 	require.Nil(t, objs)
 	require.Error(t, err)

--- a/internal/operator-controller/rukpak/render/registryv1/registryv1.go
+++ b/internal/operator-controller/rukpak/render/registryv1/registryv1.go
@@ -43,6 +43,6 @@ var ResourceGenerators = []render.ResourceGenerator{
 	generators.BundleCSVDeploymentGenerator,
 	generators.BundleValidatingWebhookResourceGenerator,
 	generators.BundleMutatingWebhookResourceGenerator,
-	generators.BundleWebhookServiceResourceGenerator,
+	generators.BundleDeploymentServiceResourceGenerator,
 	generators.CertProviderResourceGenerator,
 }

--- a/internal/operator-controller/rukpak/render/registryv1/registryv1_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/registryv1_test.go
@@ -50,7 +50,7 @@ func Test_ResourceGeneratorsHasAllGenerators(t *testing.T) {
 		generators.BundleCSVDeploymentGenerator,
 		generators.BundleValidatingWebhookResourceGenerator,
 		generators.BundleMutatingWebhookResourceGenerator,
-		generators.BundleWebhookServiceResourceGenerator,
+		generators.BundleDeploymentServiceResourceGenerator,
 		generators.CertProviderResourceGenerator,
 	}
 	actualGenerators := registryv1.ResourceGenerators


### PR DESCRIPTION
# Description

Minor refactor renaming the WebhookServiceGenerator and WebhookService attribute in the cert provider configuration. The naming is not accurate in the sense that the service is not necessarily exclusive to webhooks. In some future, if we want to implement, e.g. APIService support, the same service will be used. These are rather services that are backed by the deployments in described in the CSV.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
