### PR TITLE
:seedling: Add spec-driven development (SDD) framework

### DIFF
--- a/.claude/commands/sdd-implement.md
+++ b/.claude/commands/sdd-implement.md
@@ -1,0 +1,44 @@
+Implement the current phase spec for operator-controller.
+
+## Steps
+
+1. Identify the active phase spec. Look for a `specs/*/plan.md` file on the current branch. If multiple exist or none are found, use AskUserQuestion to clarify which phase to implement.
+
+2. Read all spec files for the phase:
+   - `plan.md` — understand the goals and approach
+   - `requirements.md` — follow task groups in order
+   - `validation.md` — know the acceptance criteria upfront
+
+3. Implement task groups in the order specified in `requirements.md`. For each task group:
+   - Read the requirements carefully before writing code
+   - Follow existing patterns in the codebase (see `AGENTS.md` for conventions)
+   - Use AskUserQuestion for any decisions not covered by the spec
+
+4. After implementing each task group, verify the relevant validation criteria from `validation.md`.
+
+5. Run the project check commands after implementation:
+   ```
+   make lint && make test-unit
+   ```
+
+6. If code generation is needed (API changes, CRD changes):
+   ```
+   make generate && make manifests
+   ```
+
+7. Run format to ensure consistency:
+   ```
+   make fmt
+   ```
+
+8. Verify all generated code is up-to-date:
+   ```
+   make verify
+   ```
+
+9. If validation criteria require e2e tests and a kind cluster is available:
+   ```
+   make test-e2e
+   ```
+
+10. Use AskUserQuestion for any implementation decisions not covered by the spec, referencing `specs/mission.md` design principles and `specs/tech-stack.md` constraints.

--- a/.claude/commands/sdd-implement.md
+++ b/.claude/commands/sdd-implement.md
@@ -1,8 +1,8 @@
-Implement the current phase spec for operator-controller.
+Implement the current epic spec for operator-controller.
 
 ## Steps
 
-1. Identify the active phase spec. Look for a `specs/*/plan.md` file on the current branch. If multiple exist or none are found, use AskUserQuestion to clarify which phase to implement.
+1. Identify the active epic spec. Look for a `specs/*/plan.md` file on the current branch. If multiple exist or none are found, use AskUserQuestion to clarify which epic to implement.
 
 2. Read all spec files for the phase:
    - `plan.md` — understand the goals and approach

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -1,0 +1,39 @@
+Plan the next development phase for operator-controller.
+
+## Steps
+
+1. Check for uncommitted changes with `git status`. If there are uncommitted changes, use AskUserQuestion to ask whether to stash them (`git stash`) or abort.
+
+2. Check out `main` and pull latest from upstream:
+   ```
+   git checkout main && git pull upstream main
+   ```
+
+3. Read `specs/roadmap.md` and find the next undefined phase (look for "TBD" or the last numbered phase and increment).
+
+4. Create a new branch:
+   ```
+   git checkout -b phase-{N}-{short-name}
+   ```
+
+5. Use AskUserQuestion to gather details about the upcoming phase:
+   - What is the focus area for this phase?
+   - What are the key deliverables (3-6 items)?
+   - Are there any dependencies or blockers?
+   - What validation criteria define "done" for this phase?
+
+6. Create the phase spec directory and files:
+   ```
+   specs/YYYY-MM-DD-phase-{N}-{name}/
+     plan.md          — overview, goals, approach
+     requirements.md  — detailed requirements and task groups
+     validation.md    — acceptance criteria and test plan
+   ```
+
+7. Reference `specs/mission.md` for alignment with project goals and design principles. Reference `specs/tech-stack.md` for implementation constraints (build commands, test frameworks, CI requirements).
+
+8. After writing the spec files, run a self-review:
+   - Check internal consistency across plan, requirements, and validation
+   - Verify alignment with mission goals and non-goals
+   - Ensure deliverables are concrete and testable
+   - Flag any gaps or ambiguities using AskUserQuestion

