### PR TITLE
:warning: Remove Paused ClusterExtensionRevision LifecycleState

### DIFF
--- a/api/v1/clusterextensionrevision_types.go
+++ b/api/v1/clusterextensionrevision_types.go
@@ -96,9 +96,6 @@ type ClusterExtensionRevisionLifecycleState string
 const (
 	// ClusterExtensionRevisionLifecycleStateActive / "Active" is the default lifecycle state.
 	ClusterExtensionRevisionLifecycleStateActive ClusterExtensionRevisionLifecycleState = "Active"
-	// ClusterExtensionRevisionLifecycleStatePaused / "Paused" disables reconciliation of the ClusterExtensionRevision.
-	// Object changes will not be reconciled. However, status updates will be propagated.
-	ClusterExtensionRevisionLifecycleStatePaused ClusterExtensionRevisionLifecycleState = "Paused"
 	// ClusterExtensionRevisionLifecycleStateArchived / "Archived" archives the revision for historical or auditing purposes.
 	// The revision is removed from the owner list of all other objects previously under management and all objects
 	// that did not transition to a succeeding revision are deleted.

--- a/internal/operator-controller/controllers/boxcutter_reconcile_steps.go
+++ b/internal/operator-controller/controllers/boxcutter_reconcile_steps.go
@@ -50,11 +50,7 @@ func (d *BoxcutterRevisionStatesGetter) GetRevisionStates(ctx context.Context, e
 
 	rs := &RevisionStates{}
 	for _, rev := range existingRevisionList.Items {
-		switch rev.Spec.LifecycleState {
-		case ocv1.ClusterExtensionRevisionLifecycleStateActive,
-			ocv1.ClusterExtensionRevisionLifecycleStatePaused:
-		default:
-			// Skip anything not active or paused, which should only be "Archived".
+		if rev.Spec.LifecycleState == ocv1.ClusterExtensionRevisionLifecycleStateArchived {
 			continue
 		}
 

--- a/internal/operator-controller/controllers/clusterextensionrevision_controller.go
+++ b/internal/operator-controller/controllers/clusterextensionrevision_controller.go
@@ -450,10 +450,6 @@ func (c *ClusterExtensionRevisionReconciler) toBoxcutterRevision(ctx context.Con
 		}
 		r.Phases = append(r.Phases, phase)
 	}
-
-	if rev.Spec.LifecycleState == ocv1.ClusterExtensionRevisionLifecycleStatePaused {
-		opts = append(opts, boxcutter.WithPaused{})
-	}
 	return r, opts, nil
 }
 


### PR DESCRIPTION
# Description

Removes references from the ClusterExtensionRevision Paused lifecycle state, since we don't plan on including it for now

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
