### PR TITLE
🐛 override local pull policy with permissive policy

### DIFF
--- a/internal/shared/util/image/pull_test.go
+++ b/internal/shared/util/image/pull_test.go
@@ -298,8 +298,15 @@ func buildSourceContextFunc(t *testing.T, ref reference.Named) func(context.Cont
 		require.NoError(t, enc.Encode(registriesConf))
 		require.NoError(t, f.Close())
 
+		// Create an insecure policy for testing to override any system-level policy
+		// that might reject unsigned images
+		policyPath := filepath.Join(configDir, "policy.json")
+		insecurePolicy := `{"default":[{"type":"insecureAcceptAnything"}]}`
+		require.NoError(t, os.WriteFile(policyPath, []byte(insecurePolicy), 0600))
+
 		return &types.SystemContext{
 			SystemRegistriesConfPath: registriesConfPath,
+			SignaturePolicyPath:      policyPath,
 		}, nil
 	}
 }


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
The image pull test requires that the user running it has a permissive image pull policy in place to be successful.  However, I run a restrictive policy on my machine, so I get test failures. 
Ideally, the unit test should not be dependent on the user's environment, so here's a change which specifies a test-specific, permissive pull policy which will be used instead of the user's environment. 

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
