### PR TITLE
:seedling: Refactor BundleValidator to a concrete class

### DIFF
--- a/internal/operator-controller/rukpak/render/registryv1/validators/v2/validator.go
+++ b/internal/operator-controller/rukpak/render/registryv1/validators/v2/validator.go
@@ -1,0 +1,356 @@
+package validator
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/bundle"
+)
+
+var (
+	// forbiddenWebhookRuleAPIGroups contain the API groups that are forbidden for webhook configuration rules in OLMv1
+	forbiddenWebhookRuleAPIGroups = sets.New("olm.operatorframework.io", "*")
+
+	// forbiddenAdmissionRegistrationResources contain the resources that are forbidden for webhook configuration rules
+	// for the admissionregistration.k8s.io api group
+	forbiddenAdmissionRegistrationResources = sets.New(
+		"*",
+		"mutatingwebhookconfiguration",
+		"mutatingwebhookconfigurations",
+		"validatingwebhookconfiguration",
+		"validatingwebhookconfigurations",
+	)
+)
+
+// BundleValidator does static validation on registry+v1 bundles and their ClusterServiceVersion resource.
+type BundleValidator struct{}
+
+func (v BundleValidator) Validate(rv1 *bundle.RegistryV1) []error {
+	validators := []func(rv1 *bundle.RegistryV1) []error{
+		v.CheckDeploymentSpecUniqueness,
+		v.CheckDeploymentNameIsDNS1123SubDomain,
+		v.CheckCRDResourceUniqueness,
+		v.CheckOwnedCRDExistence,
+		v.CheckPackageNameNotEmpty,
+		v.CheckConversionWebhookSupport,
+		v.CheckWebhookDeploymentReferentialIntegrity,
+		v.CheckWebhookNameUniqueness,
+		v.CheckWebhookNameIsDNS1123SubDomain,
+		v.CheckConversionWebhookCRDReferenceUniqueness,
+		v.CheckConversionWebhooksReferenceOwnedCRDs,
+		v.CheckWebhookRules,
+	}
+	var errs []error
+	for _, validator := range validators {
+		errs = append(errs, validator(rv1)...)
+	}
+	return errs
+}
+
+// CheckDeploymentSpecUniqueness checks that each strategy deployment spec in the csv has a unique name.
+// Errors are sorted by deployment name.
+func (v BundleValidator) CheckDeploymentSpecUniqueness(rv1 *bundle.RegistryV1) []error {
+	deploymentNameSet := sets.Set[string]{}
+	duplicateDeploymentNames := sets.Set[string]{}
+	for _, dep := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		if deploymentNameSet.Has(dep.Name) {
+			duplicateDeploymentNames.Insert(dep.Name)
+		}
+		deploymentNameSet.Insert(dep.Name)
+	}
+
+	errs := make([]error, 0, len(duplicateDeploymentNames))
+	for _, d := range slices.Sorted(slices.Values(duplicateDeploymentNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("cluster service version contains duplicate strategy deployment spec '%s'", d))
+	}
+	return errs
+}
+
+// CheckDeploymentNameIsDNS1123SubDomain checks each deployment strategy spec name complies with the Kubernetes
+// resource naming conversions
+func (v BundleValidator) CheckDeploymentNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
+	deploymentNameErrMap := map[string][]string{}
+	for _, dep := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		errs := validation.IsDNS1123Subdomain(dep.Name)
+		if len(errs) > 0 {
+			slices.Sort(errs)
+			deploymentNameErrMap[dep.Name] = errs
+		}
+	}
+
+	errs := make([]error, 0, len(deploymentNameErrMap))
+	for _, dep := range slices.Sorted(maps.Keys(deploymentNameErrMap)) {
+		errs = append(errs, fmt.Errorf("invalid cluster service version strategy deployment name '%s': %s", dep, strings.Join(deploymentNameErrMap[dep], ", ")))
+	}
+	return errs
+}
+
+// CheckOwnedCRDExistence checks bundle owned custom resource definitions declared in the csv exist in the bundle
+func (v BundleValidator) CheckOwnedCRDExistence(rv1 *bundle.RegistryV1) []error {
+	crdsNames := sets.Set[string]{}
+	for _, crd := range rv1.CRDs {
+		crdsNames.Insert(crd.Name)
+	}
+
+	missingCRDNames := sets.Set[string]{}
+	for _, crd := range rv1.CSV.Spec.CustomResourceDefinitions.Owned {
+		if !crdsNames.Has(crd.Name) {
+			missingCRDNames.Insert(crd.Name)
+		}
+	}
+
+	errs := make([]error, 0, len(missingCRDNames))
+	for _, crdName := range slices.Sorted(slices.Values(missingCRDNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("cluster service definition references owned custom resource definition '%s' not found in bundle", crdName))
+	}
+	return errs
+}
+
+// CheckCRDResourceUniqueness checks that the bundle CRD names are unique
+func (v BundleValidator) CheckCRDResourceUniqueness(rv1 *bundle.RegistryV1) []error {
+	crdsNames := sets.Set[string]{}
+	duplicateCRDNames := sets.Set[string]{}
+	for _, crd := range rv1.CRDs {
+		if crdsNames.Has(crd.Name) {
+			duplicateCRDNames.Insert(crd.Name)
+		}
+		crdsNames.Insert(crd.Name)
+	}
+
+	errs := make([]error, 0, len(duplicateCRDNames))
+	for _, crdName := range slices.Sorted(slices.Values(duplicateCRDNames.UnsortedList())) {
+		errs = append(errs, fmt.Errorf("bundle contains duplicate custom resource definition '%s'", crdName))
+	}
+	return errs
+}
+
+// CheckPackageNameNotEmpty checks that PackageName is not empty
+func (v BundleValidator) CheckPackageNameNotEmpty(rv1 *bundle.RegistryV1) []error {
+	if rv1.PackageName == "" {
+		return []error{errors.New("package name is empty")}
+	}
+	return nil
+}
+
+// CheckConversionWebhookSupport checks that if the bundle cluster service version declares conversion webhook definitions,
+// that the bundle also only supports AllNamespaces install mode. This keeps parity with OLMv0 behavior for conversion webhooks,
+// https://github.com/operator-framework/operator-lifecycle-manager/blob/dfd0b2bea85038d3c0d65348bc812d297f16b8d2/pkg/controller/install/webhook.go#L193
+func (v BundleValidator) CheckConversionWebhookSupport(rv1 *bundle.RegistryV1) []error {
+	var conversionWebhookNames []string
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		if wh.Type == v1alpha1.ConversionWebhook {
+			conversionWebhookNames = append(conversionWebhookNames, wh.GenerateName)
+		}
+	}
+
+	if len(conversionWebhookNames) > 0 {
+		supportedInstallModes := sets.Set[v1alpha1.InstallModeType]{}
+		for _, mode := range rv1.CSV.Spec.InstallModes {
+			if mode.Supported {
+				supportedInstallModes.Insert(mode.Type)
+			}
+		}
+
+		if len(supportedInstallModes) != 1 || !supportedInstallModes.Has(v1alpha1.InstallModeTypeAllNamespaces) {
+			sortedModes := slices.Sorted(slices.Values(supportedInstallModes.UnsortedList()))
+			errs := make([]error, len(conversionWebhookNames))
+			for i, webhookName := range conversionWebhookNames {
+				errs[i] = fmt.Errorf("bundle contains conversion webhook %q and supports install modes %v - conversion webhooks are only supported for bundles that only support AllNamespaces install mode", webhookName, sortedModes)
+			}
+			return errs
+		}
+	}
+
+	return nil
+}
+
+// CheckWebhookDeploymentReferentialIntegrity checks that each webhook definition in the csv
+// references an existing strategy deployment spec. Errors are sorted by strategy deployment spec name,
+// webhook type, and webhook name.
+func (v BundleValidator) CheckWebhookDeploymentReferentialIntegrity(rv1 *bundle.RegistryV1) []error {
+	webhooksByDeployment := map[string][]v1alpha1.WebhookDescription{}
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		webhooksByDeployment[wh.DeploymentName] = append(webhooksByDeployment[wh.DeploymentName], wh)
+	}
+
+	for _, depl := range rv1.CSV.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		delete(webhooksByDeployment, depl.Name)
+	}
+
+	var errs []error
+	// Loop through sorted keys to keep error messages ordered by deployment name
+	for _, deploymentName := range slices.Sorted(maps.Keys(webhooksByDeployment)) {
+		webhookDefns := webhooksByDeployment[deploymentName]
+		slices.SortFunc(webhookDefns, func(a, b v1alpha1.WebhookDescription) int {
+			return cmp.Or(cmp.Compare(a.Type, b.Type), cmp.Compare(a.GenerateName, b.GenerateName))
+		})
+		for _, webhookDef := range webhookDefns {
+			errs = append(errs, fmt.Errorf("webhook of type '%s' with name '%s' references non-existent deployment '%s'", webhookDef.Type, webhookDef.GenerateName, webhookDef.DeploymentName))
+		}
+	}
+	return errs
+}
+
+// CheckWebhookNameUniqueness checks that each webhook definition of each type (validating, mutating, or conversion)
+// has a unique name. Webhooks of different types can have the same name. Errors are sorted by webhook type
+// and name.
+func (v BundleValidator) CheckWebhookNameUniqueness(rv1 *bundle.RegistryV1) []error {
+	webhookNameSetByType := map[v1alpha1.WebhookAdmissionType]sets.Set[string]{}
+	duplicateWebhooksByType := map[v1alpha1.WebhookAdmissionType]sets.Set[string]{}
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		if _, ok := webhookNameSetByType[wh.Type]; !ok {
+			webhookNameSetByType[wh.Type] = sets.Set[string]{}
+		}
+		if webhookNameSetByType[wh.Type].Has(wh.GenerateName) {
+			if _, ok := duplicateWebhooksByType[wh.Type]; !ok {
+				duplicateWebhooksByType[wh.Type] = sets.Set[string]{}
+			}
+			duplicateWebhooksByType[wh.Type].Insert(wh.GenerateName)
+		}
+		webhookNameSetByType[wh.Type].Insert(wh.GenerateName)
+	}
+
+	var errs []error
+	for _, whType := range slices.Sorted(maps.Keys(duplicateWebhooksByType)) {
+		for _, webhookName := range slices.Sorted(slices.Values(duplicateWebhooksByType[whType].UnsortedList())) {
+			errs = append(errs, fmt.Errorf("duplicate webhook '%s' of type '%s'", webhookName, whType))
+		}
+	}
+	return errs
+}
+
+// CheckConversionWebhooksReferenceOwnedCRDs checks defined conversion webhooks reference bundle owned CRDs.
+// Errors are sorted by webhook name and CRD name.
+func (v BundleValidator) CheckConversionWebhooksReferenceOwnedCRDs(rv1 *bundle.RegistryV1) []error {
+	//nolint:prealloc
+	var conversionWebhooks []v1alpha1.WebhookDescription
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		if wh.Type != v1alpha1.ConversionWebhook {
+			continue
+		}
+		conversionWebhooks = append(conversionWebhooks, wh)
+	}
+
+	if len(conversionWebhooks) == 0 {
+		return nil
+	}
+
+	ownedCRDNames := sets.Set[string]{}
+	for _, crd := range rv1.CSV.Spec.CustomResourceDefinitions.Owned {
+		ownedCRDNames.Insert(crd.Name)
+	}
+
+	slices.SortFunc(conversionWebhooks, func(a, b v1alpha1.WebhookDescription) int {
+		return cmp.Compare(a.GenerateName, b.GenerateName)
+	})
+
+	var errs []error
+	for _, webhook := range conversionWebhooks {
+		webhookCRDs := webhook.ConversionCRDs
+		slices.Sort(webhookCRDs)
+		for _, crd := range webhookCRDs {
+			if !ownedCRDNames.Has(crd) {
+				errs = append(errs, fmt.Errorf("conversion webhook '%s' references custom resource definition '%s' not owned bundle", webhook.GenerateName, crd))
+			}
+		}
+	}
+	return errs
+}
+
+// CheckConversionWebhookCRDReferenceUniqueness checks no two (or more) conversion webhooks reference the same CRD.
+func (v BundleValidator) CheckConversionWebhookCRDReferenceUniqueness(rv1 *bundle.RegistryV1) []error {
+	// collect webhooks by crd
+	crdToWh := map[string][]string{}
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		if wh.Type != v1alpha1.ConversionWebhook {
+			continue
+		}
+		for _, crd := range wh.ConversionCRDs {
+			crdToWh[crd] = append(crdToWh[crd], wh.GenerateName)
+		}
+	}
+
+	// remove crds with single webhook
+	maps.DeleteFunc(crdToWh, func(crd string, whs []string) bool {
+		return len(whs) == 1
+	})
+
+	errs := make([]error, 0, len(crdToWh))
+	orderedCRDs := slices.Sorted(maps.Keys(crdToWh))
+	for _, crd := range orderedCRDs {
+		orderedWhs := strings.Join(slices.Sorted(slices.Values(crdToWh[crd])), ",")
+		errs = append(errs, fmt.Errorf("conversion webhooks [%s] reference same custom resource definition '%s'", orderedWhs, crd))
+	}
+	return errs
+}
+
+// CheckWebhookNameIsDNS1123SubDomain checks each webhook configuration name complies with the Kubernetes resource naming conversions
+func (v BundleValidator) CheckWebhookNameIsDNS1123SubDomain(rv1 *bundle.RegistryV1) []error {
+	invalidWebhooksByType := map[v1alpha1.WebhookAdmissionType]map[string][]string{}
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		if _, ok := invalidWebhooksByType[wh.Type]; !ok {
+			invalidWebhooksByType[wh.Type] = map[string][]string{}
+		}
+		errs := validation.IsDNS1123Subdomain(wh.GenerateName)
+		if len(errs) > 0 {
+			slices.Sort(errs)
+			invalidWebhooksByType[wh.Type][wh.GenerateName] = errs
+		}
+	}
+
+	var errs []error
+	for _, whType := range slices.Sorted(maps.Keys(invalidWebhooksByType)) {
+		for _, webhookName := range slices.Sorted(maps.Keys(invalidWebhooksByType[whType])) {
+			errs = append(errs, fmt.Errorf("webhook of type '%s' has invalid name '%s': %s", whType, webhookName, strings.Join(invalidWebhooksByType[whType][webhookName], ",")))
+		}
+	}
+	return errs
+}
+
+// CheckWebhookRules ensures webhook rules do not reference forbidden API groups or resources in line with OLMv0 behavior
+// The following are forbidden, rules targeting:
+//   - all API groups (i.e. '*')
+//   - OLMv1 API group (i.e. 'olm.operatorframework.io')
+//   - all resources under the 'admissionregistration.k8s.io' API group
+//   - the 'ValidatingWebhookConfiguration' resource under the 'admissionregistration.k8s.io' API group
+//   - the 'MutatingWebhookConfiguration' resource under the 'admissionregistration.k8s.io' API group
+//
+// These boundaries attempt to reduce the blast radius of faulty webhooks and avoid deadlocks preventing the user
+// from deleting OLMv1 resources installing and managing the faulty webhook, or deleting faulty admission webhook
+// configurations.
+// See https://github.com/operator-framework/operator-lifecycle-manager/blob/ccf0c4c91f1e7673e87f3a18947f9a1f88d48438/pkg/controller/install/webhook.go#L19
+// for more details
+func (v BundleValidator) CheckWebhookRules(rv1 *bundle.RegistryV1) []error {
+	var errs []error
+	for _, wh := range rv1.CSV.Spec.WebhookDefinitions {
+		// Rules are not used for conversion webhooks
+		if wh.Type == v1alpha1.ConversionWebhook {
+			continue
+		}
+		webhookName := wh.GenerateName
+		for _, rule := range wh.Rules {
+			for _, apiGroup := range rule.APIGroups {
+				if forbiddenWebhookRuleAPIGroups.Has(apiGroup) {
+					errs = append(errs, fmt.Errorf("webhook %q contains forbidden rule: admission webhook rules cannot reference API group %q", webhookName, apiGroup))
+				}
+				if apiGroup == "admissionregistration.k8s.io" {
+					for _, resource := range rule.Resources {
+						if forbiddenAdmissionRegistrationResources.Has(strings.ToLower(resource)) {
+							errs = append(errs, fmt.Errorf("webhook %q contains forbidden rule: admission webhook rules cannot reference resource %q for API group %q", webhookName, resource, apiGroup))
+						}
+					}
+				}
+			}
+		}
+	}
+	return errs
+}

