### PR TITLE
:bug: OCPBUGS-62021: Fix install mode support gating

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -655,9 +655,10 @@ func setupHelm(
 		ActionClientGetter: acg,
 		Preflights:         preflights,
 		HelmChartProvider: &applier.RegistryV1HelmChartProvider{
-			BundleRenderer:          registryv1.Renderer,
-			CertificateProvider:     certProvider,
-			IsWebhookSupportEnabled: certProvider != nil,
+			BundleRenderer:              registryv1.Renderer,
+			CertificateProvider:         certProvider,
+			IsWebhookSupportEnabled:     certProvider != nil,
+			IsSingleOwnNamespaceEnabled: features.OperatorControllerFeatureGate.Enabled(features.SingleOwnNamespaceInstallSupport),
 		},
 		HelmReleaseToObjectsConverter: &applier.HelmReleaseToObjectsConverter{},
 		PreAuthorizer:                 preAuth,


### PR DESCRIPTION
# Description

The RegistryV1HelmChartProvider was letting through bundles that don't support AllNamespaces mode.

RegistryV1HelmChartProvider is updated to handle the SingleOwnNamespace feature in the same way the Webhook feature is handled. In a follow-up PR, GetWatchNamespace() (which checks for the SingleOwnNamespace feature) will be moved into this component. 

Note: This PR used to have an e2e tests to ensure bundles not supported by the standard OLMv1 profile get rejected. But, there's currently no way to execute an e2e test on the standard profile only. So, I've removed it and will add in a follow up PR once we've addressed this the right way.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
