### PR TITLE
🐛 e2e: skip clusterobjectset cleanup when BoxcutterRuntime is disabled

### DIFF
--- a/test/e2e/steps/hooks.go
+++ b/test/e2e/steps/hooks.go
@@ -216,7 +216,7 @@ func ScenarioCleanup(ctx context.Context, _ *godog.Scenario, err error) (context
 	if sc.clusterExtensionName != "" {
 		forDeletion = append(forDeletion, resource{name: sc.clusterExtensionName, kind: "clusterextension"})
 	}
-	if sc.clusterObjectSetName != "" {
+	if sc.clusterObjectSetName != "" && featureGates[features.BoxcutterRuntime] {
 		forDeletion = append(forDeletion, resource{name: sc.clusterObjectSetName, kind: "clusterobjectset"})
 	}
 	forDeletion = append(forDeletion, resource{name: sc.namespace, kind: "namespace"})


### PR DESCRIPTION
# Description

Scenario cleanup unconditionally attempted to delete the pre-generated `clusterobjectset` resource, but the CRD only exists when `BoxcutterRuntime` is enabled. This produced the error:

```
error: the server doesn't have a resource type "clusterobjectset"
```

Guard the deletion with a `featureGates[features.BoxcutterRuntime]` check so it's only attempted when the CRD exists.

## Reviewer Checklist

- [x] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)