### PR TITLE
:seedling: Move applier to use Bundle interface

### DIFF
--- a/internal/operator-controller/applier/helm.go
+++ b/internal/operator-controller/applier/helm.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"slices"
 	"strings"
 
@@ -26,6 +25,7 @@ import (
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/bundle"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/features"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/bundle/source"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/preflights/crdupgradesafety"
@@ -121,8 +121,8 @@ func (h *Helm) runPreAuthorizationChecks(ctx context.Context, ext *ocv1.ClusterE
 	return nil
 }
 
-func (h *Helm) Apply(ctx context.Context, contentFS fs.FS, ext *ocv1.ClusterExtension, objectLabels map[string]string, storageLabels map[string]string) ([]client.Object, string, error) {
-	chrt, err := h.buildHelmChart(contentFS, ext)
+func (h *Helm) Apply(ctx context.Context, bundle bundle.Bundle, ext *ocv1.ClusterExtension, objectLabels map[string]string, storageLabels map[string]string) ([]client.Object, string, error) {
+	chrt, err := h.buildHelmChart(bundle, ext)
 	if err != nil {
 		return nil, "", err
 	}
@@ -203,10 +203,11 @@ func (h *Helm) Apply(ctx context.Context, contentFS fs.FS, ext *ocv1.ClusterExte
 	return relObjects, state, nil
 }
 
-func (h *Helm) buildHelmChart(bundleFS fs.FS, ext *ocv1.ClusterExtension) (*chart.Chart, error) {
+func (h *Helm) buildHelmChart(bundle bundle.Bundle, ext *ocv1.ClusterExtension) (*chart.Chart, error) {
 	if h.BundleToHelmChartConverter == nil {
 		return nil, errors.New("BundleToHelmChartConverter is nil")
 	}
+	bundleFS := bundle.FS()
 	watchNamespace, err := GetWatchNamespace(ext)
 	if err != nil {
 		return nil, err

--- a/internal/operator-controller/bundle/bundle.go
+++ b/internal/operator-controller/bundle/bundle.go
@@ -1,0 +1,19 @@
+package bundle
+
+import "io/fs"
+
+type Bundle interface {
+	FS() fs.FS
+}
+
+type fsBundle struct {
+	bundleFS fs.FS
+}
+
+func (f fsBundle) FS() fs.FS {
+	return f.bundleFS
+}
+
+func FromFS(bundleFS fs.FS) Bundle {
+	return fsBundle{bundleFS}
+}

--- a/internal/operator-controller/controllers/suite_test.go
+++ b/internal/operator-controller/controllers/suite_test.go
@@ -18,7 +18,6 @@ package controllers_test
 
 import (
 	"context"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -36,6 +35,7 @@ import (
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/bundle"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/contentmanager"
 	cmcache "github.com/operator-framework/operator-controller/internal/operator-controller/contentmanager/cache"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/controllers"
@@ -73,7 +73,7 @@ type MockApplier struct {
 	state string
 }
 
-func (m *MockApplier) Apply(_ context.Context, _ fs.FS, _ *ocv1.ClusterExtension, _ map[string]string, _ map[string]string) ([]client.Object, string, error) {
+func (m *MockApplier) Apply(_ context.Context, _ bundle.Bundle, _ *ocv1.ClusterExtension, _ map[string]string, _ map[string]string) ([]client.Object, string, error) {
 	if m.err != nil {
 		return nil, m.state, m.err
 	}


### PR DESCRIPTION
# Description

Box the boxcutter, configuration, and helm efforts will require an architecture that allows for multiple bundle formats. This PR starts us on that path by creating the simplest Bundle interface:

```
type Bundle interface {
  FS() fs.FS
}
```

and updating the Applier to use it. We will want to also update the Resolver and the ImagePuller to use the Bundle interface / API.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
