### PR TITLE
✨ Add Network Policy to e2e test bundles

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -103,6 +103,16 @@ rules:
     - "bind"
     - "escalate"
   - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+  - apiGroups:
     - "olm.operatorframework.io"
     resources:
     - "clusterextensions/finalizers"

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -152,6 +153,23 @@ func createClusterRoleAndBindingForSA(ctx context.Context, name string, sa *core
 					"watch",
 					"bind",
 					"escalate",
+				},
+			},
+			{
+				APIGroups: []string{
+					"networking.k8s.io",
+				},
+				Resources: []string{
+					"networkpolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"update",
+					"patch",
+					"delete",
 				},
 			},
 		},
@@ -376,6 +394,12 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 					assert.Contains(ct, cond.Message, "Installed bundle")
 					assert.NotEmpty(ct, clusterExtension.Status.Install.Bundle)
 				}
+			}, pollDuration, pollInterval)
+
+			t.Log("By eventually creating the NetworkPolicy named 'test-operator-network-policy'")
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				var np networkingv1.NetworkPolicy
+				assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: "test-operator-network-policy", Namespace: ns.Name}, &np))
 			}, pollDuration, pollInterval)
 		})
 	}

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
@@ -97,6 +97,16 @@ spec:
           - patch
           - delete
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.networkpolicy.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.networkpolicy.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-operator-network-policy
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.clusterserviceversion.yaml
@@ -97,6 +97,16 @@ spec:
           - patch
           - delete
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.networkpolicy.yaml
+++ b/testdata/images/bundles/test-operator/v2.0.0/manifests/testoperator.networkpolicy.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-operator-network-policy
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
Adds a Netwok Policy to the end-to-end test bundles and adds a check to the tests that the Network Policy resources are created. Closes OPRUN-3967

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
