### PR TITLE
📖 fix broken catalod api reference link

### DIFF
--- a/docs/project/public-api.md
+++ b/docs/project/public-api.md
@@ -3,7 +3,6 @@ The public API of OLM v1 is as follows:
 
 - Kubernetes APIs. For more information on these APIs, see:
     - [operator-controller API reference](../api-reference/operator-controller-api-reference.md)
-    - [catalogd API reference](../api-reference/catalogd-api-reference.md)
 - `Catalogd` web server. For more information on what this includes, see the [catalogd web server documentation](../api-reference/catalogd-webserver.md)
 
 !!! warning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,6 @@ nav:
     - Version Ranges: concepts/version-ranges.md
   - API Reference:
     - Operator Controller API reference: api-reference/operator-controller-api-reference.md
-    - CatalogD API reference: api-reference/catalogd-api-reference.md
     - CatalogD Web Server reference: api-reference/catalogd-webserver.md
   - Contribute:
     - Contributing: contribute/contributing.md


### PR DESCRIPTION
The make target `crd-ref-docs` generates the api reference doc operator-controller-api-reference.md using the API types in the `api/` directory.
The docs structure was expecting two files, while only one file was being generated.

This PR fixes the doc structure to expect only one file, getting rid of a broken link as a result.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
