### PR TITLE
:seedling: Clean up deprecated feature enablement mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ update-crds:
 #
 # Override HELM_SETTINGS on the command line to include additional Helm settings
 # e.g. make HELM_SETTINGS="options.openshift.enabled=true" manifests
-# e.g. make HELM_SETTINGS="operatorControllerFeatures={WebhookProviderCertManager}" manifests
+# e.g. make HELM_SETTINGS="options.operatorController.features.enabled={WebhookProviderCertManager}" manifests
 #
 MANIFESTS ?= $(STANDARD_MANIFEST) $(STANDARD_E2E_MANIFEST) $(EXPERIMENTAL_MANIFEST) $(EXPERIMENTAL_E2E_MANIFEST)
 $(STANDARD_MANIFEST) ?= helm/cert-manager.yaml

--- a/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
@@ -45,9 +45,6 @@ spec:
             {{- end }}
             - --metrics-bind-address=:7443
             - --external-address=catalogd-service.{{ .Values.namespaces.olmv1.name }}.svc
-            {{- range .Values.catalogdFeatures }}
-            - --feature-gates={{- . -}}=true
-            {{- end }}
             {{- range .Values.options.catalogd.features.enabled }}
             - --feature-gates={{- . -}}=true
             {{- end }}

--- a/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
@@ -44,9 +44,6 @@ spec:
             {{- if not .Values.options.tilt.enabled }}
             - --leader-elect
             {{- end }}
-            {{- range .Values.operatorControllerFeatures }}
-            - --feature-gates={{- . -}}=true
-            {{- end }}
             {{- range .Values.options.operatorController.features.enabled }}
             - --feature-gates={{- . -}}=true
             {{- end }}

--- a/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
+++ b/helm/olmv1/templates/rbac/clusterrolebinding-operator-controller-manager-rolebinding.yml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: operator-controller
     {{- include "olmv1.labels" $ | nindent 4 }}
-{{- if or (has "BoxcutterRuntime" .Values.options.operatorController.features.enabled) (has "BoxcutterRuntime" .Values.operatorControllerFeatures) }}
+{{- if has "BoxcutterRuntime" .Values.options.operatorController.features.enabled }}
   name: operator-controller-manager-admin-rolebinding
 {{- else }}
   name: operator-controller-manager-rolebinding
@@ -16,7 +16,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-{{- if or (has "BoxcutterRuntime" .Values.options.operatorController.features.enabled) (has "BoxcutterRuntime" .Values.operatorControllerFeatures) }}
+{{- if has "BoxcutterRuntime" .Values.options.operatorController.features.enabled }}
   name: cluster-admin
 {{- else }}
   name: operator-controller-manager-role

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -33,10 +33,6 @@ options:
   # This can be one of: standard or experimental
   featureSet: standard
 
-# Deprecated: The list of features
-operatorControllerFeatures: []
-catalogdFeatures: []
-
 # The set of namespaces
 namespaces:
   olmv1:


### PR DESCRIPTION
This removes `operatorControllerFeatures` and `catalogdFeatures` in favor of `options.<component>.features.{enabled|disabled}`.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
