### PR TITLE
:bug: Fix DNS1123 validation message to match rule semantics

### DIFF
--- a/api/v1/clusterobjectset_types.go
+++ b/api/v1/clusterobjectset_types.go
@@ -366,7 +366,7 @@ type ClusterObjectSetPhase struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens, and must start with an alphabetic character and end with an alphanumeric character."
+	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens, and must start and end with an alphanumeric character."
 	Name string `json:"name"`
 
 	// objects is a required list of all Kubernetes objects that belong to this phase.
@@ -532,7 +532,7 @@ type ObservedPhase struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens, and must start with an alphabetic character and end with an alphanumeric character."
+	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens, and must start and end with an alphanumeric character."
 	Name string `json:"name"`
 
 	// digest is the digest of the phase's resolved object content

--- a/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterobjectsets.yaml
+++ b/helm/olmv1/base/operator-controller/crd/experimental/olm.operatorframework.io_clusterobjectsets.yaml
@@ -150,8 +150,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                     objects:
                       description: |-
@@ -649,8 +649,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - digest

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -1474,8 +1474,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                     objects:
                       description: |-
@@ -1973,8 +1973,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - digest

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1435,8 +1435,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                     objects:
                       description: |-
@@ -1934,8 +1934,8 @@ spec:
                       type: string
                       x-kubernetes-validations:
                       - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens, and must start with an alphabetic
-                          character and end with an alphanumeric character.
+                          characters and hyphens, and must start and end with an alphanumeric
+                          character.
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - digest


### PR DESCRIPTION
## Summary
- The `XValidation` message for `dns1123Label()` on `ClusterObjectSetPhase.Name` and `ObservedPhase.Name` incorrectly stated values "must start with an alphabetic character"
- DNS1123 labels allow starting with a digit, so the message now reads "must start and end with an alphanumeric character" to match the actual rule

## Test plan
- [ ] Verify the updated validation message is accurate per [RFC 1123](https://tools.ietf.org/html/rfc1123)
- [ ] Confirm generated CRD manifests reflect the corrected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)