### PR TITLE
tilt: delete at correct index to remove --leader-elect flag for catalogd

### DIFF
--- a/config/overlays/tilt-local-dev/patches/catalogd.yaml
+++ b/config/overlays/tilt-local-dev/patches/catalogd.yaml
@@ -7,4 +7,4 @@
   value: null
 - op: remove
   # remove --leader-elect so container doesn't restart during breakpoints
-  path: /spec/template/spec/containers/0/args/2
+  path: /spec/template/spec/containers/0/args/0


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

The intention of the tilt-local-dev patches is to delete the --leader-elect flags in catalogd and operator-controller. In the kustomize reshuffling, it looks like flags moved around, but the tilt patch was not updated to use the correct index for deletion.

This fixes that.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
