### PR TITLE
✨ set `readOnlyRootFilesystem: true` for workloads

### DIFF
--- a/.tilt-support
+++ b/.tilt-support
@@ -67,6 +67,7 @@ COPY {} /
         live_update=[
             sync('.tiltbuild/bin/{}'.format(binary_name), '/{}'.format(binary_name)),
         ],
+        restart_file="/.tilt_restart_proc",
         # The command to run in the container.
         entrypoint=entrypoint,
     )

--- a/config/base/catalogd/manager/manager.yaml
+++ b/config/base/catalogd/manager/manager.yaml
@@ -52,8 +52,11 @@ spec:
         volumeMounts:
             - name: cache
               mountPath: /var/cache/
+            - name: tmp
+              mountPath: /tmp
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - ALL
@@ -79,4 +82,6 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cache
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}

--- a/config/base/operator-controller/manager/manager.yaml
+++ b/config/base/operator-controller/manager/manager.yaml
@@ -52,8 +52,11 @@ spec:
         volumeMounts:
           - name: cache
             mountPath: /var/cache
+          - name: tmp
+            mountPath: /tmp
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"
@@ -69,8 +72,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           requests:
             cpu: 10m
@@ -81,3 +82,5 @@ spec:
       volumes:
         - name: cache
           emptyDir: {}
+        - name: tmp
+          emptyDir: { }


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This makes our containers' root filesystems read-only, which improves security by preventing writes to the container’s base image filesystem.

It adds `/tmp` as an emptyDir volume so that our app can continue writing temporary files as needed.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
