### PR TITLE
:sparkles: Add NamespaceSelector to generated webhook configs

### DIFF
--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
@@ -1507,7 +1507,7 @@ func Test_BundleValidatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 			},
 			opts: render.Options{
 				InstallNamespace: "install-namespace",
-				TargetNamespaces: []string{"watch-namespace-one", "watch-namespace-two"},
+				TargetNamespaces: []string{""},
 			},
 			expectedResources: []client.Object{
 				&admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -1554,6 +1554,7 @@ func Test_BundleValidatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Port:      ptr.To(int32(443)),
 								},
 							},
+							// No NamespaceSelector is set targetNamespaces = []string{""} (AllNamespaces install mode)
 						},
 					},
 				},
@@ -1647,6 +1648,15 @@ func Test_BundleValidatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Port:      ptr.To(int32(443)),
 								},
 							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "kubernetes.io/metadata.name",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"watch-namespace-one", "watch-namespace-two"},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1692,6 +1702,15 @@ func Test_BundleValidatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Namespace: "install-namespace",
 									Name:      "my-deployment-service",
 									Port:      ptr.To(int32(443)),
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "kubernetes.io/metadata.name",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"watch-namespace-one", "watch-namespace-two"},
+									},
 								},
 							},
 						},
@@ -1772,7 +1791,7 @@ func Test_BundleMutatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 			},
 			opts: render.Options{
 				InstallNamespace: "install-namespace",
-				TargetNamespaces: []string{"watch-namespace-one", "watch-namespace-two"},
+				TargetNamespaces: []string{""},
 			},
 			expectedResources: []client.Object{
 				&admissionregistrationv1.MutatingWebhookConfiguration{
@@ -1820,6 +1839,7 @@ func Test_BundleMutatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Port:      ptr.To(int32(443)),
 								},
 							},
+							// No NamespaceSelector is set targetNamespaces = []string{""} (AllNamespaces install mode)
 						},
 					},
 				},
@@ -1915,6 +1935,15 @@ func Test_BundleMutatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Port:      ptr.To(int32(443)),
 								},
 							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "kubernetes.io/metadata.name",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"watch-namespace-one", "watch-namespace-two"},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1960,6 +1989,15 @@ func Test_BundleMutatingWebhookResourceGenerator_Succeeds(t *testing.T) {
 									Namespace: "install-namespace",
 									Name:      "my-deployment-service",
 									Port:      ptr.To(int32(443)),
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "kubernetes.io/metadata.name",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"watch-namespace-one", "watch-namespace-two"},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
# Description

Sets the NamespaceSelector in generated Validating and MutatingWebhookConfiguration resources. This ensures that webhooks for operators installed in single/own namespace mode are (at least for namespaced APIs) restricted to the target namespace of the installation.

The implementation diverges from that of OLMv0. In OLM v0 the namespace selector is derived from OperatorGroup labels OLM sets on the target namespaces. In OLMv1 we don't have OperatorGroups and there's probably no need to add any labels to target namespaces. So, we use the kubernetes provided "kubernetes.io/metadata.name" label. This may not work in older versions of kubernetes.

Note: the renderer itself supports rendering the bundle manifests for multi-namespace mode. OLMv1 just doesn't support MultiNamespace mode. Therefore, the namespace selector uses a match expression with the `In` operator.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
