### PR TITLE
:warning: fix: rename owner label and clarify variable naming

### DIFF
--- a/internal/operator-controller/applier/boxcutter.go
+++ b/internal/operator-controller/applier/boxcutter.go
@@ -26,7 +26,6 @@ import (
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
-	"github.com/operator-framework/operator-controller/internal/operator-controller/controllers"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
 )
 
@@ -183,7 +182,7 @@ func (r *SimpleRevisionGenerator) buildClusterExtensionRevision(
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,
 			Labels: map[string]string{
-				controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+				labels.OwnerNameKey: ext.Name,
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -217,7 +216,7 @@ type boxcutterStorageMigratorClient interface {
 func (m *BoxcutterStorageMigrator) Migrate(ctx context.Context, ext *ocv1.ClusterExtension, objectLabels map[string]string) error {
 	existingRevisionList := ocv1.ClusterExtensionRevisionList{}
 	if err := m.Client.List(ctx, &existingRevisionList, client.MatchingLabels{
-		controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+		labels.OwnerNameKey: ext.Name,
 	}); err != nil {
 		return fmt.Errorf("listing ClusterExtensionRevisions before attempting migration: %w", err)
 	}
@@ -429,7 +428,7 @@ func (bc *Boxcutter) garbageCollectOldRevisions(ctx context.Context, revisionLis
 func (bc *Boxcutter) getExistingRevisions(ctx context.Context, extName string) ([]ocv1.ClusterExtensionRevision, error) {
 	existingRevisionList := &ocv1.ClusterExtensionRevisionList{}
 	if err := bc.Client.List(ctx, existingRevisionList, client.MatchingLabels{
-		controllers.ClusterExtensionRevisionOwnerLabel: extName,
+		labels.OwnerNameKey: extName,
 	}); err != nil {
 		return nil, fmt.Errorf("listing revisions: %w", err)
 	}

--- a/internal/operator-controller/applier/boxcutter_test.go
+++ b/internal/operator-controller/applier/boxcutter_test.go
@@ -28,7 +28,6 @@ import (
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/applier"
-	"github.com/operator-framework/operator-controller/internal/operator-controller/controllers"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
 )
 
@@ -86,7 +85,7 @@ func Test_SimpleRevisionGenerator_GenerateRevisionFromHelmRelease(t *testing.T) 
 				"olm.operatorframework.io/package-name":     "my-package",
 			},
 			Labels: map[string]string{
-				"olm.operatorframework.io/owner": "test-123",
+				labels.OwnerNameKey: "test-123",
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -178,9 +177,9 @@ func Test_SimpleRevisionGenerator_GenerateRevision(t *testing.T) {
 	rev, err := b.GenerateRevision(t.Context(), fstest.MapFS{}, ext, map[string]string{}, map[string]string{})
 	require.NoError(t, err)
 
-	t.Log("by checking the olm.operatorframework.io/owner label is set to the name of the ClusterExtension")
+	t.Log("by checking the olm.operatorframework.io/owner-name label is set to the name of the ClusterExtension")
 	require.Equal(t, map[string]string{
-		controllers.ClusterExtensionRevisionOwnerLabel: "test-extension",
+		labels.OwnerNameKey: "test-extension",
 	}, rev.Labels)
 	t.Log("by checking the revision number is 0")
 	require.Equal(t, int64(0), rev.Spec.Revision)
@@ -344,7 +343,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			Name: "test-ext-1",
 			UID:  "rev-uid-1",
 			Labels: map[string]string{
-				controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+				labels.OwnerNameKey: ext.Name,
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -402,7 +401,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -430,7 +429,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client) {
 				revList := &ocv1.ClusterExtensionRevisionList{}
-				err := c.List(t.Context(), revList, client.MatchingLabels{controllers.ClusterExtensionRevisionOwnerLabel: ext.Name})
+				err := c.List(t.Context(), revList, client.MatchingLabels{labels.OwnerNameKey: ext.Name})
 				require.NoError(t, err)
 				require.Len(t, revList.Items, 1)
 
@@ -450,7 +449,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -481,7 +480,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client) {
 				revList := &ocv1.ClusterExtensionRevisionList{}
-				err := c.List(context.Background(), revList, client.MatchingLabels{controllers.ClusterExtensionRevisionOwnerLabel: ext.Name})
+				err := c.List(context.Background(), revList, client.MatchingLabels{labels.OwnerNameKey: ext.Name})
 				require.NoError(t, err)
 				// No new revision should be created
 				require.Len(t, revList.Items, 1)
@@ -496,7 +495,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -528,7 +527,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client) {
 				revList := &ocv1.ClusterExtensionRevisionList{}
-				err := c.List(context.Background(), revList, client.MatchingLabels{controllers.ClusterExtensionRevisionOwnerLabel: ext.Name})
+				err := c.List(context.Background(), revList, client.MatchingLabels{labels.OwnerNameKey: ext.Name})
 				require.NoError(t, err)
 				require.Len(t, revList.Items, 2)
 
@@ -557,7 +556,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			validate: func(t *testing.T, c client.Client) {
 				// Ensure no revisions were created
 				revList := &ocv1.ClusterExtensionRevisionList{}
-				err := c.List(context.Background(), revList, client.MatchingLabels{controllers.ClusterExtensionRevisionOwnerLabel: ext.Name})
+				err := c.List(context.Background(), revList, client.MatchingLabels{labels.OwnerNameKey: ext.Name})
 				require.NoError(t, err)
 				assert.Empty(t, revList.Items)
 			},
@@ -570,7 +569,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{},
@@ -582,7 +581,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-1",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -594,7 +593,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-2",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -606,7 +605,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-3",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -618,7 +617,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-4",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -630,7 +629,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-5",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -642,7 +641,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-6",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -674,7 +673,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{},
@@ -686,7 +685,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-1",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -698,7 +697,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-2",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -711,7 +710,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-3",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -723,7 +722,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-4",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -736,7 +735,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-5",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -748,7 +747,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-6",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -760,7 +759,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rev-7",
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -794,7 +793,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: revisionAnnotations,
 							Labels: map[string]string{
-								controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+								labels.OwnerNameKey: ext.Name,
 							},
 						},
 						Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -830,7 +829,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 							labels.PackageNameKey:   "test-package",
 						},
 						Labels: map[string]string{
-							controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+							labels.OwnerNameKey: ext.Name,
 						},
 					},
 					Spec: ocv1.ClusterExtensionRevisionSpec{
@@ -858,7 +857,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client) {
 				revList := &ocv1.ClusterExtensionRevisionList{}
-				err := c.List(context.Background(), revList, client.MatchingLabels{controllers.ClusterExtensionRevisionOwnerLabel: ext.Name})
+				err := c.List(context.Background(), revList, client.MatchingLabels{labels.OwnerNameKey: ext.Name})
 				require.NoError(t, err)
 				// Should still be only 1 revision (in-place update, not new revision)
 				require.Len(t, revList.Items, 1)
@@ -870,7 +869,7 @@ func TestBoxcutter_Apply(t *testing.T) {
 				assert.Equal(t, "1.0.1", rev.Annotations[labels.BundleVersionKey])
 				assert.Equal(t, "test-package", rev.Annotations[labels.PackageNameKey])
 				// Verify owner label is still present
-				assert.Equal(t, ext.Name, rev.Labels[controllers.ClusterExtensionRevisionOwnerLabel])
+				assert.Equal(t, ext.Name, rev.Labels[labels.OwnerNameKey])
 			},
 		},
 	}
@@ -1061,7 +1060,7 @@ func (m *mockBundleRevisionBuilder) GenerateRevisionFromHelmRelease(
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-revision",
 			Labels: map[string]string{
-				controllers.ClusterExtensionRevisionOwnerLabel: ext.Name,
+				labels.OwnerNameKey: ext.Name,
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{},

--- a/internal/operator-controller/controllers/clusterextension_controller.go
+++ b/internal/operator-controller/controllers/clusterextension_controller.go
@@ -280,7 +280,8 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1.Cl
 		return ctrl.Result{}, err
 	}
 
-	storeLbls := map[string]string{
+	// The following values will be stored as annotations and not labels
+	revisionAnnotations := map[string]string{
 		labels.BundleNameKey:      resolvedRevisionMetadata.Name,
 		labels.PackageNameKey:     resolvedRevisionMetadata.Package,
 		labels.BundleVersionKey:   resolvedRevisionMetadata.Version,
@@ -297,7 +298,7 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1.Cl
 	// to ensure exponential backoff can occur:
 	//   - Permission errors (it is not possible to watch changes to permissions.
 	//     The only way to eventually recover from permission errors is to keep retrying).
-	rolloutSucceeded, rolloutStatus, err := r.Applier.Apply(ctx, imageFS, ext, objLbls, storeLbls)
+	rolloutSucceeded, rolloutStatus, err := r.Applier.Apply(ctx, imageFS, ext, objLbls, revisionAnnotations)
 
 	// Set installed status
 	if rolloutSucceeded {
@@ -531,7 +532,7 @@ func (d *BoxcutterRevisionStatesGetter) GetRevisionStates(ctx context.Context, e
 	//   recent revisions. We should consolidate to avoid code duplication.
 	existingRevisionList := &ocv1.ClusterExtensionRevisionList{}
 	if err := d.Reader.List(ctx, existingRevisionList, client.MatchingLabels{
-		ClusterExtensionRevisionOwnerLabel: ext.Name,
+		labels.OwnerNameKey: ext.Name,
 	}); err != nil {
 		return nil, fmt.Errorf("listing revisions: %w", err)
 	}

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller_internal_test.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
 )
 
 func Test_ClusterExtensionRevisionReconciler_listPreviousRevisions(t *testing.T) {
@@ -106,7 +107,7 @@ func Test_ClusterExtensionRevisionReconciler_listPreviousRevisions(t *testing.T)
 
 				rev1 := newTestClusterExtensionRevisionInternal(t, "rev-1")
 				rev2 := newTestClusterExtensionRevisionInternal(t, "rev-2")
-				rev2.Labels[ClusterExtensionRevisionOwnerLabel] = "test-ext-2"
+				rev2.Labels[labels.OwnerNameKey] = "test-ext-2"
 				rev3 := newTestClusterExtensionRevisionInternal(t, "rev-3")
 				require.NoError(t, controllerutil.SetControllerReference(ext, rev1, testScheme))
 				require.NoError(t, controllerutil.SetControllerReference(ext2, rev2, testScheme))
@@ -125,7 +126,7 @@ func Test_ClusterExtensionRevisionReconciler_listPreviousRevisions(t *testing.T)
 			existingObjs: func() []client.Object {
 				ext := newTestClusterExtensionInternal()
 				rev1 := newTestClusterExtensionRevisionInternal(t, "rev-1")
-				delete(rev1.Labels, ClusterExtensionRevisionOwnerLabel)
+				delete(rev1.Labels, labels.OwnerNameKey)
 				require.NoError(t, controllerutil.SetControllerReference(ext, rev1, testScheme))
 				return []client.Object{ext, rev1}
 			},
@@ -194,7 +195,7 @@ func newTestClusterExtensionRevisionInternal(t *testing.T, name string) *ocv1.Cl
 			UID:        types.UID(name),
 			Generation: int64(1),
 			Labels: map[string]string{
-				ClusterExtensionRevisionOwnerLabel: "test-ext",
+				labels.OwnerNameKey: "test-ext",
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller_test.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller_test.go
@@ -29,6 +29,7 @@ import (
 
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/operator-framework/operator-controller/internal/operator-controller/controllers"
+	"github.com/operator-framework/operator-controller/internal/operator-controller/labels"
 )
 
 func Test_ClusterExtensionRevisionReconciler_Reconcile_RevisionProgression(t *testing.T) {
@@ -707,7 +708,7 @@ func newTestClusterExtensionRevision(t *testing.T, name string) *ocv1.ClusterExt
 			UID:        types.UID(name),
 			Generation: int64(1),
 			Labels: map[string]string{
-				controllers.ClusterExtensionRevisionOwnerLabel: "test-ext",
+				labels.OwnerNameKey: "test-ext",
 			},
 		},
 		Spec: ocv1.ClusterExtensionRevisionSpec{


### PR DESCRIPTION
Rename ClusterExtensionRevision owner label from `owner` to `owner-name` for consistency. Also rename misleading `storeLbls` variable to `revisionAnnotations` to clarify it contains annotations, not labels.

This removes the duplicate ClusterExtensionRevisionOwnerLabel constant and uses labels.OwnerNameKey directly throughout the codebase.

⚠️ Breaks the upgrade. However, we did not promoted yet so we can move forward with it: https://github.com/operator-framework/operator-controller/actions/runs/19496963917/job/55801395894?pr=2349#step:4:493 . If we re-install and install would pass. 