### PR TITLE
🌱 Add regression test for bundles with webhooks

### DIFF
--- a/test/regression/convert/generate-manifests.go
+++ b/test/regression/convert/generate-manifests.go
@@ -77,6 +77,11 @@ func main() {
 			watchNamespace:   "argocd-system",
 			bundle:           "argocd-operator.v0.6.0",
 			testCaseName:     "own-namespace",
+		}, {
+			name:             "Webhooks",
+			installNamespace: "webhook-system",
+			bundle:           "webhook-operator.v0.0.5",
+			testCaseName:     "all-webhook-types",
 		},
 	} {
 		bundlePath := filepath.Join(bundleRootDir, tc.bundle)

--- a/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/manifests/webhook-operator.clusterserviceversion.yaml
+++ b/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/manifests/webhook-operator.clusterserviceversion.yaml
@@ -1,0 +1,282 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "webhook.operators.coreos.io/v1",
+          "kind": "WebhookTest",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "webhook-operator"
+            },
+            "name": "webhooktest-sample"
+          },
+          "spec": null
+        },
+        {
+          "apiVersion": "webhook.operators.coreos.io/v2",
+          "kind": "WebhookTest",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "webhook-operator"
+            },
+            "name": "webhooktest-sample"
+          },
+          "spec": null
+        }
+      ]
+    capabilities: Basic Install
+    operators.operatorframework.io/builder: operator-sdk-v1.41.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: webhook-operator.v0.0.5
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: WebhookTest is the Schema for the webhooktests API
+        displayName: Webhook Test
+        kind: WebhookTest
+        name: webhooktests.webhook.operators.coreos.io
+        version: v1
+      - description: WebhookTest is the Schema for the webhooktests API
+        displayName: Webhook Test
+        kind: WebhookTest
+        name: webhooktests.webhook.operators.coreos.io
+        version: v2
+  description: webhook-operator test fixture
+  displayName: webhook-operator
+  icon:
+    - base64data: ""
+      mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - webhook.operators.coreos.io
+              resources:
+                - webhooktests
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - webhook.operators.coreos.io
+              resources:
+                - webhooktests/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - webhook.operators.coreos.io
+              resources:
+                - webhooktests/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: webhook-operator-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: webhook-operator
+            control-plane: controller-manager
+          name: webhook-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: webhook-operator
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/name: webhook-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-bind-address=:8443
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                      - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+                    command:
+                      - /manager
+                    image: quay.io/olmtest/webhook-operator:v0.0.5
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: webhook-certs
+                        readOnly: true
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: webhook-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: webhook-certs
+                    secret:
+                      secretName: webhook-server-cert
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: webhook-operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - test
+    - operator
+    - webhooks
+  links:
+    - name: Webhook Operator
+      url: https://webhook-operator.domain
+  maintainers:
+    - email: no-reply@operator-framework.io
+      name: no-reply
+  maturity: alpha
+  provider:
+    name: operator-framework
+  version: 0.0.5
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      conversionCRDs:
+        - webhooktests.webhook.operators.coreos.io
+      deploymentName: webhook-operator-controller-manager
+      generateName: cwebhooktests.kb.io
+      sideEffects: None
+      targetPort: 9443
+      type: ConversionWebhook
+      webhookPath: /convert
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: webhook-operator-controller-manager
+      failurePolicy: Fail
+      generateName: mwebhooktest-v1.kb.io
+      rules:
+        - apiGroups:
+            - webhook.operators.coreos.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - webhooktests
+      sideEffects: None
+      targetPort: 9443
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-webhook-operators-coreos-io-v1-webhooktest
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: webhook-operator-controller-manager
+      failurePolicy: Fail
+      generateName: vwebhooktest-v1.kb.io
+      rules:
+        - apiGroups:
+            - webhook.operators.coreos.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - webhooktests
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-webhook-operators-coreos-io-v1-webhooktest

