### PR TITLE
:seedling: Update inline config docs and annotations

### DIFF
--- a/api/v1/clusterextension_types.go
+++ b/api/v1/clusterextension_types.go
@@ -176,12 +176,14 @@ type ClusterExtensionConfig struct {
 	// inline contains JSON or YAML values specified directly in the
 	// ClusterExtension.
 	//
-	// inline must be set if configType is 'Inline'.
-	// inline accepts arbitrary JSON/YAML objects.
-	// inline is validation at runtime against the schema provided by the bundle if a schema is provided.
+	// inline is used to specify arbitrary configuration values for the ClusterExtension.
+	// It must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.
+	// The configuration values are validated at runtime against a JSON schema provided by the bundle.
 	//
 	// +kubebuilder:validation:Type=object
+	// +kubebuilder:validation:MinProperties=1
 	// +optional
+	// +unionMember
 	Inline *apiextensionsv1.JSON `json:"inline,omitempty"`
 }
 

--- a/docs/api-reference/olmv1-api-reference.md
+++ b/docs/api-reference/olmv1-api-reference.md
@@ -254,7 +254,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `configType` _[ClusterExtensionConfigType](#clusterextensionconfigtype)_ | configType is a required reference to the type of configuration source.<br />Allowed values are "Inline"<br />When this field is set to "Inline", the cluster extension configuration is defined inline within the<br />ClusterExtension resource. |  | Enum: [Inline] <br />Required: \{\} <br /> |
-| `inline` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#json-v1-apiextensions-k8s-io)_ | inline contains JSON or YAML values specified directly in the<br />ClusterExtension.<br />inline must be set if configType is 'Inline'.<br />inline accepts arbitrary JSON/YAML objects.<br />inline is validation at runtime against the schema provided by the bundle if a schema is provided. |  | Type: object <br /> |
+| `inline` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#json-v1-apiextensions-k8s-io)_ | inline contains JSON or YAML values specified directly in the<br />ClusterExtension.<br />inline is used to specify arbitrary configuration values for the ClusterExtension.<br />It must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.<br />The configuration values are validated at runtime against a JSON schema provided by the bundle. |  | MinProperties: 1 <br />Type: object <br /> |
 
 
 #### ClusterExtensionConfigType

--- a/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
+++ b/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterextensions.yaml
@@ -83,9 +83,10 @@ spec:
                       inline contains JSON or YAML values specified directly in the
                       ClusterExtension.
 
-                      inline must be set if configType is 'Inline'.
-                      inline accepts arbitrary JSON/YAML objects.
-                      inline is validation at runtime against the schema provided by the bundle if a schema is provided.
+                      inline is used to specify arbitrary configuration values for the ClusterExtension.
+                      It must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.
+                      The configuration values are validated at runtime against a JSON schema provided by the bundle.
+                    minProperties: 1
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 required:

--- a/internal/operator-controller/controllers/clusterextension_admission_test.go
+++ b/internal/operator-controller/controllers/clusterextension_admission_test.go
@@ -462,8 +462,17 @@ func Test_ClusterExtensionAdmissionInlineConfig(t *testing.T) {
 			errMsg:      "spec.config.inline in body must be of type object",
 		},
 		{
-			name:        "accepts valid json object",
+			name:        "rejects empty json object",
+			configBytes: []byte(`{}`),
+			errMsg:      "spec.config.inline in body should have at least 1 properties",
+		},
+		{
+			name:        "accepts valid json object with configuration",
 			configBytes: []byte(`{"key": "value"}`),
+		},
+		{
+			name:        "accepts valid json object with nested configuration",
+			configBytes: []byte(`{"key": {"foo": ["bar", "baz"], "h4x0r": 1337}}`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -981,9 +981,10 @@ spec:
                       inline contains JSON or YAML values specified directly in the
                       ClusterExtension.
 
-                      inline must be set if configType is 'Inline'.
-                      inline accepts arbitrary JSON/YAML objects.
-                      inline is validation at runtime against the schema provided by the bundle if a schema is provided.
+                      inline is used to specify arbitrary configuration values for the ClusterExtension.
+                      It must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.
+                      The configuration values are validated at runtime against a JSON schema provided by the bundle.
+                    minProperties: 1
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 required:

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -946,9 +946,10 @@ spec:
                       inline contains JSON or YAML values specified directly in the
                       ClusterExtension.
 
-                      inline must be set if configType is 'Inline'.
-                      inline accepts arbitrary JSON/YAML objects.
-                      inline is validation at runtime against the schema provided by the bundle if a schema is provided.
+                      inline is used to specify arbitrary configuration values for the ClusterExtension.
+                      It must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.
+                      The configuration values are validated at runtime against a JSON schema provided by the bundle.
+                    minProperties: 1
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 required:


### PR DESCRIPTION
# Description

Addresses [enhancement PR ](https://github.com/openshift/enhancements/pull/1849) reviewer comments by:

 - Updates inline configuration documentation
 - Adds missing `// +unionMember` annotation to `Inline`
 - Adds `// +kubebuilder:validation:MinProperties=1` validation to `Inline` to ensure empty configurations `{}` cannot be specified
  - Adds additional admission unit test inc. to test the added validation annotation

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
