### PR TITLE
:warning: Drop ClusterExtensionRevision Complete condition

### DIFF
--- a/api/v1/clusterextensionrevision_types.go
+++ b/api/v1/clusterextensionrevision_types.go
@@ -27,7 +27,6 @@ const (
 
 	// Condition Types
 	ClusterExtensionRevisionTypeAvailable = "Available"
-	ClusterExtensionRevisionTypeSucceeded = "Succeeded"
 
 	// Condition Reasons
 	ClusterExtensionRevisionReasonAvailable                 = "Available"
@@ -35,7 +34,6 @@ const (
 	ClusterExtensionRevisionReasonRevisionValidationFailure = "RevisionValidationFailure"
 	ClusterExtensionRevisionReasonPhaseValidationError      = "PhaseValidationError"
 	ClusterExtensionRevisionReasonObjectCollisions          = "ObjectCollisions"
-	ClusterExtensionRevisionReasonRolloutSuccess            = "RolloutSuccess"
 	ClusterExtensionRevisionReasonProbeFailure              = "ProbeFailure"
 	ClusterExtensionRevisionReasonIncomplete                = "Incomplete"
 	ClusterExtensionRevisionReasonProgressing               = "Progressing"

--- a/internal/operator-controller/applier/boxcutter.go
+++ b/internal/operator-controller/applier/boxcutter.go
@@ -298,16 +298,13 @@ func (bc *Boxcutter) apply(ctx context.Context, contentFS fs.FS, ext *ocv1.Clust
 
 	progressingCondition := meta.FindStatusCondition(currentRevision.Status.Conditions, ocv1.TypeProgressing)
 	availableCondition := meta.FindStatusCondition(currentRevision.Status.Conditions, ocv1.ClusterExtensionRevisionTypeAvailable)
-	succeededCondition := meta.FindStatusCondition(currentRevision.Status.Conditions, ocv1.ClusterExtensionRevisionTypeSucceeded)
 
-	if progressingCondition == nil && availableCondition == nil && succeededCondition == nil {
+	if progressingCondition == nil && availableCondition == nil {
 		return false, "New revision created", nil
 	} else if progressingCondition != nil && progressingCondition.Status == metav1.ConditionTrue {
 		return false, progressingCondition.Message, nil
 	} else if availableCondition != nil && availableCondition.Status != metav1.ConditionTrue {
 		return false, "", errors.New(availableCondition.Message)
-	} else if succeededCondition != nil && succeededCondition.Status != metav1.ConditionTrue {
-		return false, succeededCondition.Message, nil
 	}
 	return true, "", nil
 }

--- a/internal/operator-controller/controllers/clusterextension_controller.go
+++ b/internal/operator-controller/controllers/clusterextension_controller.go
@@ -561,12 +561,11 @@ func (d *BoxcutterRevisionStatesGetter) GetRevisionStates(ctx context.Context, e
 			},
 		}
 
-		if apimeta.IsStatusConditionTrue(rev.Status.Conditions, ocv1.ClusterExtensionRevisionTypeSucceeded) {
+		if apimeta.IsStatusConditionTrue(rev.Status.Conditions, ocv1.ClusterExtensionRevisionTypeAvailable) {
 			rs.Installed = rm
 		} else {
 			rs.RollingOut = append(rs.RollingOut, rm)
 		}
 	}
-
 	return rs, nil
 }

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller.go
@@ -275,15 +275,6 @@ func (c *ClusterExtensionRevisionReconciler) reconcile(ctx context.Context, rev 
 			Message:            "Object is available and passes all probes.",
 			ObservedGeneration: rev.Generation,
 		})
-		if !meta.IsStatusConditionTrue(rev.Status.Conditions, ocv1.ClusterExtensionRevisionTypeSucceeded) {
-			meta.SetStatusCondition(&rev.Status.Conditions, metav1.Condition{
-				Type:               ocv1.ClusterExtensionRevisionTypeSucceeded,
-				Status:             metav1.ConditionTrue,
-				Reason:             ocv1.ClusterExtensionRevisionReasonRolloutSuccess,
-				Message:            "Revision succeeded rolling out.",
-				ObservedGeneration: rev.Generation,
-			})
-		}
 	} else {
 		var probeFailureMsgs []string
 		for _, pres := range rres.GetPhases() {

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller_test.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller_test.go
@@ -250,13 +250,6 @@ func Test_ClusterExtensionRevisionReconciler_Reconcile_RevisionProgression(t *te
 				require.Equal(t, ocv1.ClusterExtensionRevisionReasonAvailable, cond.Reason)
 				require.Equal(t, "Object is available and passes all probes.", cond.Message)
 				require.Equal(t, int64(1), cond.ObservedGeneration)
-
-				cond = meta.FindStatusCondition(rev.Status.Conditions, ocv1.ClusterExtensionRevisionTypeSucceeded)
-				require.NotNil(t, cond)
-				require.Equal(t, metav1.ConditionTrue, cond.Status)
-				require.Equal(t, ocv1.ClusterExtensionRevisionReasonRolloutSuccess, cond.Reason)
-				require.Equal(t, "Revision succeeded rolling out.", cond.Message)
-				require.Equal(t, int64(1), cond.ObservedGeneration)
 			},
 		},
 		{


### PR DESCRIPTION
# Description

Drops ClusterExtensionRevision Complete condition.

This isn't necessarily a breaking change since Boxcutter is behind a feature flag.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