--- a/internal/operator-controller/rukpak/render/registryv1/validators/v2/validator_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/validators/v2/validator_test.go
@@ -1,0 +1,1404 @@
+package validator_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/bundle"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/render/registryv1/validators"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/render/registryv1/validators/v2"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/util/testing/clusterserviceversion"
+)
+
+func Test_BundleValidator_Validate(t *testing.T) {
+	// tries to exercise each validation function once
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "rejects bundles with duplicate deployment strategy spec names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-one'"),
+			},
+		},
+		{
+			name: "rejects bundles with invalid deployment strategy spec names - errors are sorted by name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "-bad-name"},
+						v1alpha1.StrategyDeploymentSpec{Name: "b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long"},
+						v1alpha1.StrategyDeploymentSpec{Name: "a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("invalid cluster service version strategy deployment name '-bad-name': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("invalid cluster service version strategy deployment name 'a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), must be no more than 253 characters"),
+				errors.New("invalid cluster service version strategy deployment name 'b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long': must be no more than 253 characters"),
+			},
+		},
+		{
+			name: "rejects bundles with duplicate custom resource definition resources",
+			bundle: &bundle.RegistryV1{CRDs: []apiextensionsv1.CustomResourceDefinition{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+			}},
+			expectedErrs: []error{
+				errors.New("bundle contains duplicate custom resource definition 'a.crd.something'"),
+			},
+		},
+		{
+			name: "rejects bundles with missing owned custom resource definition resources",
+			bundle: &bundle.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{},
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(v1alpha1.CRDDescription{Name: "a.crd.something"}).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service definition references owned custom resource definition 'a.crd.something' not found in bundle"),
+			},
+		},
+		{
+			name:   "rejects bundles with empty package name",
+			bundle: &bundle.RegistryV1{},
+			expectedErrs: []error{
+				errors.New("package name is empty"),
+			},
+		},
+		{
+			name: "rejects bundles with conversion webhook definitions when they support more modes than AllNamespaces install mode",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeSingleNamespace, v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							GenerateName: "webhook-b",
+							Type:         v1alpha1.ConversionWebhook,
+						},
+						v1alpha1.WebhookDescription{
+							GenerateName: "webhook-a",
+							Type:         v1alpha1.ConversionWebhook,
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("bundle contains conversion webhook \"webhook-b\" and supports install modes [AllNamespaces SingleNamespace] - conversion webhooks are only supported for bundles that only support AllNamespaces install mode"),
+				errors.New("bundle contains conversion webhook \"webhook-a\" and supports install modes [AllNamespaces SingleNamespace] - conversion webhooks are only supported for bundles that only support AllNamespaces install mode"),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and '*' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"*"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"*\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "rejects bundles with webhook definitions that reference non-existing strategy deployment specs",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName:   "test-webhook",
+							DeploymentName: "test-deployment-two",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' with name 'test-webhook' references non-existent deployment 'test-deployment-two'"),
+			},
+		},
+		{
+			name: "rejects bundles with duplicate validating webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("duplicate webhook 'test-webhook' of type 'ValidatingAdmissionWebhook'"),
+			},
+		},
+		{
+			name: "rejects bundles with conversion webhooks that reference existing CRDs that are not owned",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+								"another.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhook 'test-webhook' references custom resource definition 'another.crd.something' not owned bundle"),
+			},
+		},
+		{
+			name: "rejects bundles with conversion webhooks that reference the same CRD",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-two",
+							ConversionCRDs: []string{
+								"some.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhooks [test-webhook,test-webhook-two] reference same custom resource definition 'some.crd.something'"),
+			},
+		},
+		{
+			name: "rejects bundles with invalid webhook definitions names and orders errors by webhook type and name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "a-bad-name-",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook of type 'ConversionWebhook' has invalid name 'a-bad-name-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validator.BundleValidator{}.Validate(tc.bundle)
+			for _, err := range tc.expectedErrs {
+				require.Contains(t, errs, err)
+			}
+		})
+	}
+}
+
+func Test_BundleValidator_CheckDeploymentSpecUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with unique deployment strategy spec names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+					).Build(),
+			},
+			expectedErrs: []error{},
+		}, {
+			name: "rejects bundles with duplicate deployment strategy spec names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-one'"),
+			},
+		}, {
+			name: "errors are ordered by deployment strategy spec name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-a"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-b"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-c"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-b"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-a"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-a'"),
+				errors.New("cluster service version contains duplicate strategy deployment spec 'test-deployment-b'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckDeploymentSpecUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckDeploymentNameIsDNS1123SubDomain(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts valid deployment strategy spec names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+					).Build(),
+			},
+			expectedErrs: []error{},
+		}, {
+			name: "rejects bundles with invalid deployment strategy spec names - errors are sorted by name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "-bad-name"},
+						v1alpha1.StrategyDeploymentSpec{Name: "b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long"},
+						v1alpha1.StrategyDeploymentSpec{Name: "a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("invalid cluster service version strategy deployment name '-bad-name': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("invalid cluster service version strategy deployment name 'a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), must be no more than 253 characters"),
+				errors.New("invalid cluster service version strategy deployment name 'b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long': must be no more than 253 characters"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckDeploymentNameIsDNS1123SubDomain(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CRDResourceUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with unique custom resource definition resources",
+			bundle: &bundle.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b.crd.something"}},
+				},
+			},
+			expectedErrs: []error{},
+		}, {
+			name: "rejects bundles with duplicate custom resource definition resources",
+			bundle: &bundle.RegistryV1{CRDs: []apiextensionsv1.CustomResourceDefinition{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+			}},
+			expectedErrs: []error{
+				errors.New("bundle contains duplicate custom resource definition 'a.crd.something'"),
+			},
+		}, {
+			name: "errors are ordered by custom resource definition name",
+			bundle: &bundle.RegistryV1{CRDs: []apiextensionsv1.CustomResourceDefinition{
+				{ObjectMeta: metav1.ObjectMeta{Name: "c.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "c.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+			}},
+			expectedErrs: []error{
+				errors.New("bundle contains duplicate custom resource definition 'a.crd.something'"),
+				errors.New("bundle contains duplicate custom resource definition 'c.crd.something'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckCRDResourceUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckOwnedCRDExistence(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with existing owned custom resource definition resources",
+			bundle: &bundle.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a.crd.something"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b.crd.something"}},
+				},
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "a.crd.something"},
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					).Build(),
+			},
+			expectedErrs: []error{},
+		}, {
+			name: "rejects bundles with missing owned custom resource definition resources",
+			bundle: &bundle.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{},
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(v1alpha1.CRDDescription{Name: "a.crd.something"}).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service definition references owned custom resource definition 'a.crd.something' not found in bundle"),
+			},
+		}, {
+			name: "errors are ordered by owned custom resource definition name",
+			bundle: &bundle.RegistryV1{
+				CRDs: []apiextensionsv1.CustomResourceDefinition{},
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "a.crd.something"},
+						v1alpha1.CRDDescription{Name: "c.crd.something"},
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("cluster service definition references owned custom resource definition 'a.crd.something' not found in bundle"),
+				errors.New("cluster service definition references owned custom resource definition 'b.crd.something' not found in bundle"),
+				errors.New("cluster service definition references owned custom resource definition 'c.crd.something' not found in bundle"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckOwnedCRDExistence(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckPackageNameNotEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with non-empty package name",
+			bundle: &bundle.RegistryV1{
+				PackageName: "not-empty",
+			},
+		}, {
+			name:   "rejects bundles with empty package name",
+			bundle: &bundle.RegistryV1{},
+			expectedErrs: []error{
+				errors.New("package name is empty"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckPackageNameNotEmpty(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckWebhookSupport(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with conversion webhook definitions when they only support AllNamespaces install mode",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.ConversionWebhook,
+						},
+					).Build(),
+			},
+		},
+		{
+			name: "accepts bundles with validating webhook definitions when they support more modes than AllNamespaces install mode",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces, v1alpha1.InstallModeTypeSingleNamespace).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.ValidatingAdmissionWebhook,
+						},
+					).Build(),
+			},
+		},
+		{
+			name: "accepts bundles with mutating webhook definitions when they support more modes than AllNamespaces install mode",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces, v1alpha1.InstallModeTypeSingleNamespace).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.MutatingAdmissionWebhook,
+						},
+					).Build(),
+			},
+		},
+		{
+			name: "rejects bundles with conversion webhook definitions when they support more modes than AllNamespaces install mode",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeSingleNamespace, v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							GenerateName: "webhook-b",
+							Type:         v1alpha1.ConversionWebhook,
+						},
+						v1alpha1.WebhookDescription{
+							GenerateName: "webhook-a",
+							Type:         v1alpha1.ConversionWebhook,
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("bundle contains conversion webhook \"webhook-b\" and supports install modes [AllNamespaces SingleNamespace] - conversion webhooks are only supported for bundles that only support AllNamespaces install mode"),
+				errors.New("bundle contains conversion webhook \"webhook-a\" and supports install modes [AllNamespaces SingleNamespace] - conversion webhooks are only supported for bundles that only support AllNamespaces install mode"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckConversionWebhookSupport(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckWebhookRules(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles with webhook definitions without rules",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.ValidatingAdmissionWebhook,
+						},
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.MutatingAdmissionWebhook,
+						},
+					).Build(),
+			},
+		},
+		{
+			name: "accepts bundles with webhook definitions with supported rules",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.ValidatingAdmissionWebhook,
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"appsv1"},
+										Resources: []string{"deployments", "replicasets", "statefulsets"},
+									},
+								},
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type: v1alpha1.MutatingAdmissionWebhook,
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{""},
+										Resources: []string{"services"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing '*' api group",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-z",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"*"},
+									},
+								},
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"*"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-z\" contains forbidden rule: admission webhook rules cannot reference API group \"*\""),
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference API group \"*\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'olm.operatorframework.io' api group",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-z",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"olm.operatorframework.io"},
+									},
+								},
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"olm.operatorframework.io"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-z\" contains forbidden rule: admission webhook rules cannot reference API group \"olm.operatorframework.io\""),
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference API group \"olm.operatorframework.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and '*' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"*"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"*\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'MutatingWebhookConfiguration' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"MutatingWebhookConfiguration"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"MutatingWebhookConfiguration\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'mutatingwebhookconfiguration' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"mutatingwebhookconfiguration"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"mutatingwebhookconfiguration\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'mutatingwebhookconfigurations' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"mutatingwebhookconfigurations"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"mutatingwebhookconfigurations\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'ValidatingWebhookConfiguration' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"ValidatingWebhookConfiguration"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"ValidatingWebhookConfiguration\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'validatingwebhookconfiguration' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"validatingwebhookconfiguration"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"validatingwebhookconfiguration\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+		{
+			name: "reject bundles with webhook definitions with rules containing 'admissionregistration.k8s.io' api group and 'validatingwebhookconfigurations' resource",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithInstallModeSupportFor(v1alpha1.InstallModeTypeAllNamespaces).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "webhook-a",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups: []string{"admissionregistration.k8s.io"},
+										Resources: []string{"validatingwebhookconfigurations"},
+									},
+								},
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook \"webhook-a\" contains forbidden rule: admission webhook rules cannot reference resource \"validatingwebhookconfigurations\" for API group \"admissionregistration.k8s.io\""),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validators.CheckWebhookRules(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckWebhookDeploymentReferentialIntegrity(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles where webhook definitions reference existing strategy deployment specs",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-two"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.MutatingAdmissionWebhook,
+							GenerateName:   "test-webhook",
+							DeploymentName: "test-deployment-one",
+						},
+					).Build(),
+			},
+		}, {
+			name: "rejects bundles with webhook definitions that reference non-existing strategy deployment specs",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName:   "test-webhook",
+							DeploymentName: "test-deployment-two",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' with name 'test-webhook' references non-existent deployment 'test-deployment-two'"),
+			},
+		}, {
+			name: "errors are ordered by deployment strategy spec name, webhook type, and webhook name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithStrategyDeploymentSpecs(
+						v1alpha1.StrategyDeploymentSpec{Name: "test-deployment-one"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName:   "test-val-webhook-c",
+							DeploymentName: "test-deployment-c",
+						},
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.MutatingAdmissionWebhook,
+							GenerateName:   "test-mute-webhook-a",
+							DeploymentName: "test-deployment-a",
+						},
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ConversionWebhook,
+							GenerateName:   "test-conv-webhook-b",
+							DeploymentName: "test-deployment-b",
+						}, v1alpha1.WebhookDescription{
+							Type:           v1alpha1.MutatingAdmissionWebhook,
+							GenerateName:   "test-mute-webhook-c",
+							DeploymentName: "test-deployment-c",
+						},
+						v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ConversionWebhook,
+							GenerateName:   "test-conv-webhook-c-b",
+							DeploymentName: "test-deployment-c",
+						}, v1alpha1.WebhookDescription{
+							Type:           v1alpha1.ConversionWebhook,
+							GenerateName:   "test-conv-webhook-c-a",
+							DeploymentName: "test-deployment-c",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook of type 'MutatingAdmissionWebhook' with name 'test-mute-webhook-a' references non-existent deployment 'test-deployment-a'"),
+				errors.New("webhook of type 'ConversionWebhook' with name 'test-conv-webhook-b' references non-existent deployment 'test-deployment-b'"),
+				errors.New("webhook of type 'ConversionWebhook' with name 'test-conv-webhook-c-a' references non-existent deployment 'test-deployment-c'"),
+				errors.New("webhook of type 'ConversionWebhook' with name 'test-conv-webhook-c-b' references non-existent deployment 'test-deployment-c'"),
+				errors.New("webhook of type 'MutatingAdmissionWebhook' with name 'test-mute-webhook-c' references non-existent deployment 'test-deployment-c'"),
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' with name 'test-val-webhook-c' references non-existent deployment 'test-deployment-c'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckWebhookDeploymentReferentialIntegrity(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckWebhookNameUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles without webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().Build(),
+			},
+		}, {
+			name: "accepts bundles with unique webhook names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-webhook-one",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook-two",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-three",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-webhook-four",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook-five",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-six",
+						},
+					).Build(),
+			},
+		}, {
+			name: "accepts bundles with webhooks with the same name but different types",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+						},
+					).Build(),
+			},
+		}, {
+			name: "rejects bundles with duplicate validating webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("duplicate webhook 'test-webhook' of type 'ValidatingAdmissionWebhook'"),
+			},
+		}, {
+			name: "rejects bundles with duplicate mutating webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-webhook",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("duplicate webhook 'test-webhook' of type 'MutatingAdmissionWebhook'"),
+			},
+		}, {
+			name: "rejects bundles with duplicate conversion webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("duplicate webhook 'test-webhook' of type 'ConversionWebhook'"),
+			},
+		}, {
+			name: "orders errors by webhook type and name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook-b",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook-a",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook-a",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook-b",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-conv-webhook-b",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-conv-webhook-a",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-conv-webhook-a",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-conv-webhook-b",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook-b",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook-a",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook-a",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook-b",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("duplicate webhook 'test-conv-webhook-a' of type 'ConversionWebhook'"),
+				errors.New("duplicate webhook 'test-conv-webhook-b' of type 'ConversionWebhook'"),
+				errors.New("duplicate webhook 'test-mute-webhook-a' of type 'MutatingAdmissionWebhook'"),
+				errors.New("duplicate webhook 'test-mute-webhook-b' of type 'MutatingAdmissionWebhook'"),
+				errors.New("duplicate webhook 'test-val-webhook-a' of type 'ValidatingAdmissionWebhook'"),
+				errors.New("duplicate webhook 'test-val-webhook-b' of type 'ValidatingAdmissionWebhook'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validator.BundleValidator{}
+			errs := v.CheckWebhookNameUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckConversionWebhooksReferenceOwnedCRDs(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name:   "accepts bundles without webhook definitions",
+			bundle: &bundle.RegistryV1{},
+		}, {
+			name: "accepts bundles without conversion webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook",
+						},
+					).Build(),
+			},
+		}, {
+			name: "accepts bundles with conversion webhooks that reference owned CRDs",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+						v1alpha1.CRDDescription{Name: "another.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+								"another.crd.something",
+							},
+						},
+					).Build(),
+			},
+		}, {
+			name: "rejects bundles with conversion webhooks that reference existing CRDs that are not owned",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+								"another.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhook 'test-webhook' references custom resource definition 'another.crd.something' not owned bundle"),
+			},
+		}, {
+			name: "errors are ordered by webhook name and CRD name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-b",
+							ConversionCRDs: []string{
+								"b.crd.something",
+							},
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-a",
+							ConversionCRDs: []string{
+								"c.crd.something",
+								"a.crd.something",
+							},
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-c",
+							ConversionCRDs: []string{
+								"a.crd.something",
+								"d.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhook 'test-webhook-a' references custom resource definition 'a.crd.something' not owned bundle"),
+				errors.New("conversion webhook 'test-webhook-a' references custom resource definition 'c.crd.something' not owned bundle"),
+				errors.New("conversion webhook 'test-webhook-c' references custom resource definition 'a.crd.something' not owned bundle"),
+				errors.New("conversion webhook 'test-webhook-c' references custom resource definition 'd.crd.something' not owned bundle"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validator.BundleValidator{}.CheckConversionWebhooksReferenceOwnedCRDs(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckConversionWebhookCRDReferenceUniqueness(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name:         "accepts bundles without webhook definitions",
+			bundle:       &bundle.RegistryV1{},
+			expectedErrs: []error{},
+		},
+		{
+			name: "accepts bundles without conversion webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "test-val-webhook",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "test-mute-webhook",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{},
+		},
+		{
+			name: "accepts bundles with conversion webhooks that reference different CRDs",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+						v1alpha1.CRDDescription{Name: "another.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-2",
+							ConversionCRDs: []string{
+								"another.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{},
+		},
+		{
+			name: "rejects bundles with conversion webhooks that reference the same CRD",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "some.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook",
+							ConversionCRDs: []string{
+								"some.crd.something",
+							},
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-two",
+							ConversionCRDs: []string{
+								"some.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhooks [test-webhook,test-webhook-two] reference same custom resource definition 'some.crd.something'"),
+			},
+		},
+		{
+			name: "errors are ordered by CRD name and webhook names",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithOwnedCRDs(
+						v1alpha1.CRDDescription{Name: "b.crd.something"},
+					).
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-b",
+							ConversionCRDs: []string{
+								"b.crd.something",
+								"a.crd.something",
+							},
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-a",
+							ConversionCRDs: []string{
+								"d.crd.something",
+								"a.crd.something",
+								"b.crd.something",
+							},
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "test-webhook-c",
+							ConversionCRDs: []string{
+								"b.crd.something",
+								"d.crd.something",
+							},
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("conversion webhooks [test-webhook-a,test-webhook-b] reference same custom resource definition 'a.crd.something'"),
+				errors.New("conversion webhooks [test-webhook-a,test-webhook-b,test-webhook-c] reference same custom resource definition 'b.crd.something'"),
+				errors.New("conversion webhooks [test-webhook-a,test-webhook-c] reference same custom resource definition 'd.crd.something'"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validator.BundleValidator{}.CheckConversionWebhookCRDReferenceUniqueness(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}
+
+func Test_BundleValidator_CheckWebhookNameIsDNS1123SubDomain(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		bundle       *bundle.RegistryV1
+		expectedErrs []error
+	}{
+		{
+			name: "accepts bundles without webhook definitions",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().Build(),
+			},
+		}, {
+			name: "rejects bundles with invalid webhook definitions names and orders errors by webhook type and name",
+			bundle: &bundle.RegistryV1{
+				CSV: clusterserviceversion.Builder().
+					WithWebhookDefinitions(
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ValidatingAdmissionWebhook,
+							GenerateName: "-bad-name",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "b-bad-name-",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-",
+						}, v1alpha1.WebhookDescription{
+							Type:         v1alpha1.MutatingAdmissionWebhook,
+							GenerateName: "a-bad-name-",
+						},
+						v1alpha1.WebhookDescription{
+							Type:         v1alpha1.ConversionWebhook,
+							GenerateName: "a-bad-name-",
+						},
+					).Build(),
+			},
+			expectedErrs: []error{
+				errors.New("webhook of type 'ConversionWebhook' has invalid name 'a-bad-name-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("webhook of type 'ConversionWebhook' has invalid name 'b-bad-name-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("webhook of type 'MutatingAdmissionWebhook' has invalid name 'a-bad-name-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("webhook of type 'MutatingAdmissionWebhook' has invalid name 'b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),must be no more than 253 characters"),
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' has invalid name '-bad-name': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' has invalid name 'a-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long': must be no more than 253 characters"),
+				errors.New("webhook of type 'ValidatingAdmissionWebhook' has invalid name 'b-name-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long-and-bad-': a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),must be no more than 253 characters"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validator.BundleValidator{}.CheckWebhookNameIsDNS1123SubDomain(tc.bundle)
+			require.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}


### PR DESCRIPTION
# Description

The current BundleValidator is implemented almost as a framework, its a singleton that always exists in memory, and it feels a bit awkward to me. I was thinking it might be better to have it as a concrete thing that can be instantiated independently and at the point of use, if necessary.

In this PR we move BundleValidator to a concrete struct with the validation functions hanging off that.

I'm wondering whether:
- people agree that a concrete struct might be better in general
- whether I should make the Check* methods private, and
- whether we should just have a single big tabular test that exercises all of the Check* functions, or if its better to test them individually and have a test that checks whether all check functions are being exercised by the `Validate` method.

Note: the changes are currently implemented under a `v2` directory. The final form of this PR would replace the current implementation in `validators` with this. Maybe even moving it to the top level of the `render` package.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
