### PR TITLE
:seedling: scripts: skip cert-manager install if already present on cluster

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -94,7 +94,16 @@ kubectl_wait_for_query() {
     done
 }
 
-kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
+# Install cert-manager only if it is not already present on the cluster.
+# Check both the CRD and the controller deployments to avoid false positives
+# from stale CRDs left behind by a partial or incomplete installation.
+if kubectl get crd certificates.cert-manager.io &>/dev/null && \
+   kubectl get deployment -n cert-manager cert-manager-webhook &>/dev/null && \
+   kubectl get deployment -n cert-manager cert-manager-cainjector &>/dev/null; then
+    echo "cert-manager is already installed, skipping installation"
+else
+    kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
+fi
 # Wait for cert-manager to be fully ready
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
 kubectl_wait "cert-manager" "deployment/cert-manager-cainjector" "60s"


### PR DESCRIPTION
Fixes #1501

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
