### PR TITLE
:seedling: Refactor `ClusterExtension` reconciler to use composable step-based pipeline

### DIFF
--- a/internal/operator-controller/applier/helm.go
+++ b/internal/operator-controller/applier/helm.go
@@ -21,13 +21,13 @@ import (
 	apimachyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/authorization"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/contentmanager"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/contentmanager/cache"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/features"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/rukpak/util"
 	imageutil "github.com/operator-framework/operator-controller/internal/shared/util/image"
@@ -65,7 +65,7 @@ type Helm struct {
 	HelmReleaseToObjectsConverter HelmReleaseToObjectsConverterInterface
 
 	Manager contentmanager.Manager
-	Watcher crcontroller.Controller
+	Watcher cache.Watcher
 }
 
 // runPreAuthorizationChecks performs pre-authorization checks for a Helm release

--- a/internal/operator-controller/controllers/boxcutter_reconcile_steps.go
+++ b/internal/operator-controller/controllers/boxcutter_reconcile_steps.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
+)
+
+type BoxcutterRevisionStatesGetter struct {
+	Reader client.Reader
+}
+
+func (d *BoxcutterRevisionStatesGetter) GetRevisionStates(ctx context.Context, ext *ocv1.ClusterExtension) (*RevisionStates, error) {
+	// TODO: boxcutter applier has a nearly identical bit of code for listing and sorting revisions
+	//   only difference here is that it sorts in reverse order to start iterating with the most
+	//   recent revisions. We should consolidate to avoid code duplication.
+	existingRevisionList := &ocv1.ClusterExtensionRevisionList{}
+	if err := d.Reader.List(ctx, existingRevisionList, client.MatchingLabels{
+		labels.OwnerNameKey: ext.Name,
+	}); err != nil {
+		return nil, fmt.Errorf("listing revisions: %w", err)
+	}
+	slices.SortFunc(existingRevisionList.Items, func(a, b ocv1.ClusterExtensionRevision) int {
+		return cmp.Compare(a.Spec.Revision, b.Spec.Revision)
+	})
+
+	rs := &RevisionStates{}
+	for _, rev := range existingRevisionList.Items {
+		switch rev.Spec.LifecycleState {
+		case ocv1.ClusterExtensionRevisionLifecycleStateActive,
+			ocv1.ClusterExtensionRevisionLifecycleStatePaused:
+		default:
+			// Skip anything not active or paused, which should only be "Archived".
+			continue
+		}
+
+		// TODO: the setting of these annotations (happens in boxcutter applier when we pass in "revisionAnnotations")
+		//   is fairly decoupled from this code where we get the annotations back out. We may want to co-locate
+		//   the set/get logic a bit better to make it more maintainable and less likely to get out of sync.
+		rm := &RevisionMetadata{
+			Package: rev.Annotations[labels.PackageNameKey],
+			Image:   rev.Annotations[labels.BundleReferenceKey],
+			BundleMetadata: ocv1.BundleMetadata{
+				Name:    rev.Annotations[labels.BundleNameKey],
+				Version: rev.Annotations[labels.BundleVersionKey],
+			},
+		}
+
+		if apimeta.IsStatusConditionTrue(rev.Status.Conditions, ocv1.ClusterExtensionRevisionTypeSucceeded) {
+			rs.Installed = rm
+		} else {
+			rs.RollingOut = append(rs.RollingOut, rm)
+		}
+	}
+
+	return rs, nil
+}
+
+func MigrateStorage(m StorageMigrator) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		objLbls := map[string]string{
+			labels.OwnerKindKey: ocv1.ClusterExtensionKind,
+			labels.OwnerNameKey: ext.GetName(),
+		}
+
+		if err := m.Migrate(ctx, ext, objLbls); err != nil {
+			return nil, fmt.Errorf("migrating storage: %w", err)
+		}
+		return nil, nil
+	}
+}

