### PR TITLE
:bug: Fix an unclear validation error when configuring watchNamespace on an operator restricted to AllNamespaces mode.

### DIFF
--- a/internal/operator-controller/config/config.go
+++ b/internal/operator-controller/config/config.go
@@ -45,6 +45,9 @@ const (
 	// FormatSingleNamespaceInstallMode defines the format check to ensure that
 	// the watchNamespace must differ from install namespace
 	FormatSingleNamespaceInstallMode = "singleNamespaceInstallMode"
+	// FormatAllNamespacesOnlyInstallMode defines the format check to reject
+	// watchNamespace when only AllNamespaces mode is supported (registry+v1 specific)
+	FormatAllNamespacesOnlyInstallMode = "allNamespacesOnlyInstallMode"
 )
 
 // SchemaProvider lets each package format type describe what configuration it accepts.
@@ -190,6 +193,14 @@ func validateConfigWithSchema(configBytes []byte, schema map[string]any, install
 				return fmt.Errorf("invalid value %q: watchNamespace must be different from %q (the install namespace) because this operator uses SingleNamespace install mode to watch a different namespace", str, installNamespace)
 			}
 			return nil
+		},
+	})
+	compiler.RegisterFormat(&jsonschema.Format{
+		Name: FormatAllNamespacesOnlyInstallMode,
+		Validate: func(value interface{}) error {
+			// Always reject - this format is used when AllNamespaces is the only supported mode
+			// and watchNamespace configuration doesn't make sense
+			return fmt.Errorf("watchNamespace configuration is not supported when the content only supports AllNamespaces install mode")
 		},
 	})
 

--- a/internal/operator-controller/config/config_test.go
+++ b/internal/operator-controller/config/config_test.go
@@ -80,22 +80,10 @@ func Test_UnmarshalConfig(t *testing.T) {
 			expectedErrMessage:    `got object, want string`,
 		},
 		{
-			name:                  "rejects with unknown field when install modes {AllNamespaces}",
+			name:                  "rejects with descriptive message when install modes {AllNamespaces}",
 			supportedInstallModes: []v1alpha1.InstallModeType{v1alpha1.InstallModeTypeAllNamespaces},
 			rawConfig:             []byte(`{"watchNamespace": "some-namespace"}`),
-			expectedErrMessage:    `unknown field "watchNamespace"`,
-		},
-		{
-			name:                  "rejects with unknown field when install modes {MultiNamespace}",
-			supportedInstallModes: []v1alpha1.InstallModeType{v1alpha1.InstallModeTypeMultiNamespace},
-			rawConfig:             []byte(`{"watchNamespace": "some-namespace"}`),
-			expectedErrMessage:    `unknown field "watchNamespace"`,
-		},
-		{
-			name:                  "reject with unknown field when install modes {AllNamespaces, MultiNamespace}",
-			supportedInstallModes: []v1alpha1.InstallModeType{v1alpha1.InstallModeTypeAllNamespaces, v1alpha1.InstallModeTypeMultiNamespace},
-			rawConfig:             []byte(`{"watchNamespace": "some-namespace"}`),
-			expectedErrMessage:    `unknown field "watchNamespace"`,
+			expectedErrMessage:    `watchNamespace configuration is not supported when the content only supports AllNamespaces install mode`,
 		},
 		{
 			name:                  "reject with required field when install modes {OwnNamespace} and watchNamespace is null",


### PR DESCRIPTION
## Summary of Changes

When a ClusterExtension with `watchNamespace` config is applied to an AllNamespaces-only, the error message has been improved to be more descriptive.

## Before vs After

### Scenario: User tries to configure watchNamespace on AllNamespaces-only operator

**BEFORE:**
```
invalid ClusterExtension configuration: invalid configuration: unknown field "watchNamespace"
```

**NOW:**
```
invalid ClusterExtension configuration: invalid configuration: watchNamespace configuration is not supported when the content only supports "AllNamespaces" install mode
```

## Motivation

https://issues.redhat.com//browse/OCPBUGS-63611