### PR TITLE
:seedling: Change the experimental-e2e to use a two-node kind cluster

### DIFF
--- a/kind-config-experimental.yaml
+++ b/kind-config-experimental.yaml
@@ -1,0 +1,45 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+    extraPortMappings:
+    # e2e image registry service's NodePort
+      - containerPort: 30000
+        hostPort: 30000
+        listenAddress: "127.0.0.1"
+        protocol: tcp
+    # prometheus metrics service's NodePort
+      - containerPort: 30900
+        hostPort: 30900
+        listenAddress: "127.0.0.1"
+        protocol: tcp
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+            extraArgs:
+              enable-admission-plugins: OwnerReferencesPermissionEnforcement
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+          taints: []
+    extraMounts:
+      - hostPath: ./hack/kind-config/containerd/certs.d
+        containerPath: /etc/containerd/certs.d
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+          taints: []
+    extraMounts:
+      - hostPath: ./hack/kind-config/containerd/certs.d
+        containerPath: /etc/containerd/certs.d
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"


### PR DESCRIPTION
In order to fully support multiple replicas, we need to be able to run our tests in a multi-node environment, but we don't _always_ want to run in a multi-node test environment.

Update the experimental-e2e to run a 2-node kind cluster (both control- plane).

Update the `kind-load` recipe to directly load a docker image via `load docker-image`, since `load image-archive` has issues with multi-node clusters.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
