### PR TITLE
:sparkles: OPRUN-4288: Add upgrade e2es for standard to experimental

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,105 +9,67 @@ on:
       - main
 
 jobs:
-  extension-developer-e2e:
+  e2e:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: go.mod
-
-    - name: Run the extension developer e2e test
-      run: make test-extension-developer-e2e
-
-  e2e-kind:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: extension-developer-e2e
+            make-target: test-extension-developer-e2e
+            use-artifacts: false
+            use-codecov: false
+          - name: e2e
+            make-target: test-e2e
+            use-artifacts: true
+            use-codecov: true
+          - name: experimental-e2e
+            make-target: test-experimental-e2e
+            use-artifacts: true
+            use-codecov: true
+          - name: upgrade-st2st-e2e
+            make-target: test-upgrade-st2st-e2e
+            use-artifacts: true
+            use-codecov: false
+          - name: upgrade-ex2ex-e2e
+            make-target: test-upgrade-ex2ex-e2e
+            use-artifacts: true
+            use-codecov: false
+          - name: upgrade-st2ex-e2e
+            make-target: test-upgrade-st2ex-e2e
+            use-artifacts: true
+            use-codecov: false
+          - name: st2ex-e2e
+            make-target: test-st2ex-e2e
+            use-artifacts: true
+            use-codecov: false
+    name: ${{ matrix.test.name }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - name: Run e2e tests
-        run: ARTIFACT_PATH=/tmp/artifacts E2E_SUMMARY_OUTPUT=$GITHUB_STEP_SUMMARY make test-e2e
+      - name: Run e2e test
+        run: |
+          if [[ "${{ matrix.test.use-artifacts }}" == "true" ]]; then
+            ARTIFACT_PATH=/tmp/artifacts E2E_SUMMARY_OUTPUT=$GITHUB_STEP_SUMMARY make ${{ matrix.test.make-target }}
+          else
+            make ${{ matrix.test.make-target }}
+          fi
 
       - uses: actions/upload-artifact@v5
-        if: failure()
+        if: failure() && matrix.test.use-artifacts == true
         with:
-          name: e2e-artifacts
+          name: ${{ matrix.test.name }}-artifacts
           path: /tmp/artifacts/
 
       - uses: codecov/codecov-action@v5.5.1
+        if: matrix.test.use-codecov == true
         with:
           disable_search: true
-          files: coverage/e2e.out
-          flags: e2e
+          files: coverage/${{ matrix.test.name }}.out
+          flags: ${{ matrix.test.name }}
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  experimental-e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Run e2e tests
-        run: ARTIFACT_PATH=/tmp/artifacts E2E_SUMMARY_OUTPUT=$GITHUB_STEP_SUMMARY make test-experimental-e2e
-
-      - uses: actions/upload-artifact@v5
-        if: failure()
-        with:
-          name: experimental-e2e-artifacts
-          path: /tmp/artifacts/
-
-      - uses: codecov/codecov-action@v5.5.1
-        with:
-          disable_search: true
-          files: coverage/experimental-e2e.out
-          flags: experimental-e2e
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  upgrade-e2e:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: go.mod
-
-    - name: Run the upgrade e2e test
-      run: ARTIFACT_PATH=/tmp/artifacts make test-upgrade-e2e
-
-    - uses: actions/upload-artifact@v5
-      if: failure()
-      with:
-        name: upgrade-e2e-artifacts
-        path: /tmp/artifacts/
-
-  upgrade-experimental-e2e:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: go.mod
-
-    - name: Run the upgrade e2e test
-      run: ARTIFACT_PATH=/tmp/artifacts make test-upgrade-experimental-e2e
-
-    - uses: actions/upload-artifact@v5
-      if: failure()
-      with:
-        name: upgrade-experimental-e2e-artifacts
-        path: /tmp/artifacts/
 


### PR DESCRIPTION
The current set of upgrade-e2e tests upgrade from the last release to the current PR/repo state. Standard is tested against standard, experimental is tested against experimental.

We should have upgrade e2e tests that upgrade from standard to experimental, including from the current PR/repo state, and also from the prior release.

This also renames the targets to make it clear what is being upgraded.
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
