### PR TITLE
:sparkles: OPRUN-4113: Compute target namespace defaults

### DIFF
--- a/internal/operator-controller/rukpak/render/render.go
+++ b/internal/operator-controller/rukpak/render/render.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -74,9 +74,6 @@ func (o *Options) apply(opts ...Option) *Options {
 
 func (o *Options) validate(rv1 *bundle.RegistryV1) (*Options, []error) {
 	var errs []error
-	if len(o.TargetNamespaces) == 0 {
-		errs = append(errs, errors.New("at least one target namespace must be specified"))
-	}
 	if o.UniqueNameGenerator == nil {
 		errs = append(errs, errors.New("unique name generator must be specified"))
 	}
@@ -121,7 +118,7 @@ func (r BundleRenderer) Render(rv1 bundle.RegistryV1, installNamespace string, o
 	genOpts, errs := (&Options{
 		// default options
 		InstallNamespace:    installNamespace,
-		TargetNamespaces:    []string{metav1.NamespaceAll},
+		TargetNamespaces:    defaultTargetNamespacesForBundle(&rv1, installNamespace),
 		UniqueNameGenerator: DefaultUniqueNameGenerator,
 		CertificateProvider: nil,
 	}).apply(opts...).validate(&rv1)
@@ -147,31 +144,55 @@ func DefaultUniqueNameGenerator(base string, o interface{}) (string, error) {
 }
 
 func validateTargetNamespaces(rv1 *bundle.RegistryV1, installNamespace string, targetNamespaces []string) error {
-	supportedInstallModes := sets.New[string]()
-	for _, im := range rv1.CSV.Spec.InstallModes {
-		if im.Supported {
-			supportedInstallModes.Insert(string(im.Type))
-		}
-	}
+	supportedInstallModes := supportedBundleInstallModes(rv1)
 
 	set := sets.New[string](targetNamespaces...)
 	switch {
-	case set.Len() == 0 || (set.Len() == 1 && set.Has("")):
-		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
+	case set.Len() == 0:
+		if supportedInstallModes.Len() == 1 && supportedInstallModes.Has(v1alpha1.InstallModeTypeSingleNamespace) {
+			return errors.New("exactly one target namespace must be specified")
+		}
+		return errors.New("at least one target namespace must be specified")
+	case set.Len() == 1 && set.Has(""):
+		if supportedInstallModes.Has(v1alpha1.InstallModeTypeAllNamespaces) {
 			return nil
 		}
 		return fmt.Errorf("supported install modes %v do not support targeting all namespaces", sets.List(supportedInstallModes))
 	case set.Len() == 1 && !set.Has(""):
-		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeSingleNamespace)) {
+		if supportedInstallModes.Has(v1alpha1.InstallModeTypeSingleNamespace) {
 			return nil
 		}
-		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeOwnNamespace)) && targetNamespaces[0] == installNamespace {
+		if supportedInstallModes.Has(v1alpha1.InstallModeTypeOwnNamespace) && targetNamespaces[0] == installNamespace {
 			return nil
 		}
 	default:
-		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeMultiNamespace)) && !set.Has("") {
+		if supportedInstallModes.Has(v1alpha1.InstallModeTypeMultiNamespace) && !set.Has("") {
 			return nil
 		}
 	}
-	return fmt.Errorf("supported install modes %v do not support target namespaces %v", sets.List[string](supportedInstallModes), targetNamespaces)
+	return fmt.Errorf("supported install modes %v do not support target namespaces %v", sets.List[v1alpha1.InstallModeType](supportedInstallModes), targetNamespaces)
+}
+
+func defaultTargetNamespacesForBundle(rv1 *bundle.RegistryV1, installNamespace string) []string {
+	supportedInstallModes := supportedBundleInstallModes(rv1)
+
+	if supportedInstallModes.Has(v1alpha1.InstallModeTypeAllNamespaces) {
+		return []string{corev1.NamespaceAll}
+	}
+
+	if supportedInstallModes.Has(v1alpha1.InstallModeTypeOwnNamespace) {
+		return []string{installNamespace}
+	}
+
+	return nil
+}
+
+func supportedBundleInstallModes(rv1 *bundle.RegistryV1) sets.Set[v1alpha1.InstallModeType] {
+	supportedInstallModes := sets.New[v1alpha1.InstallModeType]()
+	for _, im := range rv1.CSV.Spec.InstallModes {
+		if im.Supported {
+			supportedInstallModes.Insert(im.Type)
+		}
+	}
+	return supportedInstallModes
 }

