### PR TITLE
:bug: Remove `creationTimestamp` and status fields from webhook-operator test resources

### DIFF
--- a/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
+++ b/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: webhook-operator-metrics-reader
 rules:
   - nonResourceURLs:

--- a/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook-operator.clusterserviceversion.yaml
@@ -14,7 +14,6 @@ metadata:
             },
             "name": "webhooktest-sample"
           },
-          "spec": null
         },
         {
           "apiVersion": "webhook.operators.coreos.io/v2",
@@ -26,7 +25,6 @@ metadata:
             },
             "name": "webhooktest-sample"
           },
-          "spec": null
         }
       ]
     capabilities: Basic Install

--- a/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook.operators.coreos.io_webhooktests.yaml
+++ b/testdata/images/bundles/webhook-operator/v0.0.1/manifests/webhook.operators.coreos.io_webhooktests.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: webhooktests.webhook.operators.coreos.io
 spec:
   conversion:
@@ -256,9 +255,3 @@ spec:
       storage: false
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null


### PR DESCRIPTION
# Description

Its presence has forced the BoxCutter applier to believe that resources differ from
those existing on the cluster and thus new revisions are created indefinitely on each reconcile
when trying to install webhook-operator package.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->


<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
