### PR TITLE
🐛 (fix): unhandle changes for crd upgrade safety ( OCPBUGS-59518 )

### DIFF
--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety.go
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety.go
@@ -99,8 +99,9 @@ func (p *Preflight) runPreflight(ctx context.Context, relObjects []client.Object
 			resultErrs := crdWideErrors(results)
 			resultErrs = append(resultErrs, sameVersionErrors(results)...)
 			resultErrs = append(resultErrs, servedVersionErrors(results)...)
-
-			validateErrors = append(validateErrors, fmt.Errorf("validating upgrade for CRD %q: %w", newCrd.Name, errors.Join(resultErrs...)))
+			if len(resultErrs) > 0 {
+				validateErrors = append(validateErrors, fmt.Errorf("validating upgrade for CRD %q: %w", newCrd.Name, errors.Join(resultErrs...)))
+			}
 		}
 	}
 
@@ -162,7 +163,11 @@ func sameVersionErrors(results *runner.Results) []error {
 		for property, comparisonResults := range propertyResults {
 			for _, result := range comparisonResults {
 				for _, err := range result.Errors {
-					errs = append(errs, fmt.Errorf("%s: %s: %s: %s", version, property, result.Name, err))
+					msg := err
+					if result.Name == "unhandled" {
+						msg = "unhandled changes found"
+					}
+					errs = append(errs, fmt.Errorf("%s: %s: %s: %s", version, property, result.Name, msg))
 				}
 			}
 		}
@@ -181,7 +186,11 @@ func servedVersionErrors(results *runner.Results) []error {
 		for property, comparisonResults := range propertyResults {
 			for _, result := range comparisonResults {
 				for _, err := range result.Errors {
-					errs = append(errs, fmt.Errorf("%s: %s: %s: %s", version, property, result.Name, err))
+					msg := err
+					if result.Name == "unhandled" {
+						msg = "unhandled changes found"
+					}
+					errs = append(errs, fmt.Errorf("%s: %s: %s: %s", version, property, result.Name, msg))
 				}
 			}
 		}

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	crdifyconfig "sigs.k8s.io/crdify/pkg/config"
 
 	"github.com/operator-framework/operator-controller/internal/operator-controller/applier"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/preflights/crdupgradesafety"
@@ -385,4 +386,37 @@ func TestUpgrade(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpgrade_UnhandledChanges_InSpec_DefaultPolicy(t *testing.T) {
+	t.Run("unhandled spec changes cause error by default", func(t *testing.T) {
+		preflight := newMockPreflight(getCrdFromManifestFile(t, "crd-unhandled-old.json"), nil)
+		rel := &release.Release{
+			Name:     "test-release",
+			Manifest: getManifestString(t, "crd-unhandled-new.json"),
+		}
+		err := preflight.Upgrade(context.Background(), rel)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unhandled changes found")
+		require.NotContains(t, err.Error(), "v1.JSONSchemaProps", "error message should be concise without raw diff")
+	})
+}
+
+func TestUpgrade_UnhandledChanges_PolicyError(t *testing.T) {
+	t.Run("unhandled changes error when policy is Error", func(t *testing.T) {
+		oldCrd := getCrdFromManifestFile(t, "crd-unhandled-old.json")
+		preflight := crdupgradesafety.NewPreflight(&MockCRDGetter{oldCrd: oldCrd}, crdupgradesafety.WithConfig(&crdifyconfig.Config{
+			Conversion:           crdifyconfig.ConversionPolicyIgnore,
+			UnhandledEnforcement: crdifyconfig.EnforcementPolicyError,
+		}))
+
+		rel := &release.Release{
+			Name:     "test-release",
+			Manifest: getManifestString(t, "crd-unhandled-new.json"),
+		}
+
+		err := preflight.Upgrade(context.Background(), rel)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unhandled changes found")
+	})
 }

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
@@ -395,9 +395,12 @@ func TestUpgrade_UnhandledChanges_InSpec_DefaultPolicy(t *testing.T) {
 			Name:     "test-release",
 			Manifest: getManifestString(t, "crd-unhandled-new.json"),
 		}
-		err := preflight.Upgrade(context.Background(), rel)
+		objs, err := applier.HelmReleaseToObjectsConverter{}.GetObjectsFromRelease(rel)
+		require.NoError(t, err)
+		err = preflight.Upgrade(context.Background(), objs)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unhandled changes found")
+		require.ErrorContains(t, err, "Format \"\" -> \"email\"")
 		require.NotContains(t, err.Error(), "v1.JSONSchemaProps", "error message should be concise without raw diff")
 	})
 }
@@ -415,8 +418,11 @@ func TestUpgrade_UnhandledChanges_PolicyError(t *testing.T) {
 			Manifest: getManifestString(t, "crd-unhandled-new.json"),
 		}
 