--- a/internal/operator-controller/controllers/clusterextension_reconcile_steps.go
+++ b/internal/operator-controller/controllers/clusterextension_reconcile_steps.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/finalizer"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/authentication"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/bundleutil"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/resolve"
+	imageutil "github.com/operator-framework/operator-controller/internal/shared/util/image"
+)
+
+func HandleFinalizers(f finalizer.Finalizer) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		l := log.FromContext(ctx)
+
+		l.Info("handling finalizers")
+		finalizeResult, err := f.Finalize(ctx, ext)
+		if err != nil {
+			setStatusProgressing(ext, err)
+			return nil, err
+		}
+		if finalizeResult.Updated || finalizeResult.StatusUpdated {
+			// On create: make sure the finalizer is applied before we do anything
+			// On delete: make sure we do nothing after the finalizer is removed
+			return &ctrl.Result{}, nil
+		}
+
+		if ext.GetDeletionTimestamp() != nil {
+			// If we've gotten here, that means the cluster extension is being deleted, we've handled all of
+			// _our_ finalizers (above), but the cluster extension is still present in the cluster, likely
+			// because there are _other_ finalizers that other controllers need to handle, (e.g. the orphan
+			// deletion finalizer).
+			return &ctrl.Result{}, nil
+		}
+		return nil, nil
+	}
+}
+
+func RetrieveRevisionStates(r RevisionStatesGetter) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		l := log.FromContext(ctx)
+		l.Info("getting installed bundle")
+		revisionStates, err := r.GetRevisionStates(ctx, ext)
+		if err != nil {
+			setInstallStatus(ext, nil)
+			var saerr *authentication.ServiceAccountNotFoundError
+			if errors.As(err, &saerr) {
+				setInstalledStatusConditionUnknown(ext, saerr.Error())
+				setStatusProgressing(ext, errors.New("installation cannot proceed due to missing ServiceAccount"))
+				return nil, err
+			}
+			setInstalledStatusConditionUnknown(ext, err.Error())
+			setStatusProgressing(ext, errors.New("retrying to get installed bundle"))
+			return nil, err
+		}
+		state.revisionStates = revisionStates
+		return nil, nil
+	}
+}
+
+func ResolveBundle(r resolve.Resolver) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		l := log.FromContext(ctx)
+		var resolvedRevisionMetadata *RevisionMetadata
+		if len(state.revisionStates.RollingOut) == 0 {
+			l.Info("resolving bundle")
+			var bm *ocv1.BundleMetadata
+			if state.revisionStates.Installed != nil {
+				bm = &state.revisionStates.Installed.BundleMetadata
+			}
+			resolvedBundle, resolvedBundleVersion, resolvedDeprecation, err := r.Resolve(ctx, ext, bm)
+			if err != nil {
+				// Note: We don't distinguish between resolution-specific errors and generic errors
+				setStatusProgressing(ext, err)
+				setInstalledStatusFromRevisionStates(ext, state.revisionStates)
+				ensureAllConditionsWithReason(ext, ocv1.ReasonFailed, err.Error())
+				return nil, err
+			}
+
+			// set deprecation status after _successful_ resolution
+			// TODO:
+			//  1. It seems like deprecation status should reflect the currently installed bundle, not the resolved
+			//     bundle. So perhaps we should set package and channel deprecations directly after resolution, but
+			//     defer setting the bundle deprecation until we successfully install the bundle.
+			//  2. If resolution fails because it can't find a bundle, that doesn't mean we wouldn't be able to find
+			//     a deprecation for the ClusterExtension's spec.packageName. Perhaps we should check for a non-nil
+			//     resolvedDeprecation even if resolution returns an error. If present, we can still update some of
+			//     our deprecation status.
+			//       - Open question though: what if different catalogs have different opinions of what's deprecated.
+			//         If we can't resolve a bundle, how do we know which catalog to trust for deprecation information?
+			//         Perhaps if the package shows up in multiple catalogs and deprecations don't match, we can set
+			//         the deprecation status to unknown? Or perhaps we somehow combine the deprecation information from
+			//         all catalogs?
+			SetDeprecationStatus(ext, resolvedBundle.Name, resolvedDeprecation)
+			resolvedRevisionMetadata = &RevisionMetadata{
+				Package:        resolvedBundle.Package,
+				Image:          resolvedBundle.Image,
+				BundleMetadata: bundleutil.MetadataFor(resolvedBundle.Name, *resolvedBundleVersion),
+			}
+		} else {
+			resolvedRevisionMetadata = state.revisionStates.RollingOut[0]
+		}
+		state.resolvedRevisionMetadata = resolvedRevisionMetadata
+		return nil, nil
+	}
+}
+
+func UnpackBundle(i imageutil.Puller, cache imageutil.Cache) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		l := log.FromContext(ctx)
+		l.Info("unpacking resolved bundle")
+		imageFS, _, _, err := i.Pull(ctx, ext.GetName(), state.resolvedRevisionMetadata.Image, cache)
+		if err != nil {
+			// Wrap the error passed to this with the resolution information until we have successfully
+			// installed since we intend for the progressing condition to replace the resolved condition
+			// and will be removing the .status.resolution field from the ClusterExtension status API
+			setStatusProgressing(ext, wrapErrorWithResolutionInfo(state.resolvedRevisionMetadata.BundleMetadata, err))
+			setInstalledStatusFromRevisionStates(ext, state.revisionStates)
+			return nil, err
+		}
+		state.imageFS = imageFS
+		return nil, nil
+	}
+}
+
+func ApplyBundle(a Applier) ReconcileStepFunc {
+	return func(ctx context.Context, state *reconcileState, ext *ocv1.ClusterExtension) (*ctrl.Result, error) {
+		l := log.FromContext(ctx)
+		revisionAnnotations := map[string]string{
+			labels.BundleNameKey:      state.resolvedRevisionMetadata.Name,
+			labels.PackageNameKey:     state.resolvedRevisionMetadata.Package,
+			labels.BundleVersionKey:   state.resolvedRevisionMetadata.Version,
+			labels.BundleReferenceKey: state.resolvedRevisionMetadata.Image,
+		}
+		objLbls := map[string]string{
+			labels.OwnerKindKey: ocv1.ClusterExtensionKind,
+			labels.OwnerNameKey: ext.GetName(),
+		}
+
+		l.Info("applying bundle contents")
+		// NOTE: We need to be cautious of eating errors here.
+		// We should always return any error that occurs during an
+		// attempt to apply content to the cluster. Only when there is
+		// a verifiable reason to eat the error (i.e it is recoverable)
+		// should an exception be made.
+		// The following kinds of errors should be returned up the stack
+		// to ensure exponential backoff can occur:
+		//   - Permission errors (it is not possible to watch changes to permissions.
+		//     The only way to eventually recover from permission errors is to keep retrying).
+		rolloutSucceeded, rolloutStatus, err := a.Apply(ctx, state.imageFS, ext, objLbls, revisionAnnotations)
+
+		// Set installed status
+		if rolloutSucceeded {
+			state.revisionStates = &RevisionStates{Installed: state.resolvedRevisionMetadata}
+		} else if err == nil && state.revisionStates.Installed == nil && len(state.revisionStates.RollingOut) == 0 {
+			state.revisionStates = &RevisionStates{RollingOut: []*RevisionMetadata{state.resolvedRevisionMetadata}}
+		}
+		setInstalledStatusFromRevisionStates(ext, state.revisionStates)
+
+		// If there was an error applying the resolved bundle,
+		// report the error via the Progressing condition.
+		if err != nil {
+			setStatusProgressing(ext, wrapErrorWithResolutionInfo(state.resolvedRevisionMetadata.BundleMetadata, err))
+			return nil, err
+		} else if !rolloutSucceeded {
+			apimeta.SetStatusCondition(&ext.Status.Conditions, metav1.Condition{
+				Type:               ocv1.TypeProgressing,
+				Status:             metav1.ConditionTrue,
+				Reason:             ocv1.ReasonRolloutInProgress,
+				Message:            rolloutStatus,
+				ObservedGeneration: ext.GetGeneration(),
+			})
+		} else {
+			setStatusProgressing(ext, nil)
+		}
+		return nil, nil
+	}
+}


