### PR TITLE
🌱 webhook tests: remove webhook-operator resource limits

### DIFF
--- a/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator.clusterserviceversion.yaml
@@ -107,9 +107,6 @@ spec:
                   name: webhook-server
                   protocol: TCP
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 30Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi


### PR DESCRIPTION
The memory limit was causing the pod to be OOMKilled in my local execution of the experimental e2e tests. That limit is irrelevant to the purpose of the test, so it can be safely removed.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