-		err := preflight.Upgrade(context.Background(), rel)
+		objs, err := applier.HelmReleaseToObjectsConverter{}.GetObjectsFromRelease(rel)
+		require.NoError(t, err)
+		err = preflight.Upgrade(context.Background(), objs)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unhandled changes found")
+		require.ErrorContains(t, err, "Format \"\" -> \"email\"")
 	})
 }

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-unhandled-new.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-unhandled-new.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "name": "widgets.example.com"
+  },
+  "spec": {
+    "group": "example.com",
+    "versions": [
+      {
+        "name": "v1alpha1",
+        "served": true,
+        "storage": true,
+        "schema": {
+          "openAPIV3Schema": {
+            "type": "object",
+            "properties": {
+              "spec": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "scope": "Namespaced",
+    "names": {
+      "plural": "widgets",
+      "singular": "widget",
+      "kind": "Widget"
+    }
+  }
+}
+

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-unhandled-old.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-unhandled-old.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "name": "widgets.example.com"
+  },
+  "spec": {
+    "group": "example.com",
+    "versions": [
+      {
+        "name": "v1alpha1",
+        "served": true,
+        "storage": true,
+        "schema": {
+          "openAPIV3Schema": {
+            "type": "object",
+            "properties": {
+              "spec": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "scope": "Namespaced",
+    "names": {
+      "plural": "widgets",
+      "singular": "widget",
+      "kind": "Widget"
+    }
+  }
+}
+

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/unhandled_message_test.go
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/unhandled_message_test.go
@@ -1,0 +1,28 @@
+package crdupgradesafety
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConciseUnhandledMessage_NoPrefix(t *testing.T) {
+	raw := "some other error"
+	require.Equal(t, raw, conciseUnhandledMessage(raw))
+}
+
+func TestConciseUnhandledMessage_SingleChange(t *testing.T) {
+	raw := "unhandled changes found :\n- Format: \"\"\n+ Format: \"email\"\n"
+	require.Equal(t, "unhandled changes found (Format \"\" -> \"email\")", conciseUnhandledMessage(raw))
+}
+
+func TestConciseUnhandledMessage_MultipleChanges(t *testing.T) {
+	raw := "unhandled changes found :\n- Format: \"\"\n+ Format: \"email\"\n- Default: nil\n+ Default: \"value\"\n- Title: \"\"\n+ Title: \"Widget\"\n- Description: \"old\"\n+ Description: \"new\"\n"
+	got := conciseUnhandledMessage(raw)
+	require.Equal(t, "unhandled changes found (Format \"\" -> \"email\"; Default nil -> \"value\"; Title \"\" -> \"Widget\"; Description \"old\" -> \"new\")", got)
+}
+
+func TestConciseUnhandledMessage_SkipComplexValues(t *testing.T) {
+	raw := "unhandled changes found :\n- Default: &v1.JSONSchemaProps{}\n+ Default: &v1.JSONSchemaProps{Type: \"string\"}\n"
+	require.Equal(t, "unhandled changes found (Default <complex value> -> <complex value> (changed))", conciseUnhandledMessage(raw))
+}


### PR DESCRIPTION
## Problem  

We use the **crddiff**   (https://github.com/kubernetes-sigs/crdify) library to check API differences and ensure CRD upgrade safety. See: [CRD upgrade safety docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/extensions/cluster-extensions#crd-upgrade-safety)  

When crddiff cannot handle the diff, it reports an **unhandled scenario**.  
In this case, a **full JSON diff** is returned which **causes the problem**

- The JSON is **too large** to update in the CR status.  
- This causes an error:  `Too long: may not be more than 32768 bytes</code>`  

**-As a result:**  
  - **ClusterExtension is not upgraded**.  
  - **Users see no information** about why the upgrade failed.  
  - The only details are hidden in confusing logs in the operator-controller deployment, which are not meaningful or helpful.  

More info: [OCPBUGS-59518](https://issues.redhat.com/browse/OCPBUGS-59518)  

## Solution  

Instead of outputting the **full JSON**, we:  

- Extract only the **meaningful information**.  
- Return a **short, clear message** that explains the unhandled diff.  

This allows:  

- **OLMv1** to update the status conditions.  
- **Users** to understand why the CE upgrade could not happen.  

Example (from unit tests):  

```
require.ErrorContains(t, err, "unhandled changes found")  
require.ErrorContains(t, err, "Format \"\" -> \"email\"")  
```

This way:  
- Users get actionable feedback.  
- Status remains within size limits.
- The CE status will be updated as expected  

## Note  

As discussed, any further improvement beyond this would need to be done directly in the **crddiff** library, to reduce the number of unhandled scenarios.  



## Reviewer Checklist

- [N/A ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [N/A] Links to related GitHub Issue(s)
