### PR TITLE
:bug: OPRUN-4139: Use control-plane selectors in network-policies and tests for now

### DIFF
--- a/helm/olmv1/templates/networkpolicy/networkpolicy-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/networkpolicy/networkpolicy-olmv1-system-catalogd-controller-manager.yml
@@ -22,7 +22,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: catalogd
+      control-plane: catalogd-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/helm/olmv1/templates/networkpolicy/networkpolicy-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/networkpolicy/networkpolicy-olmv1-system-operator-controller-controller-manager.yml
@@ -18,7 +18,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: operator-controller
+      control-plane: operator-controller-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: catalogd
+      control-plane: catalogd-controller-manager
   policyTypes:
     - Ingress
     - Egress
@@ -82,7 +82,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: operator-controller
+      control-plane: operator-controller-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: catalogd
+      control-plane: catalogd-controller-manager
   policyTypes:
     - Ingress
     - Egress
@@ -82,7 +82,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: operator-controller
+      control-plane: operator-controller-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: catalogd
+      control-plane: catalogd-controller-manager
   policyTypes:
     - Ingress
     - Egress
@@ -82,7 +82,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: operator-controller
+      control-plane: operator-controller-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: catalogd
+      control-plane: catalogd-controller-manager
   policyTypes:
     - Ingress
     - Egress
@@ -82,7 +82,7 @@ spec:
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: operator-controller
+      control-plane: operator-controller-controller-manager
   policyTypes:
     - Ingress
     - Egress

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -20,15 +20,12 @@ import (
 
 const (
 	minJustificationLength        = 40
+	catalogdManagerSelector       = "control-plane=catalogd-controller-manager"
+	operatorManagerSelector       = "control-plane=operator-controller-controller-manager"
 	catalogdMetricsPort           = 7443
 	catalogdWebhookPort           = 9443
 	catalogServerPort             = 8443
 	operatorControllerMetricsPort = 8443
-)
-
-var (
-	catalogdManagerSelector = []string{"app.kubernetes.io/name=catalogd", "control-plane=catalogd-controller-manager"}
-	operatorManagerSelector = []string{"app.kubernetes.io/name=operator-controller", "control-plane=operator-controller-controller-manager"}
 )
 
 type portWithJustification struct {
@@ -91,7 +88,7 @@ var prometheuSpec = allowedPolicyDefinition{
 // Ref: https://docs.google.com/document/d/1bHEEWzA65u-kjJFQRUY1iBuMIIM1HbPy4MeDLX4NI3o/edit?usp=sharing
 var allowedNetworkPolicies = map[string]allowedPolicyDefinition{
 	"catalogd-controller-manager": {
-		selector:    metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "catalogd"}},
+		selector:    metav1.LabelSelector{MatchLabels: map[string]string{"control-plane": "catalogd-controller-manager"}},
 		policyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		ingressRule: ingressRule{
 			ports: []portWithJustification{
@@ -119,7 +116,7 @@ var allowedNetworkPolicies = map[string]allowedPolicyDefinition{
 		},
 	},
 	"operator-controller-controller-manager": {
-		selector:    metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "operator-controller"}},
+		selector:    metav1.LabelSelector{MatchLabels: map[string]string{"control-plane": "operator-controller-controller-manager"}},
 		policyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		ingressRule: ingressRule{
 			ports: []portWithJustification{


### PR DESCRIPTION
Until downstream is ready to use the "app.kubernetes.io/name" selector, continue to use the "control-plane" selector in the tests.

Change the network-policies to use a "control-plane" selector (which is still on pods because the Deployment selector is immutable).

This includes a revert of "Use old and new pod selectors during kustomize-to-helm transition" This reverts #2214
This reverts commit 6e22e2b0595176c02df054566fc2b0c1f7fd3591.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
