### PR TITLE
:bug: Do not add OWNERS to bingo's .gitignore

### DIFF
--- a/.bingo/.gitignore
+++ b/.bingo/.gitignore
@@ -9,6 +9,5 @@
 !README.md
 !Variables.mk
 !variables.env
-!OWNERS
 
 *tmp.mod


### PR DESCRIPTION
bingo overwrites the .gitignore file, so it can create an unexpected merge conflict.

Leave the OWNERS file in place (unless we discover that it is also a problem later).

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
