### PR TITLE
🌱 Makefile: add test-upgrade-experimental-e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,3 +92,22 @@ jobs:
       with:
         name: upgrade-e2e-artifacts
         path: /tmp/artifacts/
+
+  upgrade-experimental-e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Run the upgrade e2e test
+      run: ARTIFACT_PATH=/tmp/artifacts make test-upgrade-experimental-e2e
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: upgrade-experimental-e2e-artifacts
+        path: /tmp/artifacts/
+

--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -109,8 +109,10 @@ rules:
     verbs:
     - get
     - list
+    - watch
     - create
     - update
+    - patch
     - delete
   - apiGroups:
     - "olm.operatorframework.io"


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

Adds a make task and github workflow for running upgrade tests against the experimental e2e release. The intent is for this to be an "informing" job pre-merge, not a blocking job.

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