--- a/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/manifests/webhook.operators.coreos.io_webhooktests.yaml
+++ b/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/manifests/webhook.operators.coreos.io_webhooktests.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: webhook-operator-system/webhook-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.19.0
+  creationTimestamp: null
+  name: webhooktests.webhook.operators.coreos.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-operator-webhook-service
+          namespace: webhook-operator-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: webhook.operators.coreos.io
+  names:
+    kind: WebhookTest
+    listKind: WebhookTestList
+    plural: webhooktests
+    singular: webhooktest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              mutate:
+                description: Mutate is a field that will be set to true by the mutating
+                  webhook.
+                type: boolean
+              valid:
+                description: Valid must be set to true or the validation webhook will
+                  reject the resource.
+                type: boolean
+            required:
+            - valid
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              conversion:
+                description: Conversion is an example field of WebhookTest. Edit WebhookTest_types.go
+                  to remove/update
+                properties:
+                  mutate:
+                    description: Mutate is a field that will be set to true by the
+                      mutating webhook.
+                    type: boolean
+                  valid:
+                    description: Valid must be set to true or the validation webhook
+                      will reject the resource.
+                    type: boolean
+                required:
+                - valid
+                type: object
+            required:
+            - conversion
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/metadata/annotations.yaml
+++ b/test/regression/convert/testdata/bundles/webhook-operator.v0.0.5/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: webhook-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/00_clusterrole_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/00_clusterrole_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+rules:
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - webhook.operators.coreos.io
+  resources:
+  - webhooktests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/01_clusterrole_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/01_clusterrole_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/02_clusterrolebinding_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/02_clusterrolebinding_webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: webhook-operator.v-119edugfdvz48oyy2ctmbp4ec5c4a7zbv5k03vg4y3ve
+subjects:
+- kind: ServiceAccount
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/03_clusterrolebinding_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/03_clusterrolebinding_webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: webhook-operator.v-1zfvwth88plw3th2midra1jqduroo1q7omiagjujsiu3
+subjects:
+- kind: ServiceAccount
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/04_customresourcedefinition_webhooktests.webhook.operators.coreos.io.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/04_customresourcedefinition_webhooktests.webhook.operators.coreos.io.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: webhook-operator-system/webhook-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: webhooktests.webhook.operators.coreos.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-operator-controller-manager-service
+          namespace: webhook-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1
+  group: webhook.operators.coreos.io
+  names:
+    kind: WebhookTest
+    listKind: WebhookTestList
+    plural: webhooktests
+    singular: webhooktest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              mutate:
+                description: Mutate is a field that will be set to true by the mutating
+                  webhook.
+                type: boolean
+              valid:
+                description: Valid must be set to true or the validation webhook will
+                  reject the resource.
+                type: boolean
+            required:
+            - valid
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: WebhookTest is the Schema for the webhooktests API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of WebhookTest
+            properties:
+              conversion:
+                description: Conversion is an example field of WebhookTest. Edit WebhookTest_types.go
+                  to remove/update
+                properties:
+                  mutate:
+                    description: Mutate is a field that will be set to true by the
+                      mutating webhook.
+                    type: boolean
+                  valid:
+                    description: Valid must be set to true or the validation webhook
+                      will reject the resource.
+                    type: boolean
+                required:
+                - valid
+                type: object
+            required:
+            - conversion
+            type: object
+          status:
+            description: status defines the observed state of WebhookTest
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the WebhookTest resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/05_deployment_webhook-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/05_deployment_webhook-operator-controller-manager.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: webhook-operator
+    control-plane: controller-manager
+  name: webhook-operator-controller-manager
+  namespace: webhook-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook-operator
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "webhook.operators.coreos.io/v1",
+              "kind": "WebhookTest",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "webhook-operator"
+                },
+                "name": "webhooktest-sample"
+              },
+              "spec": null
+            },
+            {
+              "apiVersion": "webhook.operators.coreos.io/v2",
+              "kind": "WebhookTest",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "webhook-operator"
+                },
+                "name": "webhooktest-sample"
+              },
+              "spec": null
+            }
+          ]
+        capabilities: Basic Install
+        kubectl.kubernetes.io/default-container: manager
+        olm.targetNamespaces: ""
+        operators.operatorframework.io/builder: operator-sdk-v1.41.1
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      labels:
+        app.kubernetes.io/name: webhook-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        command:
+        - /manager
+        image: quay.io/olmtest/webhook-operator:v0.0.5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: webhook-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+status: {}

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/06_mutatingwebhookconfiguration_mwebhooktest-v1.kb.io.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/06_mutatingwebhookconfiguration_mwebhooktest-v1.kb.io.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mwebhooktest-v1.kb.io
+  namespace: webhook-system
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-operator-controller-manager-service
+      namespace: webhook-system
+      path: /mutate-webhook-operators-coreos-io-v1-webhooktest
+      port: 443
+  failurePolicy: Fail
+  name: mwebhooktest-v1.kb.io
+  rules:
+  - apiGroups:
+    - webhook.operators.coreos.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - webhooktests
+  sideEffects: None

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/07_service_webhook-operator-controller-manager-service.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/07_service_webhook-operator-controller-manager-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-operator-controller-manager-service
+  namespace: webhook-system
+spec:
+  ports:
+  - name: "443"
+    port: 443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: webhook-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/08_serviceaccount_webhook-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/08_serviceaccount_webhook-operator-controller-manager.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook-operator-controller-manager
+  namespace: webhook-system

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/09_validatingwebhookconfiguration_vwebhooktest-v1.kb.io.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/09_validatingwebhookconfiguration_vwebhooktest-v1.kb.io.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: vwebhooktest-v1.kb.io
+  namespace: webhook-system
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-operator-controller-manager-service
+      namespace: webhook-system
+      path: /validate-webhook-operators-coreos-io-v1-webhooktest
+      port: 443
+  failurePolicy: Fail
+  name: vwebhooktest-v1.kb.io
+  rules:
+  - apiGroups:
+    - webhook.operators.coreos.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - webhooktests
+  sideEffects: None


### PR DESCRIPTION
# Description

We've updated the registry+v1 renderer to support bundles with webhook definitions but forgot to add a regression test.
This PR adds that regression test using a bundle for the webhook-operator used for e2e testing.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
