### PR TITLE
🐛 Fix: Use labels for queryable bundle metadata and unify owner labels

### DIFF
--- a/internal/operator-controller/applier/helm.go
+++ b/internal/operator-controller/applier/helm.go
@@ -102,7 +102,12 @@ func (h *Helm) runPreAuthorizationChecks(ctx context.Context, ext *ocv1.ClusterE
 	return nil
 }
 
-func (h *Helm) Apply(ctx context.Context, contentFS fs.FS, ext *ocv1.ClusterExtension, objectLabels map[string]string, storageLabels map[string]string) (bool, string, error) {
+// Apply applies Helm chart content. The revisionAnnotations parameter is ignored for Helm
+// (only used by boxcutter runtime which uses ClusterExtensionRevision).
+func (h *Helm) Apply(ctx context.Context, contentFS fs.FS, ext *ocv1.ClusterExtension, objectLabels, storageLabels, revisionAnnotations map[string]string) (bool, string, error) {
+	// revisionAnnotations is ignored - Helm doesn't use ClusterExtensionRevision
+	_ = revisionAnnotations
+
 	chrt, err := h.buildHelmChart(contentFS, ext)
 	if err != nil {
 		return false, "", err

--- a/internal/operator-controller/applier/helm_test.go
+++ b/internal/operator-controller/applier/helm_test.go
@@ -229,7 +229,7 @@ func TestApply_Base(t *testing.T) {
 	t.Run("fails converting content FS to helm chart", func(t *testing.T) {
 		helmApplier := applier.Helm{}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), os.DirFS("/"), testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), os.DirFS("/"), testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.False(t, installSucceeded)
 		require.Empty(t, installStatus)
@@ -242,7 +242,7 @@ func TestApply_Base(t *testing.T) {
 			HelmChartProvider:  DummyHelmChartProvider,
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "getting action client")
 		require.False(t, installSucceeded)
@@ -256,7 +256,7 @@ func TestApply_Base(t *testing.T) {
 			HelmChartProvider:  DummyHelmChartProvider,
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "getting current release")
 		require.False(t, installSucceeded)
@@ -275,7 +275,7 @@ func TestApply_Installation(t *testing.T) {
 			HelmChartProvider:  DummyHelmChartProvider,
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "attempting to dry-run install chart")
 		require.False(t, installSucceeded)
@@ -295,7 +295,7 @@ func TestApply_Installation(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "install pre-flight check")
 		require.False(t, installSucceeded)
@@ -313,7 +313,7 @@ func TestApply_Installation(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "installing chart")
 		require.False(t, installSucceeded)
@@ -337,7 +337,7 @@ func TestApply_Installation(t *testing.T) {
 			},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.NoError(t, err)
 		require.Empty(t, installStatus)
 		require.True(t, installSucceeded)
@@ -355,7 +355,7 @@ func TestApply_InstallationWithPreflightPermissionsEnabled(t *testing.T) {
 			HelmChartProvider:  DummyHelmChartProvider,
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "attempting to dry-run install chart")
 		require.False(t, installSucceeded)
@@ -380,7 +380,7 @@ func TestApply_InstallationWithPreflightPermissionsEnabled(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "install pre-flight check")
 		require.False(t, installSucceeded)
@@ -409,7 +409,7 @@ func TestApply_InstallationWithPreflightPermissionsEnabled(t *testing.T) {
 				},
 			},
 		}
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "problem running preauthorization")
 		require.False(t, installSucceeded)
@@ -438,7 +438,7 @@ func TestApply_InstallationWithPreflightPermissionsEnabled(t *testing.T) {
 				},
 			},
 		}
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, errMissingRBAC)
 		require.False(t, installSucceeded)
@@ -473,7 +473,7 @@ func TestApply_InstallationWithPreflightPermissionsEnabled(t *testing.T) {
 			},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, validCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.NoError(t, err)
 		require.Empty(t, installStatus)
 		require.True(t, installSucceeded)
@@ -494,7 +494,7 @@ func TestApply_Upgrade(t *testing.T) {
 			HelmChartProvider:  DummyHelmChartProvider,
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "attempting to dry-run upgrade chart")
 		require.False(t, installSucceeded)
@@ -518,7 +518,7 @@ func TestApply_Upgrade(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "upgrade pre-flight check")
 		require.False(t, installSucceeded)
@@ -541,7 +541,7 @@ func TestApply_Upgrade(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "upgrading chart")
 		require.False(t, installSucceeded)
