### PR TITLE
🐛 OCPBUGS-81452: prevent webhook rollout stalls by issuing certificates earlier

### DIFF
--- a/internal/operator-controller/applier/phase.go
+++ b/internal/operator-controller/applier/phase.go
@@ -120,10 +120,10 @@ var (
 		PhaseInfrastructure: {
 			{Kind: "Service"},
 			{Kind: "Issuer", Group: "cert-manager.io"},
+			{Kind: "Certificate", Group: "cert-manager.io"},
 		},
 
 		PhaseDeploy: {
-			{Kind: "Certificate", Group: "cert-manager.io"},
 			{Kind: "Deployment", Group: "apps"},
 		},
 

--- a/internal/operator-controller/applier/phase_test.go
+++ b/internal/operator-controller/applier/phase_test.go
@@ -168,6 +168,17 @@ func Test_PhaseSort(t *testing.T) {
 				{
 					Object: &unstructured.Unstructured{
 						Object: map[string]interface{}{
+							"apiVersion": "cert-manager.io/v1",
+							"kind":       "Certificate",
+							"metadata": map[string]interface{}{
+								"name": "test",
+							},
+						},
+					},
+				},
+				{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
 							"apiVersion": "autoscaling.k8s.io/v1",
 							"kind":       "VerticalPodAutoscaler",
 						},
@@ -314,6 +325,17 @@ func Test_PhaseSort(t *testing.T) {
 								},
 							},
 						},
+						{
+							Object: &unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "cert-manager.io/v1",
+									"kind":       "Certificate",
+									"metadata": map[string]interface{}{
+										"name": "test",
+									},
+								},
+							},
+						},
 					},
 				},
 				{
@@ -454,7 +476,7 @@ func Test_PhaseSort(t *testing.T) {
 			want: []*ocv1ac.ClusterObjectSetPhaseApplyConfiguration{},
 		},
 		{
-			name: "sort by group within same phase",
+			name: "sort by group across infrastructure and deploy phases",
 			objs: []ocv1ac.ClusterObjectSetObjectApplyConfiguration{
 				{
 					Object: &unstructured.Unstructured{
@@ -481,6 +503,22 @@ func Test_PhaseSort(t *testing.T) {
 			},
 			want: []*ocv1ac.ClusterObjectSetPhaseApplyConfiguration{
 				{
+					Name: ptr.To(string(applier.PhaseInfrastructure)),
+					Objects: []ocv1ac.ClusterObjectSetObjectApplyConfiguration{
+						{
+							Object: &unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"apiVersion": "cert-manager.io/v1",
+									"kind":       "Certificate",
+									"metadata": map[string]interface{}{
+										"name": "test",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
 					Name: ptr.To(string(applier.PhaseDeploy)),
 					Objects: []ocv1ac.ClusterObjectSetObjectApplyConfiguration{
 						{
@@ -488,17 +526,6 @@ func Test_PhaseSort(t *testing.T) {
 								Object: map[string]interface{}{
 									"apiVersion": "apps/v1",
 									"kind":       "Deployment",
-									"metadata": map[string]interface{}{
-										"name": "test",
-									},
-								},
-							},
-						},
-						{
-							Object: &unstructured.Unstructured{
-								Object: map[string]interface{}{
-									"apiVersion": "cert-manager.io/v1",
-									"kind":       "Certificate",
 									"metadata": map[string]interface{}{
 										"name": "test",
 									},


### PR DESCRIPTION
## What changed
- move cert-manager `Certificate` objects into the `infrastructure` phase
- keep `Issuer` in `infrastructure` and leave workload `Deployment` objects in `deploy`
- update phase sorting tests to cover the new ordering

## Why
Webhook installs can stall in `RollingOut` when certificate issuance and deployment availability are gated within the same phase. Starting certificate issuance earlier shortens the rollout critical path for webhook-backed operators.

## Impact
This reduces the chance that `ClusterExtension` installations for webhook operators remain stuck waiting for the generated deployment to become available.

## Root cause
The rollout path allowed cert-manager `Certificate` objects to be applied in the same phase as the webhook deployment. For operators that mount the serving cert secret, that can delay deployment availability long enough to hit external rollout timeouts.

## Validation
- `go test -tags containers_image_openpgp ./internal/operator-controller/applier -run Test_PhaseSort`
