### PR TITLE
:seedling: OPRUN-4138 Remove no-op patch strategy tags and markers

### DIFF
--- a/api/v1/clustercatalog_types.go
+++ b/api/v1/clustercatalog_types.go
@@ -182,7 +182,7 @@ type ClusterCatalogStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// resolvedSource contains information about the resolved source based on the source type.
 	// +optional
 	ResolvedSource *ResolvedCatalogSource `json:"resolvedSource,omitempty"`

--- a/api/v1/clusterextension_types.go
+++ b/api/v1/clusterextension_types.go
@@ -485,12 +485,10 @@ type ClusterExtensionStatus struct {
 	// PackageDeprecated is set if the requested package is marked deprecated in the catalog.
 	// Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
 	//
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// install is a representation of the current installation status for this ClusterExtension.
 	//

--- a/api/v1/clusterextensionrevision_types.go
+++ b/api/v1/clusterextensionrevision_types.go
@@ -59,8 +59,6 @@ type ClusterExtensionRevisionSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf.size() == 0", message="phases is immutable"
-	// +patchMergeKey=name
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=name
 	Phases []ClusterExtensionRevisionPhase `json:"phases"`
@@ -135,12 +133,10 @@ type ClusterExtensionRevisionPrevious struct {
 
 // ClusterExtensionRevisionStatus defines the observed state of a ClusterExtensionRevision.
 type ClusterExtensionRevisionStatus struct {
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/hack/tools/crd-generator/testdata/api/v1/clusterextension_types.go
+++ b/hack/tools/crd-generator/testdata/api/v1/clusterextension_types.go
@@ -457,12 +457,10 @@ type ClusterExtensionStatus struct {
 	// PackageDeprecated is set if the requested package is marked deprecated in the catalog.
 	// Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
 	//
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// install is a representation of the current installation status for this ClusterExtension.
 	//


### PR DESCRIPTION
# Description

* `+patchStrategy` and `+patchMergeKey` markers are not supported by controller-gen, see
  https://github.com/kubernetes-sigs/controller-tools/tree/main/pkg/crd/markers
* `patchStrategy` and `patchMergeKey` golang tags are of no use for CRDs. They have their use
  in k8s core types in order to produce proper strategic merge patches, see
  https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
  but are superseded by `+listType` and `+listMapKey` in CRD world.

Their removal, as expected, did not provide any effect on the generated resources.

Part of OPRUN-4138
<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
