### PR TITLE
:seedling: Separate the (experimental-)e2e coverage

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -86,7 +86,7 @@ jobs:
       - uses: codecov/codecov-action@v5.4.3
         with:
           disable_search: true
-          files: coverage/e2e.out
+          files: coverage/experimental-e2e.out
           flags: experimental-e2e
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -271,12 +271,14 @@ image-registry: ## Build the testdata catalog used for e2e tests and push it to 
 test-e2e: SOURCE_MANIFEST := $(STANDARD_E2E_MANIFEST)
 test-e2e: KIND_CLUSTER_NAME := operator-controller-e2e
 test-e2e: GO_BUILD_EXTRA_FLAGS := -cover
+test-e2e: COVERAGE_NAME := e2e
 test-e2e: run image-registry prometheus e2e e2e-metrics e2e-coverage kind-clean #HELP Run e2e test suite on local kind cluster
 
 .PHONY: test-experimental-e2e
 test-experimental-e2e: SOURCE_MANIFEST := $(EXPERIMENTAL_E2E_MANIFEST)
 test-experimental-e2e: KIND_CLUSTER_NAME := operator-controller-e2e
 test-experimental-e2e: GO_BUILD_EXTRA_FLAGS := -cover
+test-experimental-e2e: COVERAGE_NAME := experimental-e2e
 test-experimental-e2e: run image-registry prometheus experimental-e2e e2e e2e-metrics e2e-coverage kind-clean #HELP Run experimental e2e test suite on local kind cluster
 
 .PHONY: prometheus
@@ -316,7 +318,7 @@ test-upgrade-e2e: kind-cluster run-latest-release image-registry pre-upgrade-set
 
 .PHONY: e2e-coverage
 e2e-coverage:
-	COVERAGE_OUTPUT=./coverage/e2e.out ./hack/test/e2e-coverage.sh
+	COVERAGE_NAME=$(COVERAGE_NAME) ./hack/test/e2e-coverage.sh
 
 #SECTION KIND Cluster Operations
 

--- a/hack/test/e2e-coverage.sh
+++ b/hack/test/e2e-coverage.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-COVERAGE_OUTPUT="${COVERAGE_OUTPUT:-${ROOT_DIR}/coverage/e2e.out}"
+COVERAGE_NAME="${COVERAGE_NAME:-e2e}"
 
 OPERATOR_CONTROLLER_NAMESPACE="olmv1-system"
 OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME="operator-controller-controller-manager"
@@ -13,7 +13,8 @@ CATALOGD_MANAGER_DEPLOYMENT_NAME="catalogd-controller-manager"
 COPY_POD_NAME="e2e-coverage-copy-pod"
 
 # Create a temporary directory for coverage
-COVERAGE_DIR=${ROOT_DIR}/coverage/e2e
+COVERAGE_OUTPUT=${ROOT_DIR}/coverage/${COVERAGE_NAME}.out
+COVERAGE_DIR=${ROOT_DIR}/coverage/${COVERAGE_NAME}
 rm -rf ${COVERAGE_DIR} && mkdir -p ${COVERAGE_DIR}
 
 # Coverage-instrumented binary produces coverage on termination,


### PR DESCRIPTION
Give the experimental-e2e it's own set of output files for coverage vs the regular e2e.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
