### PR TITLE
:bug: (fix): Change make generate to not delete vendor files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ manifests: update-crds $(MANIFESTS) $(HELM) #EXHELP Generate OLMv1 manifests
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) #EXHELP Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	@find api cmd hack internal -name "zz_generated.deepcopy.go" -delete # Need to delete the files for them to be generated properly
+	@find api cmd hack internal -name "zz_generated.deepcopy.go" -not -path "*/vendor/*" -delete # Need to delete the files for them to be generated properly
 	$(CONTROLLER_GEN) --load-build-tags=$(GO_BUILD_TAGS) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: verify


### PR DESCRIPTION
### Summary

Fix `make verify` failure caused by deletion of vendored `zz_generated.deepcopy.go` files.

### Root Cause

The `generate` target in the `Makefile` deletes **all** `zz_generated.deepcopy.go` files under `api`, `cmd`, `hack`, and `internal`.  
This unintentionally removes 69 vendored deepcopy files inside `hack/tools/test-profiling/vendor/`, which cannot be regenerated by `controller-gen`.  
As a result, `git diff --exit-code` fails during `make verify`.

### Fix

Update the `find` command to **exclude vendor directories** when cleaning up generated deepcopy files:

    @find api cmd hack internal -name "zz_generated.deepcopy.go" -not -path "*/vendor/*" -delete

This ensures vendored deepcopy files are preserved while still cleaning and regenerating project code.

### References

- Issue (see make verify fails): [openshift/operator-framework-operator-controller#548](https://github.com/openshift/operator-framework-operator-controller/pull/548)  
- Verified fix in (see make verify pass): [openshift/operator-framework-operator-controller#552](https://github.com/openshift/operator-framework-operator-controller/pull/552)