--- a/.claude/commands/sdd-plan-next-phase.md
+++ b/.claude/commands/sdd-plan-next-phase.md
@@ -1,4 +1,4 @@
-Plan the next development phase for operator-controller.
+Plan the next development phase for operator-controller by selecting an eligible GitHub epic.
 
 ## Steps
 
@@ -9,31 +9,46 @@ Plan the next development phase for operator-controller.
    git checkout main && git pull upstream main
    ```
 
-3. Read `specs/roadmap.md` and find the next undefined phase (look for "TBD" or the last numbered phase and increment).
-
-4. Create a new branch:
+3. Search for eligible epics on the upstream repository. An eligible epic has labels `epic` and `refined`, is unassigned, and has no unresolved dependencies:
    ```
-   git checkout -b phase-{N}-{short-name}
+   gh issue list --repo operator-framework/operator-controller --label epic --label refined --assignee "" --state open --json number,title,body,labels,url --limit 20
    ```
 
-5. Use AskUserQuestion to gather details about the upcoming phase:
-   - What is the focus area for this phase?
-   - What are the key deliverables (3-6 items)?
-   - Are there any dependencies or blockers?
-   - What validation criteria define "done" for this phase?
-
-6. Create the phase spec directory and files:
+4. For each candidate epic, check its linked issues to verify dependencies are resolved. Use the GitHub API to inspect linked issues:
    ```
-   specs/YYYY-MM-DD-phase-{N}-{name}/
-     plan.md          — overview, goals, approach
+   gh api repos/operator-framework/operator-controller/issues/{number}/timeline --jq '.[] | select(.event=="cross-referenced" or .event=="connected")'
+   ```
+   An epic is eligible only if all blocking/dependency issues have the `done` label. Epics with no dependencies are also eligible.
+
+5. Present the eligible epics to the user via AskUserQuestion, showing the issue number, title, and a brief summary. Let the user pick which epic to work on.
+
+6. Assign the selected epic to the current git user:
+   ```
+   gh issue edit {number} --repo operator-framework/operator-controller --add-assignee @me
+   ```
+
+7. Create a new branch named after the epic:
+   ```
+   git checkout -b epic-{number}-{short-name}
+   ```
+
+8. Use AskUserQuestion to gather implementation details about the epic:
+   - What is the approach for this epic?
+   - How should the work be broken into task groups?
+   - What validation criteria define "done"?
+
+9. Create the phase spec directory and files:
+   ```
+   specs/{epic-number}-{name}/
+     plan.md          — overview, goals, approach (link back to the GitHub issue)
      requirements.md  — detailed requirements and task groups
      validation.md    — acceptance criteria and test plan
    ```
 
-7. Reference `specs/mission.md` for alignment with project goals and design principles. Reference `specs/tech-stack.md` for implementation constraints (build commands, test frameworks, CI requirements).
+10. Reference `specs/mission.md` for alignment with project goals and design principles. Reference `specs/tech-stack.md` for implementation constraints (build commands, test frameworks, CI requirements).
 
-8. After writing the spec files, run a self-review:
-   - Check internal consistency across plan, requirements, and validation
-   - Verify alignment with mission goals and non-goals
-   - Ensure deliverables are concrete and testable
-   - Flag any gaps or ambiguities using AskUserQuestion
+11. After writing the spec files, run a self-review:
+    - Check internal consistency across plan, requirements, and validation
+    - Verify alignment with mission goals and non-goals
+    - Ensure deliverables are concrete and testable
+    - Flag any gaps or ambiguities using AskUserQuestion

--- a/.claude/commands/sdd-review.md
+++ b/.claude/commands/sdd-review.md
@@ -1,0 +1,46 @@
+Review all changes on the current branch for consistency and quality.
+
+## Steps
+
+1. Identify the base branch and get the diff:
+   ```
+   git diff main...HEAD --name-only
+   ```
+
+2. Read all changed files. For each file, check:
+   - Does the change follow existing patterns and conventions in the codebase?
+   - Are there any security concerns (OWASP top 10, RBAC escalation, injection)?
+   - Is error handling consistent with surrounding code?
+   - Are tests included for new functionality?
+
+3. Check consistency with governing specs:
+   - Read `specs/mission.md` — does the change align with goals and design principles?
+   - Read `specs/tech-stack.md` — are the right tools and patterns being used?
+   - Read `specs/conventions.md` — do commit messages and code style match conventions?
+
+4. If a phase spec exists for this branch, check against it:
+   - Read `specs/*/validation.md` — are validation criteria met?
+   - Read `specs/*/requirements.md` — are all required task groups addressed?
+
+5. Check whether any governing documents need updating:
+   - Does `AGENTS.md` need updates for new patterns, APIs, or conventions?
+   - Do any specs need amendments based on what was learned during implementation?
+
+6. For issues with multiple valid approaches, use AskUserQuestion to present options and let the author decide.
+
+7. Apply straightforward fixes directly:
+   - Typos, formatting inconsistencies
+   - Missing error checks that follow established patterns
+   - Import ordering issues
+
+8. Verify generated files are up-to-date (CRDs, deepcopy, manifests):
+   ```
+   make verify
+   ```
+
+9. Run the check commands to verify the branch is clean:
+   ```
+   make lint && make test-unit
+   ```
+
+10. Summarize findings: what looks good, what needs attention, and any spec updates recommended.

--- a/.claude/commands/sdd-ship.md
+++ b/.claude/commands/sdd-ship.md
@@ -80,4 +80,9 @@ Verify, commit, and publish the current branch for operator-controller.
    )"
    ```
 
