### PR TITLE
:seedling: OPRUN-4194: Allow openshift catalog versions to be configurable via helm

### DIFF
--- a/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-certified-operators.yml
+++ b/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-certified-operators.yml
@@ -9,5 +9,5 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.20
+      ref: registry.redhat.io/redhat/certified-operator-index:{{- .Values.options.openshift.catalogs.version }}
 {{- end -}}

--- a/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
+++ b/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
@@ -9,5 +9,5 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.20
+      ref: registry.redhat.io/redhat/community-operator-index:{{- .Values.options.openshift.catalogs.version }}
 {{- end -}}

--- a/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-marketplace.yml
+++ b/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-marketplace.yml
@@ -9,5 +9,5 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:{{- .Values.options.openshift.catalogs.version }}
 {{- end -}}

--- a/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
+++ b/helm/olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
@@ -9,5 +9,5 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-operator-index:{{ .Values.options.openshift.catalogs.version }}
 {{- end -}}

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -20,6 +20,8 @@ options:
     enabled: false
   openshift:
     enabled: false
+    catalogs:
+      version: v4.20
   # This can be one of: standard or experimental
   featureSet: standard
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
