### PR TITLE
:bug: Fix testCatalogName conflict

### DIFF
--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -197,7 +198,8 @@ func TestClusterExtensionInstallRegistryMultipleBundles(t *testing.T) {
 	t.Log("When a cluster extension is installed from a catalog")
 
 	clusterExtension, extensionCatalog, sa, ns := TestInit(t)
-	extraCatalog, err := CreateTestCatalog(context.Background(), "extra-test-catalog", os.Getenv(testCatalogRefEnvVar))
+	extraCatalogName := fmt.Sprintf("extra-test-catalog-%s", rand.String(8))
+	extraCatalog, err := CreateTestCatalog(context.Background(), extraCatalogName, os.Getenv(testCatalogRefEnvVar))
 	require.NoError(t, err)
 
 	defer TestCleanup(t, extensionCatalog, clusterExtension, sa, ns)
@@ -238,7 +240,11 @@ func TestClusterExtensionInstallRegistryMultipleBundles(t *testing.T) {
 		require.NotNil(ct, cond)
 		require.Equal(ct, metav1.ConditionTrue, cond.Status)
 		require.Equal(ct, ocv1.ReasonRetrying, cond.Reason)
-		require.Contains(ct, cond.Message, "in multiple catalogs with the same priority [extra-test-catalog test-catalog]")
+		// Catalog names are sorted alphabetically in the error message
+		catalogs := []string{extensionCatalog.Name, extraCatalog.Name}
+		slices.Sort(catalogs)
+		expectedMessage := fmt.Sprintf("in multiple catalogs with the same priority %v", catalogs)
+		require.Contains(ct, cond.Message, expectedMessage)
 	}, pollDuration, pollInterval)
 }
 
@@ -441,7 +447,7 @@ func TestClusterExtensionInstallReResolvesWhenCatalogIsPatched(t *testing.T) {
 	// patch imageRef tag on test-catalog image with v2 image
 	t.Log("By patching the catalog ImageRef to point to the v2 catalog")
 	updatedCatalogImage := fmt.Sprintf("%s/e2e/test-catalog:v2", os.Getenv("CLUSTER_REGISTRY_HOST"))
-	err := patchTestCatalog(context.Background(), testCatalogName, updatedCatalogImage)
+	err := patchTestCatalog(context.Background(), extensionCatalog.Name, updatedCatalogImage)
 	require.NoError(t, err)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		require.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: extensionCatalog.Name}, extensionCatalog))
@@ -474,8 +480,9 @@ func TestClusterExtensionInstallReResolvesWhenNewCatalog(t *testing.T) {
 	require.NoError(t, err)
 
 	// create a test-catalog with latest image tag
+	catalogName := fmt.Sprintf("test-catalog-%s", rand.String(8))
 	latestCatalogImage := fmt.Sprintf("%s/e2e/test-catalog:latest", os.Getenv("CLUSTER_REGISTRY_HOST"))
-	extensionCatalog, err := CreateTestCatalog(context.Background(), testCatalogName, latestCatalogImage)
+	extensionCatalog, err := CreateTestCatalog(context.Background(), catalogName, latestCatalogImage)
 	require.NoError(t, err)
 	clusterExtensionName := fmt.Sprintf("clusterextension-%s", rand.String(8))
 	clusterExtension := &ocv1.ClusterExtension{


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

- Fix this failure that happend in https://github.com/operator-framework/operator-controller/pull/2363 

```go
=== RUN   TestClusterExtensionVersionUpdate
    single_namespace_support_test.go:361: When a cluster extension is installed from a catalog
    single_namespace_support_test.go:362: When resolving upgrade edges
    helpers.go:229: 
        	Error Trace:	/home/runner/work/operator-controller/operator-controller/test/helpers/helpers.go:229
        	Error:      	Received unexpected error:
        	            	object is being deleted: clustercatalogs.olm.operatorframework.io "test-catalog" already exists
        	Test:       	TestClusterExtensionVersionUpdate
--- FAIL: TestClusterExtensionVersionUpdate (0.01s)
```

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)

Assisted-by: Claude Code 