### PR TITLE
:sparkles: OPRUN-4206: Support disabling feature-gates

### DIFF
--- a/helm/experimental.yaml
+++ b/helm/experimental.yaml
@@ -3,21 +3,25 @@
 # Declare variables to be passed into your templates.
 
 # List of enabled experimental features for operator-controller
-# Use with {{- if has "FeatureGate" .Values.operatorControllerFeatures }}
+# Use with {{- if has "FeatureGate" .Values.options.operatorController.features.enabled }}
 # to pull in resources or additions
-operatorControllerFeatures:
-  - WebhookProviderCertManager
-  - SingleOwnNamespaceInstallSupport
-  - PreflightPermissions
-  - HelmChartSupport
-  - BoxcutterRuntime
-
-# List of enabled experimental features for catalogd
-# Use with {{- if has "FeatureGate" .Values.catalogdFeatures }}
-# to pull in resources or additions
-catalogdFeatures:
-  - APIV1MetasHandler
-
-# This can be one of: standard or experimental
 options:
+  operatorController:
+    features:
+      enabled:
+        - WebhookProviderCertManager
+        - SingleOwnNamespaceInstallSupport
+        - PreflightPermissions
+        - HelmChartSupport
+        - BoxcutterRuntime
+      disabled:
+        - WebhookProviderOpenshiftServiceCA
+# List of enabled experimental features for catalogd
+# Use with {{- if has "FeatureGate" .Values.options.catalogd.features.enabled }}
+# to pull in resources or additions
+  catalogd:
+    features:
+      enabled:
+        - APIV1MetasHandler
+# This can be one of: standard or experimental
   featureSet: experimental

--- a/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
@@ -48,6 +48,15 @@ spec:
             {{- range .Values.catalogdFeatures }}
             - --feature-gates={{- . -}}=true
             {{- end }}
+            {{- range .Values.options.catalogd.features.enabled }}
+            - --feature-gates={{- . -}}=true
+            {{- end }}
+            {{- range .Values.options.catalogd.features.disabled }}
+            - --feature-gates={{- . -}}=false
+            {{- end }}
+            {{- range .Values.options.catalogd.deployment.extraArguments }}
+            - {{ . -}}
+            {{- end }}
             {{- if .Values.options.certManager.enabled }}
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key

--- a/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
@@ -47,6 +47,15 @@ spec:
             {{- range .Values.operatorControllerFeatures }}
             - --feature-gates={{- . -}}=true
             {{- end }}
+            {{- range .Values.options.operatorController.features.enabled }}
+            - --feature-gates={{- . -}}=true
+            {{- end }}
+            {{- range .Values.options.operatorController.features.disabled }}
+            - --feature-gates={{- . -}}=false
+            {{- end }}
+            {{- range .Values.options.operatorController.deployment.extraArguments }}
+            - {{ . -}}
+            {{- end }}
             {{- if .Values.options.certManager.enabled }}
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key

--- a/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
+++ b/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: operator-controller
     {{- include "olmv1.labels" $ | nindent 4 }}
-{{- if has "BoxcutterRuntime" .Values.operatorControllerFeatures }}
+{{- if or (has "BoxcutterRuntime" .Values.options.operatorController.features.enabled) (has "BoxcutterRuntime" .Values.operatorControllerFeatures) }}
   name: operator-controller-manager-admin-rolebinding
 {{- else }}
   name: operator-controller-manager-rolebinding
@@ -16,7 +16,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-{{- if has "BoxcutterRuntime" .Values.operatorControllerFeatures }}
+{{- if or (has "BoxcutterRuntime" .Values.options.operatorController.features.enabled) (has "BoxcutterRuntime" .Values.operatorControllerFeatures) }}
   name: cluster-admin
 {{- else }}
   name: operator-controller-manager-role

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -8,10 +8,18 @@ options:
     enabled: true
     deployment:
       image: quay.io/operator-framework/operator-controller:devel
+      extraArguments: []
+    features:
+      enabled: []
+      disabled: []
   catalogd:
     enabled: true
     deployment:
       image: quay.io/operator-framework/catalogd:devel
+      extraArguments: []
+    features:
+      enabled: []
+      disabled: []
   certManager:
     enabled: false
   e2e:
@@ -25,9 +33,9 @@ options:
   # This can be one of: standard or experimental
   featureSet: standard
 
+# Deprecated: The list of features
 operatorControllerFeatures: []
 catalogdFeatures: []
-
 
 # The set of namespaces
 namespaces:

--- a/helm/tilt.yaml
+++ b/helm/tilt.yaml
@@ -11,12 +11,16 @@ options:
   tilt:
     enabled: true
   featureSet: experimental
-
-operatorControllerFeatures:
-  - WebhookProviderCertManager
-  - SingleOwnNamespaceInstallSupport
-  - PreflightPermissions
-  - HelmChartSupport
-
-catalogdFeatures:
-  - APIV1MetasHandler
+  operatorController:
+    features:
+      enabled:
+        - WebhookProviderCertManager
+        - SingleOwnNamespaceInstallSupport
+        - PreflightPermissions
+        - HelmChartSupport
+      disabled:
+        - WebhookProviderOpenshiftServiceCA
+  catalogd:
+    features:
+      enabled:
+        - APIV1MetasHandler

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -2188,6 +2188,7 @@ spec:
             - --feature-gates=PreflightPermissions=true
             - --feature-gates=HelmChartSupport=true
             - --feature-gates=BoxcutterRuntime=true
+            - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -2101,6 +2101,7 @@ spec:
             - --feature-gates=PreflightPermissions=true
             - --feature-gates=HelmChartSupport=true
             - --feature-gates=BoxcutterRuntime=true
+            - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs


### PR DESCRIPTION
The Helm manifests only support _enabling_ feature-gates. To allow for flexibility in configuring mutually-exclusive feature-gates and additional parameters that might be needed, add Helm templating for disabled feature gates and extra arguments to the deployments.

NOTE: This deprecates the old location of feature-gate config, and moves it to a new location. This is necessary to keep downstream from breaking during this transition.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
