### PR TITLE
🐛 short-circuit reconcile when objects are deleted

### DIFF
--- a/internal/catalogd/controllers/core/clustercatalog_controller.go
+++ b/internal/catalogd/controllers/core/clustercatalog_controller.go
@@ -196,6 +196,14 @@ func (r *ClusterCatalogReconciler) reconcile(ctx context.Context, catalog *ocv1.
 		return ctrl.Result{}, nil
 	}
 
+	if catalog.GetDeletionTimestamp() != nil {
+		// If we've gotten here, that means the cluster catalog is being deleted, we've handled all of
+		// _our_ finalizers (above), but the cluster catalog is still present in the cluster, likely
+		// because there are _other_ finalizers that other controllers need to handle, (e.g. the orphan
+		// deletion finalizer).
+		return ctrl.Result{}, nil
+	}
+
 	// TODO: The below algorithm to get the current state based on an in-memory
 	//    storedCatalogs map is a hack that helps us keep the ClusterCatalog's
 	//    status up-to-date. The fact that we need this setup is indicative of

--- a/internal/catalogd/controllers/core/clustercatalog_controller_test.go
+++ b/internal/catalogd/controllers/core/clustercatalog_controller_test.go
@@ -766,6 +766,40 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "reconcile should be short-circuited if the clustercatalog has a deletion timestamp and all known finalizers have been removed",
+			catalog: &ocv1.ClusterCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "catalog",
+					Finalizers:        []string{"finalizer"},
+					DeletionTimestamp: &metav1.Time{Time: time.Date(2025, 6, 10, 16, 43, 0, 0, time.UTC)},
+				},
+				Spec: ocv1.ClusterCatalogSpec{
+					Source: ocv1.CatalogSource{
+						Type: ocv1.SourceTypeImage,
+						Image: &ocv1.ImageSource{
+							Ref: "my.org/someimage:latest",
+						},
+					},
+					AvailabilityMode: ocv1.AvailabilityModeAvailable,
+				},
+			},
+			expectedCatalog: &ocv1.ClusterCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "catalog",
+					Finalizers:        []string{"finalizer"},
+					DeletionTimestamp: &metav1.Time{Time: time.Date(2025, 6, 10, 16, 43, 0, 0, time.UTC)}},
+				Spec: ocv1.ClusterCatalogSpec{
+					Source: ocv1.CatalogSource{
+						Type: ocv1.SourceTypeImage,
+						Image: &ocv1.ImageSource{
+							Ref: "my.org/someimage:latest",
+						},
+					},
+					AvailabilityMode: ocv1.AvailabilityModeAvailable,
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			reconciler := &ClusterCatalogReconciler{

--- a/internal/operator-controller/controllers/clusterextension_controller.go
+++ b/internal/operator-controller/controllers/clusterextension_controller.go
@@ -206,6 +206,14 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1.Cl
 		return ctrl.Result{}, nil
 	}
 
+	if ext.GetDeletionTimestamp() != nil {
+		// If we've gotten here, that means the cluster extension is being deleted, we've handled all of
+		// _our_ finalizers (above), but the cluster extension is still present in the cluster, likely
+		// because there are _other_ finalizers that other controllers need to handle, (e.g. the orphan
+		// deletion finalizer).
+		return ctrl.Result{}, nil
+	}
+
 	l.Info("getting installed bundle")
 	installedBundle, err := r.InstalledBundleGetter.GetInstalledBundle(ctx, ext)
 	if err != nil {


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

This is necessary to ensure that we do not keep reconciling the objects as if they were not deleted.

The need for this became apparent while trying to use --cascade=orphan with a ClusterExtension. In theory, that should work out of the box because, we set owner references on all managed objects.

However, that was not working because our controller was fully reconciling objects with metadata.finalizers: ["orphan"], which was writing owner references back into the objects that the orphan deletion process had just removed.

Ultimately this meant that the managed objects would be background deleted because they once again had an owner reference to the now-deleted ClusterExtension, which then caused the kubernetes garbage collector to clean them up.

In general, it stands to reason that once we have successfully processed all of our finalizers after a deletion of an object, we should stop reconciling that object.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
