### PR TITLE
:seedling: Add enum validation annotation to CollisionProtection

### DIFF
--- a/api/v1/clusterextensionrevision_types.go
+++ b/api/v1/clusterextensionrevision_types.go
@@ -108,6 +108,7 @@ type ClusterExtensionRevisionObject struct {
 	// already existing on the cluster or even owned by another controller.
 	//
 	// +kubebuilder:default="Prevent"
+	// +kubebuilder:validation:Enum=Prevent;IfNoController;None
 	// +optional
 	CollisionProtection CollisionProtection `json:"collisionProtection,omitempty"`
 }

--- a/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensionrevisions.yaml
+++ b/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensionrevisions.yaml
@@ -87,6 +87,10 @@ spec:
                             description: |-
                               CollisionProtection controls whether OLM can adopt and modify objects
                               already existing on the cluster or even owned by another controller.
+                            enum:
+                            - Prevent
+                            - IfNoController
+                            - None
                             type: string
                           object:
                             type: object

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -678,6 +678,10 @@ spec:
                             description: |-
                               CollisionProtection controls whether OLM can adopt and modify objects
                               already existing on the cluster or even owned by another controller.
+                            enum:
+                            - Prevent
+                            - IfNoController
+                            - None
                             type: string
                           object:
                             type: object

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -643,6 +643,10 @@ spec:
                             description: |-
                               CollisionProtection controls whether OLM can adopt and modify objects
                               already existing on the cluster or even owned by another controller.
+                            enum:
+                            - Prevent
+                            - IfNoController
+                            - None
                             type: string
                           object:
                             type: object


### PR DESCRIPTION
# Description

Adds missing enum validation on CollisionProtection `+kubebuilder:validation:Enum=Prevent;IfNoController;None`

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
