### PR TITLE
:bug: Clear cert warning during deployments

### DIFF
--- a/config/components/cert-manager/ca/issuers.yaml
+++ b/config/components/cert-manager/ca/issuers.yaml
@@ -19,6 +19,7 @@ spec:
     annotations:
       cert-manager.io/allow-direct-injection: "true"
   privateKey:
+    rotationPolicy: Always
     algorithm: ECDSA
     size: 256
   issuerRef:

--- a/config/components/cert-manager/catalogd/resources/certificate.yaml
+++ b/config/components/cert-manager/catalogd/resources/certificate.yaml
@@ -10,6 +10,7 @@ spec:
     - catalogd-service.olmv1-system.svc
     - catalogd-service.olmv1-system.svc.cluster.local
   privateKey:
+    rotationPolicy: Always
     algorithm: ECDSA
     size: 256
   issuerRef:

--- a/config/components/cert-manager/operator-controller/resources/manager_cert.yaml
+++ b/config/components/cert-manager/operator-controller/resources/manager_cert.yaml
@@ -9,6 +9,7 @@ spec:
     - operator-controller-service.olmv1-system.svc
     - operator-controller-service.olmv1-system.svc.cluster.local
   privateKey:
+    rotationPolicy: Always
     algorithm: ECDSA
     size: 256
   issuerRef:

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1863,6 +1863,7 @@ spec:
     name: self-sign-issuer
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-ca
   secretTemplate:
@@ -1887,6 +1888,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: catalogd-service-cert-git-version
 ---
@@ -1907,6 +1909,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-cert
 ---

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1816,6 +1816,7 @@ spec:
     name: self-sign-issuer
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-ca
   secretTemplate:
@@ -1840,6 +1841,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: catalogd-service-cert-git-version
 ---
@@ -1860,6 +1862,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-cert
 ---

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1858,6 +1858,7 @@ spec:
     name: self-sign-issuer
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-ca
   secretTemplate:
@@ -1882,6 +1883,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: catalogd-service-cert-git-version
 ---
@@ -1902,6 +1904,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-cert
 ---

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1811,6 +1811,7 @@ spec:
     name: self-sign-issuer
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-ca
   secretTemplate:
@@ -1835,6 +1836,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: catalogd-service-cert-git-version
 ---
@@ -1855,6 +1857,7 @@ spec:
     name: olmv1-ca
   privateKey:
     algorithm: ECDSA
+    rotationPolicy: Always
     size: 256
   secretName: olmv1-cert
 ---

--- a/testdata/build-test-registry.sh
+++ b/testdata/build-test-registry.sh
@@ -45,6 +45,7 @@ spec:
     - ${name}-controller-manager-metrics-service.${namespace}.svc
     - ${name}-controller-manager-metrics-service.${namespace}.svc.cluster.local
   privateKey:
+    rotationPolicy: Always
     algorithm: ECDSA
     size: 256
   issuerRef:


### PR DESCRIPTION
This removes the following warning by explicitly setting the value to the default:

```
Warning: spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`.
```

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
