### PR TITLE
:bug: OPRUN-4128: Rename opcon manager CRB when boxcutter is enabled

### DIFF
--- a/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
+++ b/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
@@ -8,7 +8,11 @@ metadata:
   labels:
     app.kubernetes.io/name: operator-controller
     {{- include "olmv1.labels" $ | nindent 4 }}
+{{- if has "BoxcutterRuntime" .Values.operatorControllerFeatures }}
+  name: operator-controller-manager-admin-rolebinding
+{{- else }}
   name: operator-controller-manager-rolebinding
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1688,7 +1688,7 @@ metadata:
   labels:
     app.kubernetes.io/name: operator-controller
     app.kubernetes.io/part-of: olm
-  name: operator-controller-manager-rolebinding
+  name: operator-controller-manager-admin-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1653,7 +1653,7 @@ metadata:
   labels:
     app.kubernetes.io/name: operator-controller
     app.kubernetes.io/part-of: olm
-  name: operator-controller-manager-rolebinding
+  name: operator-controller-manager-admin-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This should finally fix `test-upgrade-experimental-e2e`.
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
