### PR TITLE
:seedling: Update additional cert-manager locations to v1.18.2

### DIFF
--- a/.tilt-support
+++ b/.tilt-support
@@ -5,7 +5,7 @@ load('ext://cert_manager', 'deploy_cert_manager')
 def deploy_cert_manager_if_needed():
     cert_manager_var = '__CERT_MANAGER__'
     if os.getenv(cert_manager_var) != '1':
-        deploy_cert_manager(version="v1.15.3")
+        deploy_cert_manager(version="v1.18.2")
         os.putenv(cert_manager_var, '1')
 
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 ENVTEST_VERSION := $(K8S_VERSION).x
 
 # Define dependency versions (use go.mod if we also use Go code from dependency)
-export CERT_MGR_VERSION := v1.18.1
+export CERT_MGR_VERSION := v1.18.2
 export WAIT_TIMEOUT := 60s
 
 # Install default ClusterCatalogs


### PR DESCRIPTION
The go.mod version of cert-manager was updated to v1.18.2

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
