### PR TITLE
:seedling: Remove synthetic auth from experimental manifests

### DIFF
--- a/config/components/base/experimental/kustomization.yaml
+++ b/config/components/base/experimental/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
 - ../common
 # EXPERIMENTAL FEATURES ARE LISTED HERE
-- ../../features/synthetic-user-permissions
 - ../../features/webhook-provider-certmanager
 - ../../features/single-own-namespace
 - ../../features/preflight-permissions

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1361,13 +1361,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - groups
-  - users
-  verbs:
-  - impersonate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1774,7 +1767,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
         - --leader-elect
-        - --feature-gates=SyntheticPermissions=true
         - --feature-gates=WebhookProviderCertManager=true
         - --feature-gates=SingleOwnNamespaceInstallSupport=true
         - --feature-gates=PreflightPermissions=true

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1361,13 +1361,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - groups
-  - users
-  verbs:
-  - impersonate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1740,7 +1733,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
         - --leader-elect
-        - --feature-gates=SyntheticPermissions=true
         - --feature-gates=WebhookProviderCertManager=true
         - --feature-gates=SingleOwnNamespaceInstallSupport=true
         - --feature-gates=PreflightPermissions=true


### PR DESCRIPTION
We are not planning on doing the synthetic auth in light of the boxcutter effort.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