@@ -565,7 +565,7 @@ func TestApply_Upgrade(t *testing.T) {
 			HelmReleaseToObjectsConverter: mockHelmReleaseToObjectsConverter{},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "reconciling charts")
 		require.False(t, installSucceeded)
@@ -589,7 +589,7 @@ func TestApply_Upgrade(t *testing.T) {
 			},
 		}
 
-		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		installSucceeded, installStatus, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.NoError(t, err)
 		require.True(t, installSucceeded)
 		require.Empty(t, installStatus)
@@ -618,7 +618,7 @@ func TestApply_RegistryV1ToChartConverterIntegration(t *testing.T) {
 			},
 		}
 
-		_, _, _ = helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		_, _, _ = helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 	})
 
 	t.Run("surfaces chart generation errors", func(t *testing.T) {
@@ -640,7 +640,7 @@ func TestApply_RegistryV1ToChartConverterIntegration(t *testing.T) {
 			},
 		}
 
-		_, _, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels)
+		_, _, err := helmApplier.Apply(context.TODO(), validFS, testCE, testObjectLabels, testStorageLabels, map[string]string{})
 		require.ErrorContains(t, err, "some error")
 	})
 }

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	ClusterExtensionRevisionOwnerLabel        = "olm.operatorframework.io/owner"
+	ClusterExtensionRevisionOwnerLabel        = "olm.operatorframework.io/owner-name"
 	clusterExtensionRevisionTeardownFinalizer = "olm.operatorframework.io/teardown"
 )
 

--- a/internal/operator-controller/controllers/suite_test.go
+++ b/internal/operator-controller/controllers/suite_test.go
@@ -72,7 +72,7 @@ type MockApplier struct {
 	err              error
 }
 
