### PR TITLE
:seedling: OPRUN-4138 Load CRDs for envtests from chart directory

### DIFF
--- a/api/v1/suite_test.go
+++ b/api/v1/suite_test.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/operator-framework/operator-controller/test"
 )
 
 func newScheme(t *testing.T) *apimachineryruntime.Scheme {
@@ -46,27 +46,7 @@ func newClient(t *testing.T) client.Client {
 var config *rest.Config
 
 func TestMain(m *testing.M) {
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "helm", "olmv1", "base", "operator-controller", "crd", "experimental"),
-		},
-		ErrorIfCRDPathMissing: true,
-	}
-
-	// ENVTEST-based tests require specific binaries. By default, these binaries are located
-	// in paths defined by controller-runtime. However, the `BinaryAssetsDirectory` needs
-	// to be explicitly set when running tests directly (e.g., debugging tests in an IDE)
-	// without using the Makefile targets.
-	//
-	// This is equivalent to configuring your IDE to export the `KUBEBUILDER_ASSETS` environment
-	// variable before each test execution. The following function simplifies this process
-	// by handling the configuration for you.
-	//
-	// To ensure the binaries are in the expected path without manual configuration, run:
-	// `make envtest-k8s-bins`
-	if getFirstFoundEnvTestBinaryDir() != "" {
-		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
-	}
+	testEnv := test.NewEnv()
 
 	var err error
 	config, err = testEnv.Start()
@@ -78,16 +58,4 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	utilruntime.Must(testEnv.Stop())
 	os.Exit(code)
-}
-
-// getFirstFoundEnvTestBinaryDir finds and returns the first directory under the given path.
-func getFirstFoundEnvTestBinaryDir() string {
-	basePath := filepath.Join("..", "..", "bin", "envtest-binaries", "k8s")
-	entries, _ := os.ReadDir(basePath)
-	for _, entry := range entries {
-		if entry.IsDir() {
-			return filepath.Join(basePath, entry.Name())
-		}
-	}
-	return ""
 }

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// NewEnv creates a new envtest.Environment instance.
+func NewEnv() *envtest.Environment {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			pathFromProjectRoot("helm/olmv1/base/operator-controller/crd/experimental"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	// ENVTEST-based tests require specific binaries. By default, these binaries are located
+	// in paths defined by controller-runtime. However, the `BinaryAssetsDirectory` needs
+	// to be explicitly set when running tests directly (e.g., debugging tests in an IDE)
+	// without using the Makefile targets.
+	//
+	// This is equivalent to configuring your IDE to export the `KUBEBUILDER_ASSETS` environment
+	// variable before each test execution. The following function simplifies this process
+	// by handling the configuration for you.
+	//
+	// To ensure the binaries are in the expected path without manual configuration, run:
+	// `make envtest-k8s-bins`
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+	return testEnv
+}
+
+// pathFromProjectRoot returns the absolute path to the given relative path from the project root.
+func pathFromProjectRoot(relativePath string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	p := path.Join(path.Dir(path.Dir(filename)), relativePath)
+	return p
+}
+
+// getFirstFoundEnvTestBinaryDir finds and returns the first directory under the given path.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := pathFromProjectRoot(filepath.Join("bin", "envtest-binaries", "k8s"))
+	entries, _ := os.ReadDir(basePath)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
# Description

Followup of #2145: given that `config` folder is going to be removed soon,
`internal/operator-controller/controllers/suite_test.go` loads CRDs from
`helm/olmv1/base/operator-controller/crd`.

Creation of `envtest.Environment` moved and consolidated into `test/utils.go`
so that it can be consumed by multiple test suites.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
