### PR TITLE
🐛 dynamically create containerd registry config file for e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,12 +351,14 @@ kind-deploy: manifests
 .PHONY: kind-cluster
 kind-cluster: $(KIND) kind-verify-versions #EXHELP Standup a kind cluster.
 	-$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	./hack/setup-e2e-registry-config.sh
 	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config ./kind-config.yaml
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-clean
 kind-clean: $(KIND) #EXHELP Delete the kind cluster.
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	./hack/cleanup-e2e-registry-config.sh
 
 .PHONY: kind-verify-versions
 kind-verify-versions:

--- a/hack/cleanup-e2e-registry-config.sh
+++ b/hack/cleanup-e2e-registry-config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CERTS_DIR="${PROJECT_ROOT}/hack/kind-config/containerd/certs.d"
+
+REGISTRY_HOST="docker-registry.operator-controller-e2e.svc.cluster.local:5000"
+REGISTRY_DIR="${CERTS_DIR}/${REGISTRY_HOST}"
+
+echo "Cleaning up e2e registry configuration..."
+
+if [ -d "${REGISTRY_DIR}" ]; then
+    echo "Removing directory: ${REGISTRY_DIR}"
+    rm -rf "${REGISTRY_DIR}"
+    echo "E2E registry configuration cleanup complete."
+else
+    echo "Registry directory not found, nothing to clean."
+fi

--- a/hack/kind-config/containerd/certs.d/docker-registry.operator-controller-e2e.svc.cluster.local:5000/hosts.toml
+++ b/hack/kind-config/containerd/certs.d/docker-registry.operator-controller-e2e.svc.cluster.local:5000/hosts.toml
@@ -1,3 +1,0 @@
-[host."https://localhost:30000"]
-  capabilities = ["pull", "resolve"]
-  skip_verify = true

--- a/hack/setup-e2e-registry-config.sh
+++ b/hack/setup-e2e-registry-config.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CERTS_DIR="${PROJECT_ROOT}/hack/kind-config/containerd/certs.d"
+
+REGISTRY_HOST="docker-registry.operator-controller-e2e.svc.cluster.local:5000"
+REGISTRY_DIR="${CERTS_DIR}/${REGISTRY_HOST}"
+
+echo "Setting up e2e registry configuration..."
+echo "Creating directory: ${REGISTRY_DIR}"
+
+mkdir -p "${REGISTRY_DIR}"
+
+cat > "${REGISTRY_DIR}/hosts.toml" << 'EOF'
+[host."https://localhost:30000"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+EOF
+
+echo "Created ${REGISTRY_DIR}/hosts.toml"
+echo "E2E registry configuration setup complete."


### PR DESCRIPTION
Statically including the file with name that has a colon in it is invalid for Go modules, which lead to the v1.5.0 release being rendered broken:

The go mod error shows:
 - malformed file path "...local:5000/hosts.toml": invalid char ':'
 - This prevents the module from being downloaded and verified
 - Finally, the Go sum database returns 404 because it can't process this malformed module

This commit creates the file dynamically, instead of including the file statically in the repository.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