-func (m *MockApplier) Apply(_ context.Context, _ fs.FS, _ *ocv1.ClusterExtension, _ map[string]string, _ map[string]string) (bool, string, error) {
+func (m *MockApplier) Apply(_ context.Context, _ fs.FS, _ *ocv1.ClusterExtension, _ map[string]string, _ map[string]string, _ map[string]string) (bool, string, error) {
 	return m.installCompleted, m.installStatus, m.err
 }
 


### PR DESCRIPTION
## Problem

Bundle metadata (package-name, bundle-name, bundle-version) was stored in **annotations** on ClusterExtensionRevision, making it impossible to query or filter revisions by package, bundle, or version. Additionally, owner labels were inconsistent across different object types.

## Solution

1. **Move bundle metadata to labels** - Enables kubectl queries and follows Kubernetes best practices
2. **Unify owner labels** - Use `owner-name` + `owner-kind` consistently on all objects
3. **Fix naming** - Rename misleading `storeLbls` variable to `revisionLabels` + `revisionAnnotations`

## Changes

### BEFORE

#### ClusterExtensionRevision Resource
```yaml
apiVersion: olm.operatorframework.io/v1
kind: ClusterExtensionRevision
metadata:
  name: prometheus-operator-1
  labels:
    # ❌ Only owner label (inconsistent pattern)
    olm.operatorframework.io/owner: prometheus-operator
  annotations:
    # ❌ Bundle metadata in annotations (NOT queryable)
    olm.operatorframework.io/package-name: prometheus-operator
    olm.operatorframework.io/bundle-name: prometheus-operator.v0.56.0
    olm.operatorframework.io/bundle-version: 0.56.0
    olm.operatorframework.io/bundle-reference: quay.io/prometheus-operator/prometheus-operator@sha256:abc123...
spec:
  revision: 1
  lifecycleState: Active
  phases:
    - name: deploy
      objects:
        - object:
            apiVersion: apps/v1
            kind: Deployment
            metadata:
              name: prometheus-operator
              labels:
                # ✅ Managed objects use owner-kind + owner-name (different pattern)
                olm.operatorframework.io/owner-kind: ClusterExtension
                olm.operatorframework.io/owner-name: prometheus-operator
```

#### kubectl Queries (Didn't Work)
```bash
# ❌ FAILED - package-name is an annotation
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/package-name=prometheus-operator
No resources found

# ❌ FAILED - bundle-version is an annotation  
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/bundle-version=0.56.0
No resources found

# ✅ Only owner filtering worked
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/owner=prometheus-operator
NAME                       AGE
prometheus-operator-1      5m
```

### AFTER

#### ClusterExtensionRevision Resource
```yaml
apiVersion: olm.operatorframework.io/v1
kind: ClusterExtensionRevision
metadata:
  name: prometheus-operator-1
  labels:
    # ✅ Owner labels (NOW CONSISTENT with managed objects)
    olm.operatorframework.io/owner-kind: ClusterExtension
    olm.operatorframework.io/owner-name: prometheus-operator
    # ✅ Bundle metadata in labels (QUERYABLE!)
    olm.operatorframework.io/package-name: prometheus-operator
    olm.operatorframework.io/bundle-name: prometheus-operator.v0.56.0
    olm.operatorframework.io/bundle-version: 0.56.0
  annotations:
    # ✅ Only bundle-reference in annotations (can exceed 63 chars)
    olm.operatorframework.io/bundle-reference: quay.io/prometheus-operator/prometheus-operator@sha256:abc123...
spec:
  revision: 1
  lifecycleState: Active
  phases:
    - name: deploy
      objects:
        - object:
            apiVersion: apps/v1
            kind: Deployment
            metadata:
              name: prometheus-operator
              labels:
                # ✅ Same pattern as ClusterExtensionRevision (consistent!)
                olm.operatorframework.io/owner-kind: ClusterExtension
                olm.operatorframework.io/owner-name: prometheus-operator
```

#### kubectl Queries (Now Work!)
```bash
# ✅ SUCCESS - Filter by package
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/package-name=prometheus-operator
NAME                       AGE
prometheus-operator-1      5m
prometheus-operator-2      3m
other-prometheus-1         2m

# ✅ SUCCESS - Filter by version
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/bundle-version=0.56.0
NAME                       AGE
prometheus-operator-1      5m
prometheus-operator-2      3m

# ✅ SUCCESS - Filter by bundle name
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/bundle-name=prometheus-operator.v0.56.0
NAME                       AGE
prometheus-operator-1      5m

# ✅ SUCCESS - Combine filters (AND logic)
$ kubectl get clusterextensionrevisions \
  -l olm.operatorframework.io/package-name=prometheus-operator,olm.operatorframework.io/bundle-version=0.56.0
NAME                       AGE
prometheus-operator-1      5m
prometheus-operator-2      3m

# ✅ SUCCESS - Updated owner query (now uses owner-name)
$ kubectl get clusterextensionrevisions -l olm.operatorframework.io/owner-name=prometheus-operator
NAME                       AGE
prometheus-operator-1      5m
prometheus-operator-2      3m
```

## Code Changes

### BEFORE (Confusing and Wrong)
```go
// ❌ Misleadingly named - actually contains annotations!
storeLbls := map[string]string{
    labels.BundleNameKey:      resolvedRevisionMetadata.Name,
    labels.PackageNameKey:     resolvedRevisionMetadata.Package,
    labels.BundleVersionKey:   resolvedRevisionMetadata.Version,
    labels.BundleReferenceKey: resolvedRevisionMetadata.Image,
}

// ❌ Applied as annotations (not labels!)
rolloutSucceeded, rolloutStatus, err := r.Applier.Apply(ctx, imageFS, ext, objLbls, storeLbls)
```

### AFTER (Clear and Correct)
```go
// ✅ Clear split: labels for queryable data
revisionLabels := map[string]string{
    labels.BundleNameKey:    resolvedRevisionMetadata.Name,
    labels.PackageNameKey:   resolvedRevisionMetadata.Package,
    labels.BundleVersionKey: resolvedRevisionMetadata.Version,
}

// ✅ Annotations for reference data (can exceed 63 chars)
revisionAnnotations := map[string]string{
    labels.BundleReferenceKey: resolvedRevisionMetadata.Image,
}

// ✅ Clear what goes where
rolloutSucceeded, rolloutStatus, err := r.Applier.Apply(ctx, imageFS, ext, objLbls, revisionLabels, revisionAnnotations)
```

## Rationale

Following [Kubernetes best practices](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/):

### Labels (for selection/filtering)
- ✅ **Indexed** by Kubernetes for efficient queries
- ✅ Used in **label selectors** (`kubectl get -l`)
- ✅ Enable **cache filtering** and controller logic
- ⚠️ Limited to **63 characters**

### Annotations (for reference data)
- ✅ Can be **large** (up to 256KB total)
- ✅ For **non-queryable** metadata
- ❌ Not indexed or selectable

**Decision:**
- `package-name`, `bundle-name`, `bundle-version` → **Labels** (short, queryable)
- `bundle-reference` → **Annotation** (can be >63 chars: `quay.io/org/image@sha256:...`)

## References

- [Kubernetes Labels Concepts](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
- [Kubernetes Annotations Concepts](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
- [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)

