### PR TITLE
:seedling: OPRUN-4138 Remove `bingo-upgrade` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,13 +189,6 @@ fix-lint: $(GOLANGCI_LINT) #EXHELP Fix lint issues
 fmt: #EXHELP Formats code
 	go fmt ./...
 
-.PHONY: bingo-upgrade
-bingo-upgrade: $(BINGO) #EXHELP Upgrade tools
-	@for pkg in $$($(BINGO) list | awk '{ print $$3 }' | tail -n +3 | sed 's/@.*//'); do \
-		echo -e "Upgrading \033[35m$$pkg\033[0m to latest..."; \
-		$(BINGO) get "$$pkg@latest"; \
-	done
-
 .PHONY: verify-crd-compatibility
 CRD_DIFF_ORIGINAL_REF := git://main?path=
 CRD_DIFF_UPDATED_REF := file://


### PR DESCRIPTION
# Description

It is not referred in any of CI workflows, nor documented in the contribution guide.
Also, its usage is questionable given that it tries to upgrade all tools to the latest version at once.
Typically such upgrades are performed in a more controlled way, one PR per tool, either by developer
or dependbot.

Developers are still able to initiate an update by invoking

```
bingo get foo@x.y.z
```

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
