### PR TITLE
:bug: OPRUN-4139: Use old and new pod selectors during kustomize-to-helm transition

### DIFF
--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -20,12 +20,15 @@ import (
 
 const (
 	minJustificationLength        = 40
-	catalogdManagerSelector       = "app.kubernetes.io/name=catalogd"
-	operatorManagerSelector       = "app.kubernetes.io/name=operator-controller"
 	catalogdMetricsPort           = 7443
 	catalogdWebhookPort           = 9443
 	catalogServerPort             = 8443
 	operatorControllerMetricsPort = 8443
+)
+
+var (
+	catalogdManagerSelector = []string{"app.kubernetes.io/name=catalogd", "control-plane=catalogd-controller-manager"}
+	operatorManagerSelector = []string{"app.kubernetes.io/name=operator-controller", "control-plane=operator-controller-controller-manager"}
 )
 
 type portWithJustification struct {


### PR DESCRIPTION
Downstream e2es are failing because the old selectors are still being used.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
