### PR TITLE
🐛 Fix Prometheus Using Endpoints

### DIFF
--- a/hack/test/setup-monitoring.sh
+++ b/hack/test/setup-monitoring.sh
@@ -92,6 +92,7 @@ spec:
     runAsUser: 65534
     seccompProfile:
         type: RuntimeDefault
+  serviceDiscoveryRole: EndpointSlice
   serviceMonitorSelector: {}
 EOF
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

`Endpoints`, which Prometheus uses by default, are now fully deprecated since kind has been updated and we need to add configuration to tell Prometheus to use `EndpointSlices` instead.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
