### PR TITLE
:bug: Fix downstream e2e test compatibility

### DIFF
--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -1027,8 +1027,17 @@ func TestClusterExtensionRecoversFromExistingDeploymentWhenFailureFixed(t *testi
 							ImagePullPolicy: corev1.PullAlways,
 							Name:            "busybox",
 							SecurityContext: &corev1.SecurityContext{
-								RunAsNonRoot: ptr.To(true),
-								RunAsUser:    ptr.To(int64(1000)),
+								RunAsNonRoot:             ptr.To(true),
+								RunAsUser:                ptr.To(int64(1000)),
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{
+										"ALL",
+									},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 						},
 					},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -40,7 +41,9 @@ func TestMain(m *testing.M) {
 
 	res := m.Run()
 	err = utils.PrintSummary(testSummaryOutputEnvVar)
-	utilruntime.Must(err)
+	if err != nil {
+		fmt.Println("PrintSummary error", err)
+	}
 	os.Exit(res)
 }
 


### PR DESCRIPTION
* Update busybox deployment SecurityContext
* Don't panic at end of e2e test if PrintSummary fails

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
