### PR TITLE
🐛 retract v1.5.0; exclude hack/kind-config/containerd/certs.d from root module [release-v1.5]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,6 +245,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 )
 
+retract v1.5.0 // contains filename with ':' which causes failure creating module zip file
+
 replace k8s.io/api => k8s.io/api v0.33.2
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.2

--- a/hack/kind-config/containerd/certs.d/go.mod
+++ b/hack/kind-config/containerd/certs.d/go.mod
@@ -1,0 +1,5 @@
+module hack-cert.d
+// This file is present in the certs.d directory to ensure that
+// certs.d/host:port directories are not included in the main go
+// module. Go modules are not allowed to contain files with ':'
+// in their name.


### PR DESCRIPTION
Back port of #2202

* retract v1.5.0; exclude hack/kind-config/containerd/certs.d from root module

* fixup! retract v1.5.0; exclude hack/kind-config/containerd/certs.d from root module

* fixup! retract v1.5.0; exclude hack/kind-config/containerd/certs.d from root module



---------

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
