### PR TITLE
:bug: tlsprofiles: guard empty parse results; write JSON atomically

### DIFF
--- a/hack/tools/update-tls-profiles.sh
+++ b/hack/tools/update-tls-profiles.sh
@@ -4,8 +4,13 @@ set -e
 
 OUTPUT=internal/shared/util/tlsprofiles/mozilla_data.json
 INPUT=https://ssl-config.mozilla.org/guidelines/latest.json
+tmp="$(mktemp "${OUTPUT}.tmp.XXXXXX")"
+trap 'rm -f "${tmp}"' EXIT
 
-if ! curl -L -s -f "${INPUT}" -o "${OUTPUT}"; then
+if ! curl -L -s -f "${INPUT}" -o "${tmp}"; then
     echo "ERROR: Failed to download ${INPUT} (HTTP error or connection failure)" >&2
     exit 1
 fi
+
+mv "${tmp}" "${OUTPUT}"
+trap - EXIT

--- a/internal/shared/util/tlsprofiles/mozilla_data.go
+++ b/internal/shared/util/tlsprofiles/mozilla_data.go
@@ -96,6 +96,13 @@ func parseProfile(name string, cfg mozillaConfiguration) (tlsProfile, []string, 
 		panic(fmt.Sprintf("tlsprofiles: profile %q has unrecognized tls_versions[0] %q: %v", name, cfg.TLSVersions[0], err))
 	}
 
+	if len(curveNums) == 0 {
+		panic(fmt.Sprintf("tlsprofiles: profile %q resolved no supported tls_curves from embedded mozilla_data.json", name))
+	}
+	if version < tlsVersion(tls.VersionTLS13) && len(cipherNums) == 0 {
+		panic(fmt.Sprintf("tlsprofiles: profile %q resolved no supported cipher suites from embedded mozilla_data.json", name))
+	}
+
 	return tlsProfile{
 		ciphers:       cipherSlice{cipherNums: cipherNums},
 		curves:        curveSlice{curveNums: curveNums},


### PR DESCRIPTION
Panic in parseProfile if all curves or all pre-TLS-1.3 ciphers are skipped, preventing a silent zero-value profile. Download mozilla_data.json to a temp file and mv atomically to avoid leaving a corrupt file on partial curl failure.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
