### PR TITLE
:sparkles: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/helm/olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+++ b/helm/olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
@@ -16,6 +16,7 @@ spec:
   {{- if .Values.options.catalogd.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.options.catalogd.podDisruptionBudget.maxUnavailable }}
   {{- end }}
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager

--- a/helm/olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+++ b/helm/olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
@@ -16,6 +16,7 @@ spec:
   {{- if .Values.options.operatorController.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.options.operatorController.podDisruptionBudget.maxUnavailable }}
   {{- end }}
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -100,6 +100,7 @@ metadata:
     olm.operatorframework.io/feature-set: experimental-e2e
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -117,6 +118,7 @@ metadata:
     olm.operatorframework.io/feature-set: experimental-e2e
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -100,6 +100,7 @@ metadata:
     olm.operatorframework.io/feature-set: experimental
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -117,6 +118,7 @@ metadata:
     olm.operatorframework.io/feature-set: experimental
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -100,6 +100,7 @@ metadata:
     olm.operatorframework.io/feature-set: standard-e2e
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -117,6 +118,7 @@ metadata:
     olm.operatorframework.io/feature-set: standard-e2e
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -100,6 +100,7 @@ metadata:
     olm.operatorframework.io/feature-set: standard
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -117,6 +118,7 @@ metadata:
     olm.operatorframework.io/feature-set: standard
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager


### PR DESCRIPTION



# Description

Allow eviction of unhealthy (not ready) pods even if there are no disruptions allowed on a PodDisruptionBudget. This can help to drain/maintain a node and recover without a manual intervention when multiple instances of nodes or pods are misbehaving.

- https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
