### PR TITLE
:warning: Remove Migrated reason from ClusterExtensionRevision Available condition

### DIFF
--- a/api/v1/clusterextensionrevision_types.go
+++ b/api/v1/clusterextensionrevision_types.go
@@ -32,7 +32,6 @@ const (
 	// Condition Reasons
 	ClusterExtensionRevisionReasonArchived        = "Archived"
 	ClusterExtensionRevisionReasonBlocked         = "Blocked"
-	ClusterExtensionRevisionReasonMigrated        = "Migrated"
 	ClusterExtensionRevisionReasonProbeFailure    = "ProbeFailure"
 	ClusterExtensionRevisionReasonProbesSucceeded = "ProbesSucceeded"
 	ClusterExtensionRevisionReasonReconciling     = "Reconciling"

--- a/internal/operator-controller/applier/boxcutter.go
+++ b/internal/operator-controller/applier/boxcutter.go
@@ -266,20 +266,6 @@ func (m *BoxcutterStorageMigrator) Migrate(ctx context.Context, ext *ocv1.Cluste
 		return fmt.Errorf("getting created revision: %w", err)
 	}
 
-	// Set Available=Unknown so the revision controller will verify cluster state through probes.
-	// During migration, ClusterExtension will briefly show as not installed until verification completes.
-	meta.SetStatusCondition(&rev.Status.Conditions, metav1.Condition{
-		Type:               ocv1.ClusterExtensionRevisionTypeAvailable,
-		Status:             metav1.ConditionUnknown,
-		Reason:             ocv1.ClusterExtensionRevisionReasonMigrated,
-		Message:            "Migrated from Helm storage, awaiting cluster state verification",
-		ObservedGeneration: rev.Generation,
-	})
-
-	if err := m.Client.Status().Update(ctx, rev); err != nil {
-		return fmt.Errorf("updating migrated revision status: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Description

Removes the Migrated reason from the ClusterExtensionRevision Available condition. It would be short-lived and it makes more sense to let the revision controller set the conditions. If there is need to call out migration, we could set an annotation on the revision resource.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
