### PR TITLE
:seedling: Only include ClusterExtensionRevision CRD when Boxcutter enabled

### DIFF
--- a/helm/olmv1/templates/crds/customresourcedefinition-clusterextensionrevisions.olm.operatorframework.io.yml
+++ b/helm/olmv1/templates/crds/customresourcedefinition-clusterextensionrevisions.olm.operatorframework.io.yml
@@ -2,7 +2,9 @@
 {{- if (eq .Values.options.featureSet "standard") }}
 {{- /* Add when GA: tpl (.Files.Get "base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensionrevisionss.yaml") . */}}
 {{- else if (eq .Values.options.featureSet "experimental") }}
+{{- if has "BoxcutterRuntime" .Values.options.operatorController.features.enabled }}
 {{ tpl (.Files.Get "base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensionrevisions.yaml") . }}
+{{- end }}
 {{- else }}
 {{- fail "options.featureSet must be set to one of: {standard,experimental}" }}
 {{- end }}


### PR DESCRIPTION
Add a check for the BoxcutterRuntime feature-gate before including the ClusterExtensionRevision CRD into the manifest.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
