### PR TITLE
:seedling: Pass all feature gates explicitly in controller deployments

### DIFF
--- a/helm/experimental.yaml
+++ b/helm/experimental.yaml
@@ -11,13 +11,15 @@ options:
       replicas: 2
     features:
       enabled:
-        - SingleOwnNamespaceInstallSupport
-        - PreflightPermissions
-        - HelmChartSupport
         - BoxcutterRuntime
-        - DeploymentConfig
         - BundleReleaseSupport
+        - DeploymentConfig
+        - HelmChartSupport
+        - PreflightPermissions
+        - SingleOwnNamespaceInstallSupport
+        - WebhookProviderCertManager
       disabled:
+        - SyntheticPermissions
         - WebhookProviderOpenshiftServiceCA
 # List of enabled experimental features for catalogd
 # Use with {{- if has "FeatureGate" .Values.options.catalogd.features.enabled }}
@@ -28,5 +30,6 @@ options:
     features:
       enabled:
         - APIV1MetasHandler
+      disabled: []
 # This can be one of: standard or experimental
   featureSet: experimental

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -11,8 +11,17 @@ options:
       replicas: 1
       extraArguments: []
     features:
-      enabled: []
-      disabled: []
+      enabled:
+        - WebhookProviderCertManager
+      disabled:
+        - BoxcutterRuntime
+        - BundleReleaseSupport
+        - DeploymentConfig
+        - HelmChartSupport
+        - PreflightPermissions
+        - SingleOwnNamespaceInstallSupport
+        - SyntheticPermissions
+        - WebhookProviderOpenshiftServiceCA
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
@@ -24,7 +33,8 @@ options:
       extraArguments: []
     features:
       enabled: []
-      disabled: []
+      disabled:
+        - APIV1MetasHandler
     podDisruptionBudget:
       enabled: true
       minAvailable: 1

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -2823,12 +2823,14 @@ spec:
             - --metrics-bind-address=:8443
             - --pprof-bind-address=:6060
             - --leader-elect
-            - --feature-gates=SingleOwnNamespaceInstallSupport=true
-            - --feature-gates=PreflightPermissions=true
-            - --feature-gates=HelmChartSupport=true
             - --feature-gates=BoxcutterRuntime=true
-            - --feature-gates=DeploymentConfig=true
             - --feature-gates=BundleReleaseSupport=true
+            - --feature-gates=DeploymentConfig=true
+            - --feature-gates=HelmChartSupport=true
+            - --feature-gates=PreflightPermissions=true
+            - --feature-gates=SingleOwnNamespaceInstallSupport=true
+            - --feature-gates=WebhookProviderCertManager=true
+            - --feature-gates=SyntheticPermissions=false
             - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -2729,12 +2729,14 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8443
             - --leader-elect
-            - --feature-gates=SingleOwnNamespaceInstallSupport=true
-            - --feature-gates=PreflightPermissions=true
-            - --feature-gates=HelmChartSupport=true
             - --feature-gates=BoxcutterRuntime=true
-            - --feature-gates=DeploymentConfig=true
             - --feature-gates=BundleReleaseSupport=true
+            - --feature-gates=DeploymentConfig=true
+            - --feature-gates=HelmChartSupport=true
+            - --feature-gates=PreflightPermissions=true
+            - --feature-gates=SingleOwnNamespaceInstallSupport=true
+            - --feature-gates=WebhookProviderCertManager=true
+            - --feature-gates=SyntheticPermissions=false
             - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1805,6 +1805,7 @@ spec:
             - --metrics-bind-address=:7443
             - --pprof-bind-address=:6060
             - --external-address=catalogd-service.olmv1-system.svc
+            - --feature-gates=APIV1MetasHandler=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --pull-cas-dir=/var/ca-certs
@@ -1955,6 +1956,15 @@ spec:
             - --metrics-bind-address=:8443
             - --pprof-bind-address=:6060
             - --leader-elect
+            - --feature-gates=WebhookProviderCertManager=true
+            - --feature-gates=BoxcutterRuntime=false
+            - --feature-gates=BundleReleaseSupport=false
+            - --feature-gates=DeploymentConfig=false
+            - --feature-gates=HelmChartSupport=false
+            - --feature-gates=PreflightPermissions=false
+            - --feature-gates=SingleOwnNamespaceInstallSupport=false
+            - --feature-gates=SyntheticPermissions=false
+            - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1724,6 +1724,7 @@ spec:
             - --leader-elect
             - --metrics-bind-address=:7443
             - --external-address=catalogd-service.olmv1-system.svc
+            - --feature-gates=APIV1MetasHandler=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --pull-cas-dir=/var/ca-certs
@@ -1861,6 +1862,15 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8443
             - --leader-elect
+            - --feature-gates=WebhookProviderCertManager=true
+            - --feature-gates=BoxcutterRuntime=false
+            - --feature-gates=BundleReleaseSupport=false
+            - --feature-gates=DeploymentConfig=false
+            - --feature-gates=HelmChartSupport=false
+            - --feature-gates=PreflightPermissions=false
+            - --feature-gates=SingleOwnNamespaceInstallSupport=false
+            - --feature-gates=SyntheticPermissions=false
+            - --feature-gates=WebhookProviderOpenshiftServiceCA=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs


### PR DESCRIPTION
# Description

Previously, only non-default feature gates were passed as `--feature-gates`
args to controller pods:
- **Standard deployments** had no feature gate args at all
- **Experimental deployments** only listed flags that differed from defaults

This made it impossible to determine the active feature gate configuration
by inspecting a running deployment or pod spec — you had to cross-reference
the Go source code to know the defaults.

Now all 10 feature gates (9 operator-controller + 1 catalogd) are listed
explicitly in every deployment variant (standard, standard-e2e, experimental,
experimental-e2e), improving readability when inspecting deployments or pods.

### Changes
- `helm/olmv1/values.yaml`: Populated empty `enabled`/`disabled` lists with
  all feature gates at their default values
- `helm/experimental.yaml`: Added missing feature gates (`WebhookProviderCertManager`,
  `SyntheticPermissions`) so all flags are listed; sorted alphabetically
- `manifests/*.yaml`: Regenerated

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)