### PR TITLE
:sparkles: Add feature-set annotation to all manifest resources

### DIFF
--- a/config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/catalogd/crd/experimental/olm.operatorframework.io_clustercatalogs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/catalogd/crd/standard/olm.operatorframework.io_clustercatalogs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/generated: standard
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
+++ b/config/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml
+++ b/config/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/generated: standard
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/config/overlays/basic-olm/kustomization.yaml
+++ b/config/overlays/basic-olm/kustomization.yaml
@@ -2,5 +2,7 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: basic-olm
 components:
 - ../../components/base/standard

--- a/config/overlays/experimental-e2e/kustomization.yaml
+++ b/config/overlays/experimental-e2e/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: experimental
 components:
 - ../../components/base/experimental
 - ../../components/e2e

--- a/config/overlays/experimental/kustomization.yaml
+++ b/config/overlays/experimental/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: experimental
 components:
 - ../../components/base/experimental
 # This must be last due to namespace overwrite issues of the ca

--- a/config/overlays/standard-e2e/kustomization.yaml
+++ b/config/overlays/standard-e2e/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: standard-e2e
 components:
 - ../../components/base/standard
 - ../../components/e2e

--- a/config/overlays/standard/kustomization.yaml
+++ b/config/overlays/standard/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: standard
 components:
 - ../../components/base/standard
 # This must be last due to namespace overwrite issues of the ca

--- a/config/overlays/tilt-local-dev/catalogd/kustomization.yaml
+++ b/config/overlays/tilt-local-dev/catalogd/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: tilt
 resources:
 - ../../../base/catalogd
 - ../../../base/common

--- a/config/overlays/tilt-local-dev/operator-controller/kustomization.yaml
+++ b/config/overlays/tilt-local-dev/operator-controller/kustomization.yaml
@@ -2,6 +2,8 @@
 # DO NOT ADD A NAMESPACE HERE
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  olm.operatorframework.io/feature-set: tilt
 resources:
 - ../../../base/operator-controller
 - ../../../base/common

