### PR TITLE
CER: centralize status updates into big-R Reconcile method

### DIFF
--- a/internal/operator-controller/controllers/clusterextension_controller.go
+++ b/internal/operator-controller/controllers/clusterextension_controller.go
@@ -108,13 +108,13 @@ func (r *ClusterExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	l := log.FromContext(ctx).WithName("cluster-extension")
 	ctx = log.IntoContext(ctx, l)
 
-	l.Info("reconcile starting")
-	defer l.Info("reconcile ending")
-
 	existingExt := &ocv1.ClusterExtension{}
 	if err := r.Get(ctx, req.NamespacedName, existingExt); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	l.Info("reconcile starting")
+	defer l.Info("reconcile ending")
 
 	reconciledExt := existingExt.DeepCopy()
 	res, reconcileErr := r.reconcile(ctx, reconciledExt)
@@ -124,7 +124,7 @@ func (r *ClusterExtensionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	updateFinalizers := !equality.Semantic.DeepEqual(existingExt.Finalizers, reconciledExt.Finalizers)
 
 	// If any unexpected fields have changed, panic before updating the resource
-	unexpectedFieldsChanged := checkForUnexpectedFieldChange(*existingExt, *reconciledExt)
+	unexpectedFieldsChanged := checkForUnexpectedClusterExtensionFieldChange(*existingExt, *reconciledExt)
 	if unexpectedFieldsChanged {
 		panic("spec or metadata changed by reconciler")
 	}
@@ -169,7 +169,7 @@ func ensureAllConditionsWithReason(ext *ocv1.ClusterExtension, reason v1alpha1.C
 }
 
 // Compare resources - ignoring status & metadata.finalizers
-func checkForUnexpectedFieldChange(a, b ocv1.ClusterExtension) bool {
+func checkForUnexpectedClusterExtensionFieldChange(a, b ocv1.ClusterExtension) bool {
 	a.Status, b.Status = ocv1.ClusterExtensionStatus{}, ocv1.ClusterExtensionStatus{}
 	a.Finalizers, b.Finalizers = []string{}, []string{}
 	return !equality.Semantic.DeepEqual(a, b)


### PR DESCRIPTION
Re-opening here now that poc-boxcutter PR is merged

Original PR: https://github.com/thetechnick/operator-controller/pull/5

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

A few small fixups and comment additions to help remember follow-ups:
1. Make `Reconcile` and `reconcile` more consistent between CE and CER reconcilers
   - update status in one place in `Reconcile`
   - only log reconciler start/stop if we actually call `reconcile`


NOTE: There is still one major difference: CER updates finalizers as separate patches and continues reconcile logic. CE updates finalizers and requires re-reconcile to continue beyond. The CER logic may cause issues where the _next_ reconcile sees a stale resource version (from finalizer patch) because the status update event isn't seen by our informer in time. This ultimately leads to reconciling a stale CER that manifests as a conflict error in our logs that is often a red herring for users trying to troubleshoot issues in controllers.

Another noticeable difference is that CE uses controller-runtime Finalizers helpers, and CER handles things manually. 

Changing this broke unit tests, so I decided not to leave that change out to keep the PR scope small. I'll make a separate PR that focuses just on finalizers.


<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)