### PR TITLE
:bug: Add option to yamlfmt to ignore vendor directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ fix-lint: $(GOLANGCI_LINT) #EXHELP Fix lint issues
 .PHONY: fmt
 fmt: $(YAMLFMT) #EXHELP Formats code
 	go fmt ./...
-	$(YAMLFMT) testdata
+	$(YAMLFMT) -gitignore_excludes testdata
 
 .PHONY: update-tls-profiles
 update-tls-profiles: $(GOJQ) #EXHELP Update TLS profiles from the Mozilla wiki


### PR DESCRIPTION
The `make fmt` target now includes YAML formatting. This is causing an issue downstream where vendored YAML files are being formatted. This fix excludes vendor directories (and other files) based on the project's .gitignore.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
