### PR TITLE
:bug: add PDB to make sure at least 1 pod is always available during upgrade

### DIFF
--- a/hack/test/install-prometheus.sh
+++ b/hack/test/install-prometheus.sh
@@ -38,8 +38,11 @@ echo "Patching namespace to ${PROMETHEUS_NAMESPACE}..."
 echo "Applying Prometheus base..."
 kubectl apply -k "$TMPDIR" --server-side
 
+echo "Waiting for Prometheus Operator deployment to become available..."
+kubectl wait --for=condition=Available deployment/prometheus-operator -n "$PROMETHEUS_NAMESPACE" --timeout=180s
+
 echo "Waiting for Prometheus Operator pod to become ready..."
-kubectl wait --for=condition=Ready pod -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus-operator
+kubectl wait --for=condition=Ready pod -n "$PROMETHEUS_NAMESPACE" -l app.kubernetes.io/name=prometheus-operator --timeout=120s
 
 echo "Applying prometheus Helm chart..."
 ${HELM} template prometheus helm/prometheus ${PROMETHEUS_VALUES} | sed "s/cert-git-version/cert-${VERSION}/g" | kubectl apply -f -

--- a/helm/olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+++ b/helm/olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
@@ -1,0 +1,22 @@
+{{- if and .Values.options.catalogd.enabled .Values.options.catalogd.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: {{ .Values.namespaces.olmv1.name }}
+  labels:
+    app.kubernetes.io/name: catalogd
+    {{- include "olmv1.labels" . | nindent 4 }}
+  annotations:
+    {{- include "olmv1.annotations" . | nindent 4 }}
+spec:
+  {{- if .Values.options.catalogd.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.options.catalogd.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.options.catalogd.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.options.catalogd.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+{{- end }}

--- a/helm/olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+++ b/helm/olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
@@ -1,0 +1,22 @@
+{{- if and .Values.options.operatorController.enabled .Values.options.operatorController.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: {{ .Values.namespaces.olmv1.name }}
+  labels:
+    app.kubernetes.io/name: operator-controller
+    {{- include "olmv1.labels" . | nindent 4 }}
+  annotations:
+    {{- include "olmv1.annotations" . | nindent 4 }}
+spec:
+  {{- if .Values.options.operatorController.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.options.operatorController.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.options.operatorController.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.options.operatorController.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+{{- end }}

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -12,6 +12,9 @@ options:
     features:
       enabled: []
       disabled: []
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
   catalogd:
     enabled: true
     deployment:
@@ -20,6 +23,9 @@ options:
     features:
       enabled: []
       disabled: []
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
   certManager:
     enabled: false
   e2e:

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -87,6 +87,40 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental-e2e
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental-e2e
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -87,6 +87,40 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -87,6 +87,40 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard-e2e
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -87,6 +87,40 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: olmv1-system
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

To address [OCPBUGS-62517](https://issues.redhat.com/browse/OCPBUGS-62517). Currently, the operator-controller lacks `PodDisruptionBudget` configuration. During node drain operations or cluster upgrades, all controller pods can be evicted
Simultaneously, causing the operator to report `Available=False`, which violates the OpenShift API contract:

  > "A component must not report Available=False during the course of a normal upgrade."
  > — [OpenShift API Contract](https://github.com/openshift/api/blob/master/config/v1/types_cluster_operator.go#L156)


<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

  Add PodDisruptionBudget resources with `minAvailable: 1` for both controllers to ensure at least one pod remains available during:
  - Rolling updates
  - Node drain operations
  - Cluster upgrades

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)

Assisted-by: Claude code