### PR TITLE
✨ Fix Tilt by adding certManager option to the tilt.yaml chart

### DIFF
--- a/helm/tilt.yaml
+++ b/helm/tilt.yaml
@@ -2,10 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Tilt is an exeption to the multi-values case,
-# as the Tilt runner only accepts a single values fle
+# Tilt is an exception to the multi-values case,
+# as the Tilt runner only accepts a single values file
 
 options:
+  certManager:
+    enabled: true
   tilt:
     enabled: true
   featureSet: experimental


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->
When the move was made to use helm charts for the Tilt configuration, the TLS components were not added. This means in the current state, both operator-controller and catalogd will exit on launch due to metrics-bind-address requiring the tls-key and tls-cert. This PR adds the certManager option to fix this issue.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
