### PR TITLE
:bug: Fix webhook cert duplicate volume mount path bug

### DIFF
--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
@@ -26,6 +26,11 @@ import (
 	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/util"
 )
 
+const (
+	tlsCrtPath = "tls.crt"
+	tlsKeyPath = "tls.key"
+)
+
 var certVolumeMounts = map[string]corev1.VolumeMount{
 	"webhook-cert": {
 		Name:      "webhook-cert",
@@ -491,11 +496,11 @@ func addCertVolumesToDeployment(dep *appsv1.Deployment, certSecretInfo render.Ce
 						Items: []corev1.KeyToPath{
 							{
 								Key:  certSecretInfo.CertificateKey,
-								Path: "tls.crt",
+								Path: tlsCrtPath,
 							},
 							{
 								Key:  certSecretInfo.PrivateKeyKey,
-								Path: "tls.key",
+								Path: tlsKeyPath,
 							},
 						},
 					},

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
@@ -27,10 +27,6 @@ import (
 )
 
 var certVolumeMounts = map[string]corev1.VolumeMount{
-	"apiservice-cert": {
-		Name:      "apiservice-cert",
-		MountPath: "/apiserver.local.config/certificates",
-	},
 	"webhook-cert": {
 		Name:      "webhook-cert",
 		MountPath: "/tmp/k8s-webhook-server/serving-certs",
@@ -488,23 +484,6 @@ func addCertVolumesToDeployment(dep *appsv1.Deployment, certSecretInfo render.Ce
 		}),
 		[]corev1.Volume{
 			{
-				Name: "apiservice-cert",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: certSecretInfo.SecretName,
-						Items: []corev1.KeyToPath{
-							{
-								Key:  certSecretInfo.CertificateKey,
-								Path: "apiserver.crt",
-							},
-							{
-								Key:  certSecretInfo.PrivateKeyKey,
-								Path: "apiserver.key",
-							},
-						},
-					},
-				},
-			}, {
 				Name: "webhook-cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
@@ -173,7 +173,7 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 		},
 	}
 
-	bundle := &bundle.RegistryV1{
+	b := &bundle.RegistryV1{
 		CSV: MakeCSV(
 			WithWebhookDefinitions(
 				v1alpha1.WebhookDescription{
@@ -189,12 +189,6 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 							Spec: corev1.PodSpec{
 								Volumes: []corev1.Volume{
 									{
-										Name: "apiservice-cert",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{},
-										},
-									},
-									{
 										Name: "some-other-mount",
 										VolumeSource: corev1.VolumeSource{
 											EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -206,7 +200,6 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 									{
 										Name: "container-1",
 										VolumeMounts: []corev1.VolumeMount{
-											// expect apiservice-cert volume to be injected
 											{
 												Name:      "webhook-cert",
 												MountPath: "/webhook-cert-path",
@@ -229,7 +222,7 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 		),
 	}
 
-	objs, err := generators.BundleCSVDeploymentGenerator(bundle, render.Options{
+	objs, err := generators.BundleCSVDeploymentGenerator(b, render.Options{
 		InstallNamespace:    "install-namespace",
 		CertificateProvider: fakeProvider,
 	})
@@ -247,23 +240,6 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 			},
 		},
 		{
-			Name: "apiservice-cert",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "some-secret",
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "some-cert-key",
-							Path: "apiserver.crt",
-						},
-						{
-							Key:  "some-private-key-key",
-							Path: "apiserver.key",
-						},
-					},
-				},
-			},
-		}, {
 			Name: "webhook-cert",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
@@ -291,10 +267,6 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 					MountPath: "/some/other/mount/path",
 				},
 				{
-					Name:      "apiservice-cert",
-					MountPath: "/apiserver.local.config/certificates",
-				},
-				{
 					Name:      "webhook-cert",
 					MountPath: "/tmp/k8s-webhook-server/serving-certs",
 				},
@@ -303,10 +275,6 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 		{
 			Name: "container-2",
 			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "apiservice-cert",
-					MountPath: "/apiserver.local.config/certificates",
-				},
 				{
 					Name:      "webhook-cert",
 					MountPath: "/tmp/k8s-webhook-server/serving-certs",

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
@@ -194,18 +194,33 @@ func Test_BundleCSVDeploymentGenerator_WithCertWithCertProvider_Succeeds(t *test
 											EmptyDir: &corev1.EmptyDirVolumeSource{},
 										},
 									},
-									// expect webhook-cert volume to be injected
+									// this volume should be replaced by the webhook-cert volume
+									// because it has a volume mount targeting the protected path
+									// /tmp/k8s-webhook-server/serving-certs
+									{
+										Name: "some-webhook-cert-mount",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
 								},
 								Containers: []corev1.Container{
 									{
 										Name: "container-1",
 										VolumeMounts: []corev1.VolumeMount{
+											// the mount path for this volume mount will be replaced with
+											// /tmp/k8s-webhook-server/serving-certs
 											{
 												Name:      "webhook-cert",
 												MountPath: "/webhook-cert-path",
 											}, {
 												Name:      "some-other-mount",
 												MountPath: "/some/other/mount/path",
+											},
+											// this volume mount will be removed
+											{
+												Name:      "some-webhook-cert-mount",
+												MountPath: "/tmp/k8s-webhook-server/serving-certs",
 											},
 										},
 									},


### PR DESCRIPTION
# Description

1. Removes the APIService volume mount - since we don't yet support APIServices (let's avoid adding things that aren't needed yet)
2. Moves the tls.crt and tls.key magic strings to constants
3. Addresses the following bug:

When installing the Red Hat Network Observability operator, we were faced with the following error:

```
"error for resolved bundle \"network-observability-operator.v1.7.0\" with version \"1.7.0\": failed to create resource: Deployment.apps \"netobserv-controller-manager\" is invalid: spec.template.spec.containers[0].volumeMounts[2].mountPath: Invalid value: \"/tmp/k8s-webhook-server/serving-certs\": must be unique",
```

The root cause is related to the operator's `Deployment`'s `Pod` template spec described in the CSV that included a volume mount pointing to the webhook certificate volume mount path (but had a different name than 'webhook-cert'):

```
volumeMounts:
- mountPath: /tmp/k8s-webhook-server/serving-certs
  name: cert
  readOnly: true
```

This PR updates the bundle deployment generator to replace any volume/mount referencing a protected path with the OLM generated values.

Before fixes, OLMv1 generated a deployment like:

```
volumeMounts:
- mountPath: /tmp/k8s-webhook-server/serving-certs
  name: cert
- mountPath: /etc/tls/private
  name: manager-metric-tls
  readOnly: true
- mountPath: /apiserver.local.config/certificates
  name: apiservice-cert
- mountPath: /tmp/k8s-webhook-server/serving-certs
  name: webhook-cert
```

```
volumes:
- name: cert
  secret:
    defaultMode: 420
    secretName: webhook-server-cert
- name: manager-metric-tls
  secret:
    defaultMode: 420
    secretName: manager-metrics-tls
- name: apiservice-cert
  secret:
    items:
    - key: tls.crt
      path: apiserver.crt
    - key: tls.key
      path: apiserver.key
    secretName: netobserv-controller-manager-service-cert
- name: webhook-cert
  secret:
    items:
    - key: tls.crt
      path: tls.crt
    - key: tls.key
      path: tls.key
    secretName: netobserv-controller-manager-service-cert
```
 
Now, it looks like:

```
volumeMounts:
- mountPath: /etc/tls/private
  name: manager-metric-tls
  readOnly: true
- mountPath: /tmp/k8s-webhook-server/serving-certs
  name: webhook-cert
```

```
volumes:
- name: manager-metric-tls
  secret:
    defaultMode: 420
    secretName: manager-metrics-tls
- name: webhook-cert
  secret:
    items:
    - key: tls.crt
      path: tls.crt
    - key: tls.key
      path: tls.key
    secretName: netobserv-controller-manager-service-cert
```

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
