### PR TITLE
:seedling: Add more feature gate configuration to experimental

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ test-e2e: run image-registry prometheus e2e e2e-metrics e2e-coverage kind-clean 
 test-experimental-e2e: SOURCE_MANIFEST := $(EXPERIMENTAL_E2E_MANIFEST)
 test-experimental-e2e: KIND_CLUSTER_NAME := operator-controller-e2e
 test-experimental-e2e: GO_BUILD_EXTRA_FLAGS := -cover
-test-experimental-e2e: run image-registry prometheus experimental-e2e e2e-metrics e2e-coverage kind-clean #HELP Run experimental e2e test suite on local kind cluster
+test-experimental-e2e: run image-registry prometheus experimental-e2e e2e e2e-metrics e2e-coverage kind-clean #HELP Run experimental e2e test suite on local kind cluster
 
 .PHONY: prometheus
 prometheus: PROMETHEUS_NAMESPACE := olmv1-system

--- a/config/components/base/experimental/kustomization.yaml
+++ b/config/components/base/experimental/kustomization.yaml
@@ -10,4 +10,8 @@ components:
 # EXPERIMENTAL FEATURES ARE LISTED HERE
 - ../../features/synthetic-user-permissions
 - ../../features/webhook-provider-certmanager
-- ../../features/webhook-provider-openshift-serviceca
+- ../../features/single-own-namespace
+- ../../features/preflight-permissions
+- ../../features/apiv1-metas-handler
+# This one is downstream only, so we shant use it
+# - ../../features/webhook-provider-openshift-serviceca

--- a/config/components/features/apiv1-metas-handler/kustomization.yaml
+++ b/config/components/features/apiv1-metas-handler/kustomization.yaml
@@ -1,0 +1,9 @@
+# kustomization file for catalogd APIv1 metas handler
+# DO NOT ADD A NAMESPACE HERE
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+ - target:
+      kind: Deployment
+      name: catalogd-controller-manager
+   path: patches/enable-featuregate.yaml

--- a/config/components/features/apiv1-metas-handler/patches/enable-featuregate.yaml
+++ b/config/components/features/apiv1-metas-handler/patches/enable-featuregate.yaml
@@ -1,0 +1,4 @@
+# enable APIv1 meta handler feature gate
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--feature-gates=APIV1MetasHandler=true"

--- a/config/components/features/preflight-permissions/kustomization.yaml
+++ b/config/components/features/preflight-permissions/kustomization.yaml
@@ -1,0 +1,9 @@
+# kustomization file for preflight permissions support
+# DO NOT ADD A NAMESPACE HERE
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+ - target:
+      kind: Deployment
+      name: operator-controller-controller-manager
+   path: patches/enable-featuregate.yaml

--- a/config/components/features/preflight-permissions/patches/enable-featuregate.yaml
+++ b/config/components/features/preflight-permissions/patches/enable-featuregate.yaml
@@ -1,0 +1,4 @@
+# enable preflight permissions feature gate
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--feature-gates=PreflightPermissions=true"

--- a/config/components/features/single-own-namespace/kustomization.yaml
+++ b/config/components/features/single-own-namespace/kustomization.yaml
@@ -1,0 +1,9 @@
+# kustomization file for single/own namespace install support
+# DO NOT ADD A NAMESPACE HERE
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+ - target:
+      kind: Deployment
+      name: operator-controller-controller-manager
+   path: patches/enable-featuregate.yaml

--- a/config/components/features/single-own-namespace/patches/enable-featuregate.yaml
+++ b/config/components/features/single-own-namespace/patches/enable-featuregate.yaml
@@ -1,0 +1,4 @@
+# enable single/own namespace install support feature gate
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--feature-gates=SingleOwnNamespaceInstallSupport=true"

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1596,6 +1596,7 @@ spec:
         - --leader-elect
         - --metrics-bind-address=:7443
         - --external-address=catalogd-service.olmv1-system.svc
+        - --feature-gates=APIV1MetasHandler=true
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
         - --pull-cas-dir=/var/ca-certs
@@ -1711,7 +1712,8 @@ spec:
         - --leader-elect
         - --feature-gates=SyntheticPermissions=true
         - --feature-gates=WebhookProviderCertManager=true
-        - --feature-gates=WebhookProviderOpenshiftServiceCA=true
+        - --feature-gates=SingleOwnNamespaceInstallSupport=true
+        - --feature-gates=PreflightPermissions=true
         - --catalogd-cas-dir=/var/certs
         - --pull-cas-dir=/var/certs
         - --tls-cert=/var/certs/tls.cert

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1573,6 +1573,7 @@ spec:
         - --leader-elect
         - --metrics-bind-address=:7443
         - --external-address=catalogd-service.olmv1-system.svc
+        - --feature-gates=APIV1MetasHandler=true
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
         - --pull-cas-dir=/var/ca-certs
@@ -1680,7 +1681,8 @@ spec:
         - --leader-elect
         - --feature-gates=SyntheticPermissions=true
         - --feature-gates=WebhookProviderCertManager=true
-        - --feature-gates=WebhookProviderOpenshiftServiceCA=true
+        - --feature-gates=SingleOwnNamespaceInstallSupport=true
+        - --feature-gates=PreflightPermissions=true
         - --catalogd-cas-dir=/var/certs
         - --pull-cas-dir=/var/certs
         - --tls-cert=/var/certs/tls.cert


### PR DESCRIPTION
Add the following feature gates to the experimental manifests:
* APIV1MetasHandler
* SingleOwnNamespaceInstallSupport
* PReflightPermissions

Update manifests

Add the regular e2e tests into the experimental-e2e tests. This makes the experimental-e2e longer, but it should help with coverage.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