--- a/hack/tools/crd-generator/main.go
+++ b/hack/tools/crd-generator/main.go
@@ -35,10 +35,10 @@ import (
 const (
 	// FeatureSetAnnotation is the annotation key used in the Operator-Controller API CRDs to specify
 	// the installed Operator-Controller API channel.
-	FeatureSetAnnotation = "olm.operatorframework.io/feature-set"
-	VersionAnnotation    = "controller-gen.kubebuilder.io/version"
-	StandardChannel      = "standard"
-	ExperimentalChannel  = "experimental"
+	GeneratorAnnotation = "olm.operatorframework.io/generated"
+	VersionAnnotation   = "controller-gen.kubebuilder.io/version"
+	StandardChannel     = "standard"
+	ExperimentalChannel = "experimental"
 )
 
 var standardKinds = map[string]bool{
@@ -123,7 +123,7 @@ func runGenerator(args ...string) {
 			if crdRaw.Annotations == nil {
 				crdRaw.Annotations = map[string]string{}
 			}
-			crdRaw.Annotations[FeatureSetAnnotation] = channel
+			crdRaw.Annotations[GeneratorAnnotation] = channel
 			if ctVer != "" {
 				crdRaw.Annotations[VersionAnnotation] = ctVer
 			}

--- a/hack/tools/crd-generator/testdata/output/experimental/olm.operatorframework.io_clusterextensions.yaml
+++ b/hack/tools/crd-generator/testdata/output/experimental/olm.operatorframework.io_clusterextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/hack/tools/crd-generator/testdata/output/standard/olm.operatorframework.io_clusterextensions.yaml
+++ b/hack/tools/crd-generator/testdata/output/standard/olm.operatorframework.io_clusterextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/generated: standard
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/part-of: olm
     pod-security.kubernetes.io/enforce: restricted
@@ -13,6 +15,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -455,6 +458,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -1042,6 +1046,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1051,12 +1057,16 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-controller-manager
   namespace: olmv1-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1098,6 +1108,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-manager-role
   namespace: olmv1-system
 rules:
@@ -1114,6 +1126,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-leader-election-role
   namespace: olmv1-system
 rules:
@@ -1152,6 +1166,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-role
   namespace: olmv1-system
 rules:
@@ -1180,6 +1196,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-manager-role
 rules:
 - apiGroups:
@@ -1212,6 +1230,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1225,6 +1245,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1246,6 +1268,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-clusterextension-editor-role
 rules:
 - apiGroups:
@@ -1264,6 +1288,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-clusterextension-viewer-role
 rules:
 - apiGroups:
@@ -1278,6 +1304,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-role
 rules:
 - apiGroups:
@@ -1344,6 +1372,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1354,6 +1384,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-proxy-role
 rules:
 - apiGroups:
@@ -1372,6 +1404,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1389,6 +1423,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1406,6 +1442,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-leader-election-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1420,6 +1458,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1434,6 +1474,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1450,6 +1492,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1466,6 +1510,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1479,6 +1525,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1497,12 +1545,16 @@ data:
     location = "docker-registry.operator-controller-e2e.svc.cluster.local:5000"
 kind: ConfigMap
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: e2e-registries-conf
   namespace: olmv1-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1528,6 +1580,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-service
@@ -1544,6 +1598,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: e2e-coverage
   namespace: olmv1-system
 spec:
@@ -1558,6 +1614,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: catalogd-controller-manager
   name: catalogd-controller-manager
@@ -1572,6 +1629,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: experimental
       labels:
         control-plane: catalogd-controller-manager
     spec:
@@ -1673,6 +1731,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-controller-manager
@@ -1686,6 +1745,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: experimental
       labels:
         control-plane: operator-controller-controller-manager
     spec:
@@ -1793,6 +1853,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-ca
   namespace: cert-manager
 spec:
@@ -1813,6 +1875,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-service-cert
   namespace: olmv1-system
 spec:
@@ -1832,6 +1896,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-cert
   namespace: olmv1-system
 spec:
@@ -1850,6 +1916,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-ca
 spec:
   ca:
@@ -1858,6 +1926,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: self-sign-issuer
   namespace: cert-manager
 spec:
@@ -1866,6 +1936,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-controller-manager
   namespace: olmv1-system
 spec:
@@ -1889,6 +1961,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: default-deny-all-traffic
   namespace: olmv1-system
 spec:
@@ -1900,6 +1974,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
@@ -1919,6 +1995,8 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: e2e-coverage-copy-pod
   namespace: olmv1-system
 spec:
@@ -1955,6 +2033,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from-secret: cert-manager/olmv1-ca
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/part-of: olm
     pod-security.kubernetes.io/enforce: restricted
@@ -13,6 +15,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -455,6 +458,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: experimental
+    olm.operatorframework.io/generated: experimental
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -1042,6 +1046,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1051,12 +1057,16 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-controller-manager
   namespace: olmv1-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1098,6 +1108,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-manager-role
   namespace: olmv1-system
 rules:
@@ -1114,6 +1126,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-leader-election-role
   namespace: olmv1-system
 rules:
@@ -1152,6 +1166,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-role
   namespace: olmv1-system
 rules:
@@ -1180,6 +1196,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-manager-role
 rules:
 - apiGroups:
@@ -1212,6 +1230,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1225,6 +1245,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1246,6 +1268,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-clusterextension-editor-role
 rules:
 - apiGroups:
@@ -1264,6 +1288,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-clusterextension-viewer-role
 rules:
 - apiGroups:
@@ -1278,6 +1304,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-role
 rules:
 - apiGroups:
@@ -1344,6 +1372,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1354,6 +1384,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-proxy-role
 rules:
 - apiGroups:
@@ -1372,6 +1404,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1389,6 +1423,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1406,6 +1442,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-leader-election-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1420,6 +1458,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1434,6 +1474,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1450,6 +1492,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1466,6 +1510,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1479,6 +1525,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1492,6 +1540,8 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1517,6 +1567,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-service
@@ -1535,6 +1587,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: catalogd-controller-manager
   name: catalogd-controller-manager
@@ -1549,6 +1602,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: experimental
       labels:
         control-plane: catalogd-controller-manager
     spec:
@@ -1642,6 +1696,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: experimental
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-controller-manager
@@ -1655,6 +1710,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: experimental
       labels:
         control-plane: operator-controller-controller-manager
     spec:
@@ -1749,6 +1805,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-ca
   namespace: cert-manager
 spec:
@@ -1769,6 +1827,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-service-cert
   namespace: olmv1-system
 spec:
@@ -1788,6 +1848,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-cert
   namespace: olmv1-system
 spec:
@@ -1806,6 +1868,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: olmv1-ca
 spec:
   ca:
@@ -1814,6 +1878,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: self-sign-issuer
   namespace: cert-manager
 spec:
@@ -1822,6 +1888,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-controller-manager
   namespace: olmv1-system
 spec:
@@ -1845,6 +1913,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: default-deny-all-traffic
   namespace: olmv1-system
 spec:
@@ -1856,6 +1926,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
@@ -1877,6 +1949,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from-secret: cert-manager/olmv1-ca
+    olm.operatorframework.io/feature-set: experimental
   name: catalogd-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/part-of: olm
     pod-security.kubernetes.io/enforce: restricted
@@ -12,7 +14,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/feature-set: standard-e2e
+    olm.operatorframework.io/generated: standard
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -454,7 +457,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/feature-set: standard-e2e
+    olm.operatorframework.io/generated: standard
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -1042,6 +1046,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1051,12 +1057,16 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-controller-manager
   namespace: olmv1-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1098,6 +1108,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: catalogd-manager-role
   namespace: olmv1-system
 rules:
@@ -1114,6 +1126,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-leader-election-role
   namespace: olmv1-system
 rules:
@@ -1152,6 +1166,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-manager-role
   namespace: olmv1-system
 rules:
@@ -1180,6 +1196,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: catalogd-manager-role
 rules:
 - apiGroups:
@@ -1212,6 +1230,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1225,6 +1245,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1246,6 +1268,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-clusterextension-editor-role
 rules:
 - apiGroups:
@@ -1264,6 +1288,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-clusterextension-viewer-role
 rules:
 - apiGroups:
@@ -1278,6 +1304,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-manager-role
 rules:
 - apiGroups:
@@ -1337,6 +1365,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1347,6 +1377,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-proxy-role
 rules:
 - apiGroups:
@@ -1365,6 +1397,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1382,6 +1416,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1399,6 +1435,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-leader-election-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1413,6 +1451,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-manager-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1427,6 +1467,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1443,6 +1485,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1459,6 +1503,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1472,6 +1518,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1490,12 +1538,16 @@ data:
     location = "docker-registry.operator-controller-e2e.svc.cluster.local:5000"
 kind: ConfigMap
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: e2e-registries-conf
   namespace: olmv1-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1521,6 +1573,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-service
@@ -1537,6 +1591,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: e2e-coverage
   namespace: olmv1-system
 spec:
@@ -1551,6 +1607,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     control-plane: catalogd-controller-manager
   name: catalogd-controller-manager
@@ -1565,6 +1622,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: standard-e2e
       labels:
         control-plane: catalogd-controller-manager
     spec:
@@ -1665,6 +1723,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: standard-e2e
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-controller-manager
@@ -1678,6 +1737,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: standard-e2e
       labels:
         control-plane: operator-controller-controller-manager
     spec:
@@ -1781,6 +1841,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: olmv1-ca
   namespace: cert-manager
 spec:
@@ -1801,6 +1863,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: catalogd-service-cert
   namespace: olmv1-system
 spec:
@@ -1820,6 +1884,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: olmv1-cert
   namespace: olmv1-system
 spec:
@@ -1838,6 +1904,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: olmv1-ca
 spec:
   ca:
@@ -1846,6 +1914,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: self-sign-issuer
   namespace: cert-manager
 spec:
@@ -1854,6 +1924,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: catalogd-controller-manager
   namespace: olmv1-system
 spec:
@@ -1877,6 +1949,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: default-deny-all-traffic
   namespace: olmv1-system
 spec:
@@ -1888,6 +1962,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
@@ -1907,6 +1983,8 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
   name: e2e-coverage-copy-pod
   namespace: olmv1-system
 spec:
@@ -1943,6 +2021,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from-secret: cert-manager/olmv1-ca
+    olm.operatorframework.io/feature-set: standard-e2e
   name: catalogd-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/part-of: olm
     pod-security.kubernetes.io/enforce: restricted
@@ -13,6 +15,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/generated: standard
   name: clustercatalogs.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -455,6 +458,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     olm.operatorframework.io/feature-set: standard
+    olm.operatorframework.io/generated: standard
   name: clusterextensions.olm.operatorframework.io
 spec:
   group: olm.operatorframework.io
@@ -1042,6 +1046,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1051,12 +1057,16 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-controller-manager
   namespace: olmv1-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1098,6 +1108,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: catalogd-manager-role
   namespace: olmv1-system
 rules:
@@ -1114,6 +1126,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-leader-election-role
   namespace: olmv1-system
 rules:
@@ -1152,6 +1166,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-manager-role
   namespace: olmv1-system
 rules:
@@ -1180,6 +1196,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: catalogd-manager-role
 rules:
 - apiGroups:
@@ -1212,6 +1230,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1225,6 +1245,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1246,6 +1268,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-clusterextension-editor-role
 rules:
 - apiGroups:
@@ -1264,6 +1288,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-clusterextension-viewer-role
 rules:
 - apiGroups:
@@ -1278,6 +1304,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-manager-role
 rules:
 - apiGroups:
@@ -1337,6 +1365,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-metrics-reader
 rules:
 - nonResourceURLs:
@@ -1347,6 +1377,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-proxy-role
 rules:
 - apiGroups:
@@ -1365,6 +1397,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1382,6 +1416,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1399,6 +1435,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-leader-election-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1413,6 +1451,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-manager-rolebinding
   namespace: olmv1-system
 roleRef:
@@ -1427,6 +1467,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1443,6 +1485,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1459,6 +1503,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1472,6 +1518,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1485,6 +1533,8 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     app.kubernetes.io/name: catalogd
     app.kubernetes.io/part-of: olm
@@ -1510,6 +1560,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-service
@@ -1528,6 +1580,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: standard
   labels:
     control-plane: catalogd-controller-manager
   name: catalogd-controller-manager
@@ -1542,6 +1595,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: standard
       labels:
         control-plane: catalogd-controller-manager
     spec:
@@ -1634,6 +1688,7 @@ kind: Deployment
 metadata:
   annotations:
     kubectl.kubernetes.io/default-logs-container: manager
+    olm.operatorframework.io/feature-set: standard
   labels:
     control-plane: operator-controller-controller-manager
   name: operator-controller-controller-manager
@@ -1647,6 +1702,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorframework.io/feature-set: standard
       labels:
         control-plane: operator-controller-controller-manager
     spec:
@@ -1737,6 +1793,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: olmv1-ca
   namespace: cert-manager
 spec:
@@ -1757,6 +1815,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: catalogd-service-cert
   namespace: olmv1-system
 spec:
@@ -1776,6 +1836,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: olmv1-cert
   namespace: olmv1-system
 spec:
@@ -1794,6 +1856,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: olmv1-ca
 spec:
   ca:
@@ -1802,6 +1866,8 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: self-sign-issuer
   namespace: cert-manager
 spec:
@@ -1810,6 +1876,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: catalogd-controller-manager
   namespace: olmv1-system
 spec:
@@ -1833,6 +1901,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: default-deny-all-traffic
   namespace: olmv1-system
 spec:
@@ -1844,6 +1914,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    olm.operatorframework.io/feature-set: standard
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
@@ -1865,6 +1937,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from-secret: cert-manager/olmv1-ca
+    olm.operatorframework.io/feature-set: standard
   name: catalogd-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
The feature-set annotation was originally applied by the crd-generator to the generated CRDs. Now, that annotaion is being added by the overlay, and is being added to all resources in the manifest.

Each manifest has an annotation value based its name.

The crd-generator is now adding a generated annotation indicating what the CRD was generated for.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
