### PR TITLE
:bug: Fix race condition in e2e code coverage collection

### DIFF
--- a/hack/test/e2e-coverage.sh
+++ b/hack/test/e2e-coverage.sh
@@ -22,8 +22,9 @@ rm -rf ${COVERAGE_DIR} && mkdir -p ${COVERAGE_DIR}
 kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" scale deployment/"$OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME" --replicas=0
 kubectl -n "$CATALOGD_NAMESPACE" scale deployment/"$CATALOGD_MANAGER_DEPLOYMENT_NAME" --replicas=0
 
-# Wait for the copy pod to be ready
-kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" wait --for=condition=ready pod "$COPY_POD_NAME"
+# Wait for deployments to scale down so coverage data is flushed to the PVC
+kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" wait --for=jsonpath='{.status.replicas}'=0 deployment/"$OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME" --timeout=60s
+kubectl -n "$CATALOGD_NAMESPACE" wait --for=jsonpath='{.status.replicas}'=0 deployment/"$CATALOGD_MANAGER_DEPLOYMENT_NAME" --timeout=60s
 
 # Copy the coverage data from the temporary pod
 kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" cp "$COPY_POD_NAME":/e2e-coverage/ "$COVERAGE_DIR"

--- a/hack/test/e2e-coverage.sh
+++ b/hack/test/e2e-coverage.sh
@@ -22,9 +22,9 @@ rm -rf ${COVERAGE_DIR} && mkdir -p ${COVERAGE_DIR}
 kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" scale deployment/"$OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME" --replicas=0
 kubectl -n "$CATALOGD_NAMESPACE" scale deployment/"$CATALOGD_MANAGER_DEPLOYMENT_NAME" --replicas=0
 
-# Wait for deployments to scale down so coverage data is flushed to the PVC
-kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" wait --for=jsonpath='{.status.replicas}'=0 deployment/"$OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME" --timeout=60s
-kubectl -n "$CATALOGD_NAMESPACE" wait --for=jsonpath='{.status.replicas}'=0 deployment/"$CATALOGD_MANAGER_DEPLOYMENT_NAME" --timeout=60s
+# Wait for manager pods to terminate so coverage data is flushed to the PVC
+kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" wait --for=delete pods -l control-plane="$OPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME" --timeout=60s
+kubectl -n "$CATALOGD_NAMESPACE" wait --for=delete pods -l control-plane="$CATALOGD_MANAGER_DEPLOYMENT_NAME" --timeout=60s
 
 # Copy the coverage data from the temporary pod
 kubectl -n "$OPERATOR_CONTROLLER_NAMESPACE" cp "$COPY_POD_NAME":/e2e-coverage/ "$COVERAGE_DIR"


### PR DESCRIPTION
# Description

`hack/test/e2e-coverage.sh` has a race condition that causes intermittent
coverage data loss in CI. `kubectl scale --replicas=0` is non-blocking —
it returns as soon as the API server accepts the change, not when pods
have terminated. The existing `wait --for=condition=ready` on the copy pod
was a no-op since it was already running. This meant `kubectl cp` could
execute before manager pods had terminated and flushed coverage data to
the PVC.

The fix replaces the no-op wait with `kubectl wait --for=delete` on the
manager pods, ensuring they have fully terminated and the Go coverage
runtime has written its data before copying.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)