### PR TITLE
:seedling: Use metadata to determine namespace in args

### DIFF
--- a/config/base/catalogd/manager/manager.yaml
+++ b/config/base/catalogd/manager/manager.yaml
@@ -46,7 +46,12 @@ spec:
         args:
         - --leader-elect
         - --metrics-bind-address=:7443
-        - --external-address=catalogd-service.olmv1-system.svc
+        - --external-address=catalogd-service.$(POD_NAMESPACE).svc
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         image: controller:latest
         name: manager
         volumeMounts:

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1595,7 +1595,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-address=:7443
-        - --external-address=catalogd-service.olmv1-system.svc
+        - --external-address=catalogd-service.$(POD_NAMESPACE).svc
         - --feature-gates=APIV1MetasHandler=true
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
@@ -1605,6 +1605,10 @@ spec:
         env:
         - name: GOCOVERDIR
           value: /e2e-coverage
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/operator-framework/catalogd:devel
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1572,13 +1572,18 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-address=:7443
-        - --external-address=catalogd-service.olmv1-system.svc
+        - --external-address=catalogd-service.$(POD_NAMESPACE).svc
         - --feature-gates=APIV1MetasHandler=true
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
         - --pull-cas-dir=/var/ca-certs
         command:
         - ./catalogd
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/operator-framework/catalogd:devel
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1588,7 +1588,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-address=:7443
-        - --external-address=catalogd-service.olmv1-system.svc
+        - --external-address=catalogd-service.$(POD_NAMESPACE).svc
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
         - --pull-cas-dir=/var/ca-certs
@@ -1597,6 +1597,10 @@ spec:
         env:
         - name: GOCOVERDIR
           value: /e2e-coverage
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/operator-framework/catalogd:devel
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1565,12 +1565,17 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-address=:7443
-        - --external-address=catalogd-service.olmv1-system.svc
+        - --external-address=catalogd-service.$(POD_NAMESPACE).svc
         - --tls-cert=/var/certs/tls.crt
         - --tls-key=/var/certs/tls.key
         - --pull-cas-dir=/var/ca-certs
         command:
         - ./catalogd
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/operator-framework/catalogd:devel
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
Use an env to get the metadata.namespace, and then use a variable in the arguments to get the value. Avoids putting the namespace into the manifest.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
