### PR TITLE
:bug: Use long name for curl image

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -129,7 +129,7 @@ func (c *MetricsTestConfig) getServiceAccountToken(t *testing.T) string {
 func (c *MetricsTestConfig) createCurlMetricsPod(t *testing.T) {
 	t.Logf("Creating curl pod (%s/%s) to validate the metrics endpoint", c.namespace, c.curlPodName)
 	cmd := exec.Command(c.client, "run", c.curlPodName,
-		"--image=curlimages/curl:8.15.0",
+		"--image=quay.io/curl/curl:8.15.0",
 		"--namespace", c.namespace,
 		"--restart=Never",
 		"--overrides", `{
@@ -137,7 +137,7 @@ func (c *MetricsTestConfig) createCurlMetricsPod(t *testing.T) {
 				"terminationGradePeriodSeconds": 0,
 				"containers": [{
 					"name": "curl",
-					"image": "curlimages/curl:8.15.0",
+					"image": "quay.io/curl/curl:8.15.0",
 					"command": ["sh", "-c", "sleep 3600"],
 					"securityContext": {
 						"allowPrivilegeEscalation": false,


### PR DESCRIPTION
The short name was causing downstream issues:

```
image name curlimages/curl:8.15.0 returns ambiguous list
```

Using the long name seems to fix this.

Already tested downstream.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
