### PR TITLE
🌱 (fix): Experimental E2E Upgrade does breaks up we do a release when breaking changes on experimental features are merged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,10 @@ test-extension-developer-e2e: run-internal image-registry extension-developer-e2
 run-latest-release:
 	curl -L -s https://github.com/operator-framework/operator-controller/releases/latest/download/$(notdir $(RELEASE_INSTALL)) | bash -s
 
+.PHONY: run-main-install
+run-main-install:
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) ./hack/test/install-from-main.sh $(notdir $(SOURCE_MANIFEST))
+
 .PHONY: pre-upgrade-setup
 pre-upgrade-setup:
 	./hack/test/pre-upgrade-setup.sh $(CATALOG_IMG) $(TEST_CLUSTER_CATALOG_NAME) $(TEST_CLUSTER_EXTENSION_NAME)
@@ -315,6 +319,7 @@ post-upgrade-checks:
 
 
 TEST_UPGRADE_E2E_TASKS := kind-cluster run-latest-release image-registry pre-upgrade-setup docker-build kind-load kind-deploy post-upgrade-checks kind-clean
+TEST_UPGRADE_EXPERIMENTAL_E2E_TASKS := kind-cluster run-main-install image-registry pre-upgrade-setup docker-build kind-load kind-deploy post-upgrade-checks kind-clean
 
 .PHONY: test-upgrade-e2e
 test-upgrade-e2e: SOURCE_MANIFEST := $(STANDARD_MANIFEST)
@@ -332,7 +337,7 @@ test-upgrade-experimental-e2e: KIND_CLUSTER_NAME := operator-controller-upgrade-
 test-upgrade-experimental-e2e: export MANIFEST := $(EXPERIMENTAL_RELEASE_MANIFEST)
 test-upgrade-experimental-e2e: export TEST_CLUSTER_CATALOG_NAME := test-catalog
 test-upgrade-experimental-e2e: export TEST_CLUSTER_EXTENSION_NAME := test-package
-test-upgrade-experimental-e2e: $(TEST_UPGRADE_E2E_TASKS) #HELP Run upgrade e2e tests on a local kind cluster
+test-upgrade-experimental-e2e: $(TEST_UPGRADE_EXPERIMENTAL_E2E_TASKS) #HELP Run upgrade e2e tests on a local kind cluster
 
 
 .PHONY: e2e-coverage

--- a/hack/test/install-from-main.sh
+++ b/hack/test/install-from-main.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+
+set -euo pipefail
+
+# This script is used to install OLMv1 from the main branch by:
+# 1. Checking out main branch in a temporary location
+# 2. Building container images from main source code
+# 3. Loading images into the kind cluster
+# 4. Deploying manifests from main
+
+
+help="install-from-main.sh installs OLMv1 from main branch source code
+
+Usage:
+  install-from-main.sh [MANIFEST_NAME]
+
+Example:
+  install-from-main.sh experimental.yaml
+  install-from-main.sh standard.yaml
+
+Environment variables:
+  KIND_CLUSTER_NAME: Name of the kind cluster (required)
+"
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Illegal number of arguments passed"
+  echo "${help}"
+  exit 1
+fi
+
+if [[ -z "${KIND_CLUSTER_NAME:-}" ]]; then
+  echo "Error: KIND_CLUSTER_NAME environment variable must be set"
+  exit 1
+fi
+
+MANIFEST_NAME=$1
+
+# Create temporary directory for main branch checkout
+TEMP_DIR=$(mktemp -d)
+trap 'echo "Cleaning up ${TEMP_DIR}"; rm -rf "${TEMP_DIR}"' EXIT
+
+echo "Cloning main branch to temporary directory..."
+# Clone from GitHub (works in CI and locally)
+git clone --depth 1 --branch main https://github.com/operator-framework/operator-controller.git "${TEMP_DIR}"
+
+cd "${TEMP_DIR}"
+
+echo "Building images from main branch source code..."
+make docker-build
+
+echo "Loading images into kind cluster ${KIND_CLUSTER_NAME}..."
+make kind-load KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME}"
+
+echo "Deploying manifests from main branch..."
+# Extract CERT_MGR_VERSION from main branch Makefile
+# Expected Makefile line format: export CERT_MGR_VERSION := <value>
+CERT_MGR_VERSION_FROM_MAIN=$(grep "^export CERT_MGR_VERSION" Makefile | awk -F'[ :=]+' '{print $NF}')
+export CERT_MGR_VERSION="${CERT_MGR_VERSION_FROM_MAIN:-v1.18.2}"
+export MANIFEST="https://raw.githubusercontent.com/operator-framework/operator-controller/main/manifests/${MANIFEST_NAME}"
+export DEFAULT_CATALOG="https://raw.githubusercontent.com/operator-framework/operator-controller/main/manifests/default-catalogs.yaml"
+export INSTALL_DEFAULT_CATALOGS="${INSTALL_DEFAULT_CATALOGS:-false}"
+
+curl -L -s https://raw.githubusercontent.com/operator-framework/operator-controller/main/scripts/install.tpl.sh | \
+  envsubst '$$DEFAULT_CATALOG,$$CERT_MGR_VERSION,$$INSTALL_DEFAULT_CATALOGS,$$MANIFEST' | bash -s
+
+echo "Successfully installed OLMv1 from main branch"
+


### PR DESCRIPTION
This PR updates the experimental upgrade path to avoid failures caused by expected breaking changes in experimental features by moving experimental upgrade tests to main → PR to prevent experimental breakages from failing and forcing us to do a release. 

### Current issue
The current flow is: latest release → PR, with all experimental features enabled.  
If an experimental feature breaks, the upgrade job fails, blocking merges until the next release.

### Proposed change
Switch the experimental upgrade flow to: main → PR.  
This keeps the stable upgrade path clean while still validating experimental changes against `main`.
**So, we can safe merge a breaking change for experimental and then the follow PRs will pass and we still raising those scenarios to be aware of.** 
