### PR TITLE
:bug: Restore ManagedFields to operator-controller cache

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -234,7 +234,7 @@ func run() error {
 		},
 		DefaultLabelSelector: k8slabels.Nothing(),
 		// Memory optimization: strip managed fields and large annotations from cached objects
-		DefaultTransform: cacheutil.StripManagedFieldsAndAnnotations(),
+		DefaultTransform: cacheutil.StripAnnotations(),
 	}
 
 	if features.OperatorControllerFeatureGate.Enabled(features.BoxcutterRuntime) {

--- a/internal/operator-controller/applier/boxcutter.go
+++ b/internal/operator-controller/applier/boxcutter.go
@@ -66,9 +66,9 @@ func (r *SimpleRevisionGenerator) GenerateRevisionFromHelmRelease(
 		obj.SetLabels(labels)
 		obj.SetOwnerReferences(nil) // reset OwnerReferences for migration.
 
-		// Memory optimization: strip large annotations and managed fields
+		// Memory optimization: strip large annotations
 		// Note: ApplyStripTransform never returns an error in practice
-		_ = cache.ApplyStripTransform(&obj)
+		_ = cache.ApplyStripAnnotationsTransform(&obj)
 
 		objs = append(objs, ocv1.ClusterExtensionRevisionObject{
 			Object:              obj,
@@ -118,8 +118,8 @@ func (r *SimpleRevisionGenerator) GenerateRevision(
 		unstr := unstructured.Unstructured{Object: unstrObj}
 		unstr.SetGroupVersionKind(gvk)
 
-		// Memory optimization: strip large annotations and managed fields
-		if err := cache.ApplyStripTransform(&unstr); err != nil {
+		// Memory optimization: strip large annotations
+		if err := cache.ApplyStripAnnotationsTransform(&unstr); err != nil {
 			return nil, err
 		}
 

--- a/internal/shared/util/cache/transform.go
+++ b/internal/shared/util/cache/transform.go
@@ -58,14 +58,34 @@ func StripManagedFieldsAndAnnotations() toolscache.TransformFunc {
 	}
 }
 
-// ApplyStripTransform applies the strip transform directly to an object.
+// StripAnnotations returns a cache transform function that removes
+// memory-heavy annotation fields that aren't needed for controller operations.
+// This significantly reduces memory usage in informer caches by removing:
+// - kubectl.kubernetes.io/last-applied-configuration annotation (can be very large)
+//
+// Use this function as a DefaultTransform in controller-runtime cache.Options
+// to reduce memory overhead across all cached objects.
+//
+// Example:
+//
+//	cacheOptions := cache.Options{
+//	    DefaultTransform: cacheutil.StripAnnotations(),
+//	}
+func StripAnnotations() toolscache.TransformFunc {
+	return func(obj interface{}) (interface{}, error) {
+		// Strip the large annotations
+		return stripAnnotations(obj)
+	}
+}
+
+// ApplyStripAnnotationsTransform applies the strip transform directly to an object.
 // This is a convenience function for cases where you need to strip fields
 // from an object outside of the cache transform context.
 //
 // Note: This function never returns an error in practice, but returns error
 // to satisfy the TransformFunc interface.
-func ApplyStripTransform(obj client.Object) error {
-	transform := StripManagedFieldsAndAnnotations()
+func ApplyStripAnnotationsTransform(obj client.Object) error {
+	transform := StripAnnotations()
 	_, err := transform(obj)
 	return err
 }


### PR DESCRIPTION
The Boxcutter library uses ManagedFields internally, so we need to keep them around, at least in operator-controller. Catalogd can still strip them from its cache.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