### PR DESCRIPTION
# Description

Replaces the monolithic 170-line reconcile() method with a flexible step-based architecture that executes discrete reconciliation phases in sequence. Each phase (`HandleFinalizers`, `RetrieveRevisionStates`, `RetrieveRevisionMetadata`, `UnpackBundle`, `ApplyBundle`) is now a standalone function that can be composed differently for Helm vs Boxcutter workflows.

The motivation for this PR came out the work in https://github.com/operator-framework/operator-controller/pull/2281 where we have realized that handling conditions with Boxcutter differently would require introducing conditional executions depending on the backend type in one part of the reconcile loop, although the rest of the reconciliation is the same. In order to keep things easy to understand and test, I have divided the reconciliation into steps so that some of them could be swapped out/replaced depending on the used backend. Moreover, we are opening a possibility to add and write simpler unit tests.

Changes:
  - Introduce `ReconcileStepFunc` type and `ReconcileSteps` executor
  - Extract reconcile logic into individual step functions in new file  `clusterextension_reconcile_steps.go`
  - Move `BoxcutterRevisionStatesGetter` to `boxcutter_reconcile_steps.go`  alongside `MigrateStorage` step
  - Configure step pipelines in `main.go` for each applier type
  - Refactor tests to use functional options pattern for reconciler setup

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