-6. Report the PR URL when done.
+6. If this branch is linked to a GitHub epic (check `specs/*/plan.md` for an issue reference), use AskUserQuestion to ask whether to add the `done` label to the epic:
+   ```
+   gh issue edit {number} --repo operator-framework/operator-controller --add-label done
+   ```
+
+7. Report the PR URL when done.

--- a/.claude/commands/sdd-ship.md
+++ b/.claude/commands/sdd-ship.md
@@ -1,0 +1,83 @@
+Verify, commit, and publish the current branch for operator-controller.
+
+## Phase 1: Verify
+
+1. Run the project check commands:
+   ```
+   make lint && make test-unit
+   ```
+
+2. Run format to ensure consistency:
+   ```
+   make fmt
+   ```
+
+3. Verify all generated code is up-to-date:
+   ```
+   make verify
+   ```
+
+4. If a phase spec exists for this branch, read `specs/*/validation.md` and verify all acceptance criteria are met.
+
+5. Check if `AGENTS.md` needs updating for any new patterns, APIs, or conventions introduced in this branch.
+
+6. If any verification step fails, fix the issue before proceeding. Use AskUserQuestion if the fix is ambiguous.
+
+## Phase 2: Commit
+
+1. Read `specs/conventions.md` for commit message and PR format requirements.
+
+2. Review all staged and unstaged changes:
+   ```
+   git status
+   git diff
+   ```
+
+3. Use AskUserQuestion to confirm the commit plan:
+   - Show a summary of what will be committed
+   - Propose a commit message following conventions (no emoji prefix on commits; that's for PR titles)
+   - Ask whether to create a single commit or multiple logical commits
+
+4. If there are post-review fixup commits that should be squashed, handle squashing into logical commits. Preserve DCO sign-off trailers (`Signed-off-by`) when squashing. Use AskUserQuestion to confirm before any interactive rebase.
+
+5. Ensure all commits have DCO sign-off (`-s` flag).
+
+## Phase 3: Publish
+
+1. Check the current branch. If on `main`, use AskUserQuestion to warn that shipping directly to main is not allowed — a feature branch is required. Abort if confirmed.
+
+2. Use AskUserQuestion to confirm before pushing. Show:
+   - The branch name
+   - Number of commits ahead of main
+   - Summary of changes
+
+3. Push the branch to the fork:
+   ```
+   git push -u origin <branch-name>
+   ```
+
+4. Determine the PR title emoji prefix based on the change type:
+   - `:warning:` for breaking changes
+   - `:sparkles:` for new features
+   - `:bug:` for bug fixes
+   - `:book:` for documentation
+   - `:seedling:` for everything else
+
+5. Create the PR against upstream using the project's template format:
+   ```
+   gh pr create --title "<emoji> <title>" --body "$(cat <<'EOF'
+   # Description
+
+   <Summary of changes and motivation>
+
+   ## Reviewer Checklist
+
+   - [ ] API Go Documentation
+   - [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
+   - [ ] Comprehensive Commit Messages
+   - [ ] Links to related GitHub Issue(s)
+   EOF
+   )"
+   ```
+
+6. Report the PR URL when done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,4 +342,30 @@ Two manifest variants exist:
 
 ---
 
-**Last Updated:** 2025-12-10
+## Spec-Driven Development
+
+This project uses spec-driven development. Governing specs live in `specs/`:
+
+| Spec | Purpose |
+|---|---|
+| `specs/mission.md` | Goals, non-goals, design principles |
+| `specs/tech-stack.md` | Language, dependencies, build commands, project structure |
+| `specs/roadmap.md` | Historical phases and next steps |
+| `specs/conventions.md` | Commit, PR, and branch conventions |
+
+### Workflow Commands
+
+| Command | Purpose |
+|---|---|
+| `/sdd-plan-next-phase` | Plan the next development phase: create branch and spec directory |
+| `/sdd-implement` | Implement a phase spec: follow task groups, run checks |
+| `/sdd-review` | Review branch changes for consistency with specs and conventions |
+| `/sdd-ship` | Verify, commit, and publish: run checks, create PR with conventions |
+
+Primary check command: `make lint && make test-unit`
+
+API changes in `api/v1/` require: `make generate && make manifests && make crd-ref-docs`
+
+---
+
+**Last Updated:** 2026-04-22

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ This project uses spec-driven development. Governing specs live in `specs/`:
 
 | Command | Purpose |
 |---|---|
-| `/sdd-plan-next-phase` | Plan the next development phase: create branch and spec directory |
+| `/sdd-plan-next-phase` | Pick an eligible GitHub epic (`epic`+`refined`, unassigned, deps resolved), assign it, create branch and spec directory |
 | `/sdd-implement` | Implement a phase spec: follow task groups, run checks |
 | `/sdd-review` | Review branch changes for consistency with specs and conventions |
 | `/sdd-ship` | Verify, commit, and publish: run checks, create PR with conventions |

--- a/specs/conventions.md
+++ b/specs/conventions.md
@@ -1,0 +1,88 @@
+# Conventions
+
+## Commit Messages
+
+Format:
+
+```
+<High-level description>
+
+<Optional detailed description explaining the why, not the what>
+
+Signed-off-by: Your Name <your@email.com>
+```
+
+Example:
+
+```
+Refactor Boxcutter controller to rely on kubernetes for resource cleanup
+
+Instead of manually tracking and deleting owned resources, rely on
+Kubernetes garbage collection via owner references. This simplifies
+the controller logic and eliminates a class of race conditions during
+concurrent reconciles.
+
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+Rules:
+- DCO sign-off (`Signed-off-by`) is required on all commits
+- Keep the subject line concise and descriptive
+- Use the body to explain motivation when non-obvious
+- Generated files must be committed alongside the source changes that require them
+
+## Pull Requests
+
+### Title Format
+
+PR titles must use an emoji prefix indicating the change type:
+
+| Emoji | Shortcode | Meaning |
+|---|---|---|
+| ⚠ | `:warning:` | Major/breaking change |
+| ✨ | `:sparkles:` | Minor/compatible change (new feature) |
+| 🐛 | `:bug:` | Patch/bug fix |
+| 📖 | `:book:` | Documentation |
+| 🌱 | `:seedling:` | Other (deps, chores, refactors) |
+
+Examples:
+- `:sparkles: Add support for deploying OCI helm charts in OLM v1`
+- `:bug: Fix race condition in Helm to Boxcutter migration during OLM upgrades`
+- `:warning: Remove support for annotation based config`
+- `:seedling: Upgrade boxcutter from v0.11.0 to v0.12.0`
+
+### Description Template
+
+```markdown
+# Description
+
+<Summary of changes and motivation>
+
+## Reviewer Checklist
+
+- [ ] API Go Documentation
+- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
+- [ ] Comprehensive Commit Messages
+- [ ] Links to related GitHub Issue(s)
+```
+
+### Requirements
+
+- Must pass all CI checks (unit-test, e2e, sanity, lint)
+- Must have both `approved` and `lgtm` labels (from repository approvers and reviewers)
+- Draft PRs: prefix with "WIP:" or use GitHub draft feature
+
+## Branch Naming
+
+- **Main branch:** `main` (default, protected)
+- **Release branches:** `release-v{MAJOR}.{MINOR}` (e.g., `release-v1.2`)
+- **Feature branches:** Created from `main`, typically in contributor forks, merged via PR
+
+## Git Remotes
+
+Fork-based development workflow:
+- **`origin`** — your personal fork (push here)
+- **`upstream`** — the project repository `operator-framework/operator-controller` (pull from here)
+
+To sync with upstream: `git pull upstream main`
+To push a branch: `git push -u origin <branch-name>`

--- a/specs/conventions.md
+++ b/specs/conventions.md
@@ -78,6 +78,16 @@ Examples:
 - **Release branches:** `release-v{MAJOR}.{MINOR}` (e.g., `release-v1.2`)
 - **Feature branches:** Created from `main`, typically in contributor forks, merged via PR
 
+## Issue Labels
+
+| Label | Purpose |
+|---|---|
+| `epic` | Marks an issue as an epic (a significant body of work) |
+| `refined` | Indicates the epic has been refined and is ready for implementation |
+| `done` | Marks a completed epic; used to resolve dependency chains |
+
+An epic is eligible for work when it has both `epic` and `refined` labels, is unassigned, and all linked blocking issues carry the `done` label.
+
 ## Git Remotes
 
 Fork-based development workflow:

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -1,0 +1,33 @@
+# Mission
+
+operator-controller is the central component of Operator Lifecycle Manager (OLM) v1. It extends Kubernetes with a declarative API for installing, upgrading, and managing cluster extensions. Together with catalogd, it provides a complete lifecycle management system for Kubernetes operators and, eventually, other workload types.
+
+## Goals
+
+1. Provide a declarative, GitOps-aligned API for installing and managing Kubernetes extensions
+2. Replace OLM v0 with a simpler, more secure, and more predictable lifecycle management system
+3. Give cluster admins minimal but sufficient controls to build desired cluster architectures
+4. Serve operator catalog content reliably via catalogd
+5. Support multi-arch container deployments (amd64, arm64, ppc64le, s390x)
+
+## Non-Goals
+
+- Replacing Helm or other generic package managers
+- Providing a UI or dashboard
+
+## Design Principles
+
+- **Align with Kubernetes conventions:** Follow Kubernetes API design patterns and user assumptions
+- **Declarative and GitOps-compatible:** All configuration expressed as Kubernetes resources
+- **Security by default:** Non-root containers, distroless base images, least-privilege RBAC
+- **Predictable upgrades:** Semantic versioning, phase-based rollouts, compatibility checks
+- **Minimal surface area:** Expose only what cluster admins need; avoid unnecessary abstractions
+
+## Development Practices
+
+- All changes go through PRs with CI checks (unit tests, e2e tests, linting, API/CRD compatibility)
+- DCO sign-off required on all commits
+- Generated files (CRDs, deepcopy, manifests) must be committed alongside source changes
+- Two-week cooldown on non-critical dependency updates
+- Go version lags upstream to give integrators time to adopt
+- Shell scripts and Makefiles must work on both macOS and Linux

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -1,0 +1,89 @@
+# Roadmap
+
+This document captures the historical evolution of operator-controller in phases, followed by open next steps for the team to define.
+
+## Phase 1: Foundation (Dec 2022 - Jun 2023)
+
+- Kubebuilder project initialization and Operator API (cluster-scoped CRD)
+- Deppy-based resolution engine: bundle entities, variable sources, solver integration
+- BundleDeployment creation via server-side apply
+- Status conditions, e2e test framework, CI workflows (unit-test, e2e, linting)
+- Catalogd integration (v0.2.0+) for entity sourcing
+- Feature gate infrastructure, bingo tooling, codecov integration
+- plain+v0 bundle type support, Tilt dev environment
+
+## Phase 2: API Stabilization & Resolution Overhaul (Jul 2023 - Jan 2024)
+
+- Upgrade edge support and replace-based upgrades
+- SemVer upgrade constraint support with `upgradeConstraintPolicy` field
+- Switch from CatalogMetadata API to catalogd HTTP server for resolution
+- New `catalogmetadata` package replacing entities/entity sources
+- Operator API renamed to ClusterExtension API
+- Channel support (`spec.channel`) and version range filtering
+- Cross-component e2e tests, DCO compliance
+- Deppy solver upgrades, bundle deprecation logic
+
+## Phase 3: Extension API & Helm Applier (Feb 2024 - Oct 2024)
+
+- Extension API introduction (namespaced, with source union discriminator)
+- ClusterExtension reworked to use Helm under the hood for manifest application
+- ValidatingAdmissionPolicy for package uniqueness
+- CRD upgrade safety checks (skip option via API field)
+- Removal of Deppy solver, resolution CLI, plain+v0 bundle support
+- Go 1.22 upgrade, k8s v0.30 dependency update
+- Catalogd TLS overlay, improved status conditions and error types
+- API v1 promotion, status.resolution removal, PullSecret controller
+- GitHub issue forms, CODEOWNERS, release process improvements
+
+## Phase 4: Configuration, Webhooks & Security (Nov 2024 - Jun 2025)
+
+- API audit and breaking changes (spec.install.namespace/serviceAccount moved to top-level)
+- Webhook support: certificate generation, rule validation, namespace selectors
+- Network policies with namespace-wide default deny for ingress/egress
+- RBAC preflight checks for install permissions
+- Prometheus metrics, performance alerting, API call alerts
+- OCI Helm chart deployment support
+- CRD generator update for experimental CRD variants (standard vs experimental manifests)
+- ServiceAccount pull secrets support
+- k8s 1.33 upgrade, controller-runtime updates
+- Experimental manifest generation and release pipeline
+
+## Phase 5: Boxcutter Runtime & Revision Management (Jul 2025 - Dec 2025)
+
+- Boxcutter runtime implementation (package-operator.run integration)
+- ClusterExtensionRevision API: revision lifecycle, conditions, status propagation
+- Helm-based deployment configuration (replacing kustomize-based config)
+- ClusterExtensionConfig API (`spec.config`)
+- ClusterExtension reconciler refactored to composable step-based pipeline
+- Memory optimization: caching, transforms, reduced allocations
+- Prometheus alert threshold calibration via memory profiling
+- E2e profiling toolchain (heap and CPU analysis)
+- Label-based cache for revision lookups
+- JSONSchema validation for bundle configuration
+- TLS profile support (Mozilla-based)
+- Revision manifest sanitization, collision protection
+- e2e tests refactored for feature-gate aware skipping
+- AGENTS.md for AI coding assistant guidance
+
+## Phase 6: Maturation & Operational Hardening (Jan 2026 - Present)
+
+- ClusterExtensionRevision renamed to ClusterObjectSet
+- Phase object externalization into Secrets (large bundle support)
+- DeploymentConfig feature gate: deployment customization for registry+v1 bundles
+- Progression probes: namespace, PVC, and availability probes for revision health
+- ApplyConfiguration types for server-side apply
+- Validation framework with ServiceAccount and object support validators
+- HA-ready deployments with configurable replica count
+- RBACPreAuthorizer configurable collection verbs
+- Least-privilege RBAC replacing cluster-admin for BoxcutterRuntime
+- Boxcutter upgrades (v0.9.0 through v0.13.1) with collision detection and preflight checks
+- E2e migration to Godog/Cucumber BDD framework
+- Single/Own Namespace install mode (promoted to GA, reverted to alpha, iterated)
+- TLS profile updates (Mozilla v5.8), DNS1123 validation fixes
+- Orphaned temp dir cleanup in catalog cache and storage
+
+## Next Steps
+
+<!-- The team will iterate on these. Add upcoming phases here as priorities become clear. -->
+
+- **Phase 7:** _TBD - to be defined by the team_

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -84,6 +84,9 @@ This document captures the historical evolution of operator-controller in phases
 
 ## Next Steps
 
-<!-- The team will iterate on these. Add upcoming phases here as priorities become clear. -->
+Future work is tracked via GitHub issues on the upstream repository rather than phases in this file. The `/sdd-plan-next-phase` command discovers the next available epic automatically.
 
-- **Phase 7:** _TBD - to be defined by the team_
+An issue is eligible for work when it has:
+- Labels: `epic` and `refined`
+- No assignee
+- No unresolved dependencies (all linked blocking issues have the `done` label)

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -1,0 +1,128 @@
+# Tech Stack
+
+## Language & Runtime
+
+- **Language:** Go (version specified in go.mod; intentionally lags upstream to give integrators adoption time)
+- **Module:** `github.com/operator-framework/operator-controller`
+- **Runtime platform:** Linux containers (multi-arch: amd64, arm64, ppc64le, s390x)
+- **Developer platform:** macOS and Linux
+- **Container base:** `gcr.io/distroless/static:nonroot` (user 65532:65532)
+- **Build tags:** `containers_image_openpgp`
+
+## Core Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| k8s.io/client-go, api, apimachinery | Kubernetes API interaction |
+| sigs.k8s.io/controller-runtime | Controller framework |
+| operator-framework/api | OLMv0 API types |
+| operator-framework/operator-registry | File-based catalog (FBC) processing |
+| helm-operator-plugins | Helm-based bundle rendering |
+| cert-manager | TLS certificate management |
+| package-operator.run (boxcutter) | Object set management |
+| google/go-containerregistry | OCI image handling |
+| spf13/cobra | CLI tooling |
+
+## Dev Dependencies
+
+| Tool | Purpose | Management |
+|---|---|---|
+| controller-gen | CRD/RBAC/deepcopy generation | bingo |
+| golangci-lint | Linting | bingo |
+| goreleaser | Release builds | bingo |
+| helm | Chart rendering/linting | bingo |
+| kind | Local Kubernetes clusters | bingo |
+| kustomize | Manifest composition | bingo |
+| setup-envtest | Test environment binaries | bingo |
+| operator-sdk | Extension developer tooling | bingo |
+| yamlfmt | YAML formatting | bingo |
+| conftest | Helm policy testing | bingo |
+| godog/cucumber | E2E BDD tests | go.mod |
+
+## Project Structure
+
+```
+/
++-- api/v1/                          # API definitions (CRD types)
++-- applyconfigurations/             # Generated apply configurations
++-- cmd/
+|   +-- operator-controller/         # Operator controller binary
+|   +-- catalogd/                    # Catalogd binary
++-- internal/
+|   +-- operator-controller/         # Operator controller internals
+|   +-- catalogd/                    # Catalogd internals
+|   +-- shared/                      # Shared utilities
++-- helm/olmv1/                      # Helm chart (base CRDs, templates, values)
++-- test/
+|   +-- e2e/                         # End-to-end tests (godog/cucumber)
+|   +-- extension-developer-e2e/     # Extension developer tests
+|   +-- upgrade-e2e/                 # Upgrade tests
+|   +-- regression/                  # Regression tests
++-- config/samples/                  # Example manifests
++-- docs/                            # Documentation (mkdocs)
++-- hack/                            # Scripts and dev tools
++-- manifests/                       # Generated release manifests
++-- .github/workflows/               # CI/CD workflows
++-- .bingo/                          # Pinned tool versions
+```
+
+## Build Commands
+
+| Command | Purpose |
+|---|---|
+| `make build` | Build binaries for local platform |
+| `make build-linux` | Build binaries for Linux (required for Docker) |
+| `make docker-build` | Build container images |
+| `make lint` | Run golangci-lint |
+| `make fmt` | Format code (Go + YAML) |
+| `make test-unit` | Run unit tests (envtest-based) |
+| `make test-e2e` | Run e2e tests (requires kind cluster) |
+| `make test-regression` | Run regression tests |
+| `make verify` | Verify all generated code is up-to-date |
+| `make manifests` | Generate CRDs and release manifests |
+| `make generate` | Generate deepcopy and apply configurations |
+| `make run` | Create kind cluster and deploy (standard) |
+| `make run-experimental` | Create kind cluster and deploy (experimental) |
+| `make kind-clean` | Tear down kind cluster |
+
+### Primary Check Command
+
+```bash
+make lint && make test-unit
+```
+
+### Format Command
+
+```bash
+make fmt
+```
+
+### Container Verification
+
+```bash
+make docker-build
+```
+
+## CI/CD
+
+GitHub Actions workflows:
+- `unit-test.yaml` - Unit tests with coverage
+- `e2e.yaml` - Multiple e2e test suites (7 variants)
+- `sanity.yaml` - Verification, linting, helm linting
+- `test-regression.yaml` - Regression tests
+- `go-apidiff.yaml` - API compatibility checks
+- `crd-diff.yaml` - CRD compatibility verification
+- `release.yaml` - Automated releases on tags (goreleaser)
+
+## Containerization
+
+- Two Dockerfiles: `Dockerfile.operator-controller`, `Dockerfile.catalogd`
+- Multi-arch builds: amd64, arm64, ppc64le, s390x
+- Base image: `gcr.io/distroless/static:nonroot`
+- Non-root user: `65532:65532`
+
+## Feature Gates
+
+Two manifest variants:
+- **Standard:** Production-ready features
+- **Experimental:** Features under development (includes `ClusterObjectSet` API)


### PR DESCRIPTION
# Description

Bootstrap spec-driven development (SDD) framework for the project. Adds governing specs under `specs/` and four Claude Code workflow commands under `.claude/commands/` for phase-based development.

**Governing specs:**
- `specs/mission.md` — goals, non-goals, design principles, development practices
- `specs/tech-stack.md` — language, dependencies, build commands, project structure
- `specs/roadmap.md` — 6 historical phases derived from merged PRs, with open Phase 7 placeholder
- `specs/conventions.md` — commit messages, PR format, branch naming, fork-based git remote conventions

**Workflow commands:**
- `/sdd-plan-next-phase` — plan the next development phase with spec directory
- `/sdd-implement` — implement a phase spec following task groups
- `/sdd-review` — review branch changes for consistency with specs
- `/sdd-ship` — verify, commit, and publish with project conventions

Also updates `AGENTS.md` with an SDD section referencing the specs and commands.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)