--- a/internal/operator-controller/rukpak/render/render.go
+++ b/internal/operator-controller/rukpak/render/render.go
@@ -159,10 +159,13 @@ func validateTargetNamespaces(rv1 *bundle.RegistryV1, installNamespace string, t
 		}
 		return fmt.Errorf("supported install modes %v do not support targeting all namespaces", sets.List(supportedInstallModes))
 	case set.Len() == 1 && !set.Has(""):
-		if supportedInstallModes.Has(v1alpha1.InstallModeTypeSingleNamespace) {
+		if targetNamespaces[0] == installNamespace {
+			if !supportedInstallModes.Has(v1alpha1.InstallModeTypeOwnNamespace) {
+				return fmt.Errorf("supported install modes %v do not support targeting own namespace", sets.List(supportedInstallModes))
+			}
 			return nil
 		}
-		if supportedInstallModes.Has(v1alpha1.InstallModeTypeOwnNamespace) && targetNamespaces[0] == installNamespace {
+		if supportedInstallModes.Has(v1alpha1.InstallModeTypeSingleNamespace) {
 			return nil
 		}
 	default:

--- a/internal/operator-controller/rukpak/render/render_test.go
+++ b/internal/operator-controller/rukpak/render/render_test.go
@@ -213,7 +213,7 @@ func Test_BundleRenderer_ValidatesRenderOptions(t *testing.T) {
 			opts: []render.Option{
 				render.WithTargetNamespaces("install-namespace"),
 			},
-			err: errors.New("invalid option(s): invalid target namespaces [install-namespace]: supported install modes [AllNamespaces] do not support target namespaces [install-namespace]"),
+			err: errors.New("invalid option(s): invalid target namespaces [install-namespace]: supported install modes [AllNamespaces] do not support targeting own namespace"),
 		}, {
 			name:             "rejects install out of own namespace if only OwnNamespace install mode is supported",
 			installNamespace: "install-namespace",
@@ -266,6 +266,14 @@ func Test_BundleRenderer_ValidatesRenderOptions(t *testing.T) {
 			opts: []render.Option{
 				render.WithTargetNamespaces("some-namespace"),
 			},
+		}, {
+			name:             "rejects single namespace render if OwnNamespace install mode is unsupported and targets own namespace",
+			installNamespace: "install-namespace",
+			csv:              MakeCSV(WithInstallModeSupportFor(v1alpha1.InstallModeTypeSingleNamespace)),
+			opts: []render.Option{
+				render.WithTargetNamespaces("install-namespace"),
+			},
+			err: errors.New("invalid option(s): invalid target namespaces [install-namespace]: supported install modes [SingleNamespace] do not support targeting own namespace"),
 		}, {
 			name:             "accepts multi namespace render if MultiNamespace install mode is supported",
 			installNamespace: "install-namespace",


### PR DESCRIPTION
# Description

Updates registry+v1 renderer to compute target namespace defaults based on the bundle's install mode configuration:

- bundle supports AllNamespaces: default is [""] (install in AllNamespaces mode)
- bundle supports OwnNamespace: default is [<install-namespace>]
- bundle supports neither AllNamespaces or OwnNamespace mode: undefined (user must specify TargetNamespaces)

We also update the targetNamespace validation to ensure the own namespace cannot be used unless OwnNamespace install mode is supported

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
