### PR TITLE
:seedling: Use local cache to check kind version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ kind-clean: $(KIND) #EXHELP Delete the kind cluster.
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-verify-versions
-kind-verify-versions:
+kind-verify-versions: $(KIND)
 	env K8S_VERSION=v$(K8S_VERSION) KIND=$(KIND) GOBIN=$(GOBIN) hack/tools/validate_kindest_node.sh
 
 

--- a/hack/tools/validate_kindest_node.sh
+++ b/hack/tools/validate_kindest_node.sh
@@ -4,8 +4,24 @@
 # Extract the version of kind, by removing the "${GOBIN}/kind-" prefix
 KIND=${KIND#${GOBIN}/kind-}
 
-# Get the version of the image
-KIND_VER=$(curl -L -s https://github.com/kubernetes-sigs/kind/raw/refs/tags/${KIND}/pkg/apis/config/defaults/image.go | grep -Eo 'v[0-9]+\.[0-9]+')
+GOMODCACHE=$(go env GOMODCACHE)
+
+REGEX='v[0-9]+\.[0-9]+'
+
+# Get the version of the image from the local kind build
+if [ -d "${GOMODCACHE}" ]; then
+    KIND_VER=$(grep -Eo "${REGEX}" ${GOMODCACHE}/sigs.k8s.io/kind@${KIND}/pkg/apis/config/defaults/image.go)
+fi
+
+# Get the version of the image from github
+if [ -z "${KIND_VER}" ]; then
+    KIND_VER=$(curl -L -s https://github.com/kubernetes-sigs/kind/raw/refs/tags/${KIND}/pkg/apis/config/defaults/image.go | grep -Eo "${REGEX}")
+fi
+
+if [ -z "${KIND_VER}" ]; then
+    echo "Unable to determine kindest/node version"
+    exit 1
+fi
 
 # Compare the versions
 if [ "${KIND_VER}" != "${K8S_VERSION}" ]; then


### PR DESCRIPTION
Use the local cached source of kind to determine the k8s version it supports. It avoids hitting github if possible.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
