### PR TITLE
:bug: add rollingUpdate strategy

### DIFF
--- a/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
@@ -13,6 +13,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager

--- a/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
@@ -12,6 +12,11 @@ metadata:
   namespace: {{ .Values.namespaces.olmv1.name }}
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -2003,6 +2003,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -2148,6 +2153,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1928,6 +1928,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -2061,6 +2066,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1762,6 +1762,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -1906,6 +1911,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1687,6 +1687,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -1819,6 +1824,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

To address the issue: the cluster operator olm `Available=False` when cluster upgrading. 
I have tested this solution in https://github.com/openshift/operator-framework-operator-controller/pull/515, and it works.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
