### PR TITLE
🌱 E2E Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ cover.out
 /install.sh
 /install-experimental.sh
 
+# upgrade-e2e artifacts
+/experimental-install.sh
+/operator-controller-standard.yaml
+/standard-install.sh
+
 # vendored files
 vendor/
 

--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,11 @@ e2e: E2E_TIMEOUT ?= 20m
 e2e: GODOG_ARGS ?=
 e2e: #EXHELP Run the e2e tests.
 ifeq ($(strip $(GODOG_ARGS)),)
+	trap 'exit 130' INT; \
 	set +e; \
-	go test -count=1 -v ./test/e2e/features_test.go -timeout=${E2E_TIMEOUT} -args --godog.tags="~@Serial" --godog.concurrency=100; \
+	go test -count=1 -v ./test/e2e/features_test.go -timeout $(E2E_TIMEOUT) -args --godog.tags="~@Serial" --godog.concurrency=100; \
 	parallelExit=$$?; \
-	go test -count=1 -v ./test/e2e/features_test.go -timeout=${E2E_TIMEOUT} -args --godog.tags="@Serial" --godog.concurrency=1; \
+	go test -count=1 -v ./test/e2e/features_test.go -timeout $(E2E_TIMEOUT) -args --godog.tags="@Serial" --godog.concurrency=1; \
 	serialExit=$$?; \
 	if [[ $$parallelExit -ne 0 ]] || [[ $$serialExit -ne 0 ]]; then \
 		echo "e2e tests failed: parallel=$$parallelExit serial=$$serialExit"; \

--- a/test/e2e/features/proxy.feature
+++ b/test/e2e/features/proxy.feature
@@ -7,7 +7,9 @@ Feature: HTTPS proxy support for outbound catalog requests
 
   Background:
     Given OLM is available
-    And ClusterCatalog "test" serves bundles
+    And a catalog "test" with packages:
+      | package | version | channel | replaces | contents                   |
+      | test    | 1.2.0   | beta    |          | CRD, Deployment, ConfigMap |
     And ServiceAccount "olm-sa" with needed permissions is available in test namespace
 
   @HTTPProxy
@@ -26,10 +28,10 @@ Feature: HTTPS proxy support for outbound catalog requests
         source:
           sourceType: Catalog
           catalog:
-            packageName: test
+            packageName: ${PACKAGE:test}
             selector:
               matchLabels:
-                "olm.operatorframework.io/metadata.name": test-catalog
+                "olm.operatorframework.io/metadata.name": ${CATALOG:test}
       """
     Then ClusterExtension reports Progressing as True with Reason Retrying and Message includes:
       """
@@ -57,9 +59,9 @@ Feature: HTTPS proxy support for outbound catalog requests
         source:
           sourceType: Catalog
           catalog:
-            packageName: test
+            packageName: ${PACKAGE:test}
             selector:
               matchLabels:
-                "olm.operatorframework.io/metadata.name": test-catalog
+                "olm.operatorframework.io/metadata.name": ${CATALOG:test}
       """
     Then the recording proxy received a CONNECT request for the catalogd service

--- a/test/e2e/features/update.feature
+++ b/test/e2e/features/update.feature
@@ -38,7 +38,7 @@ Feature: Update ClusterExtension
       """
     And ClusterExtension is rolled out
     And ClusterExtension is available
-    When ClusterExtension is updated to version "1.0.1"
+    When ClusterExtension version is updated to "1.0.1"
     Then ClusterExtension is rolled out
     And ClusterExtension is available
     And bundle "${PACKAGE:test}.1.0.1" is installed in version "1.0.1"
@@ -219,7 +219,7 @@ Feature: Update ClusterExtension
     And ClusterExtension is rolled out
     And ClusterExtension is available
     And bundle "${PACKAGE:test}.1.0.0" is installed in version "1.0.0"
-    When ClusterExtension is updated to version "1.0.4"
+    When ClusterExtension version is updated to "1.0.4"
     Then ClusterExtension is rolled out
     And ClusterExtension is available
     And bundle "${PACKAGE:test}.1.0.4" is installed in version "1.0.4"
@@ -247,7 +247,7 @@ Feature: Update ClusterExtension
       """
     And ClusterExtension is rolled out
     And ClusterExtension is available
-    When ClusterExtension is updated to version "1.0.1"
+    When ClusterExtension version is updated to "1.0.1"
     Then ClusterExtension is rolled out
     And ClusterExtension is available
     And bundle "${PACKAGE:test}.1.0.1" is installed in version "1.0.1"
@@ -300,7 +300,7 @@ Feature: Update ClusterExtension
       """
     And ClusterExtension is rolled out
     And ClusterExtension is available
-    When ClusterExtension is updated to version "1.2.0"
+    When ClusterExtension version is updated to "1.2.0"
     Then bundle "${PACKAGE:test}.1.2.0" is installed in version "1.2.0"
     And ClusterExtension is rolled out
     And ClusterExtension is available
@@ -334,7 +334,7 @@ Feature: Update ClusterExtension
       """
     And ClusterExtension is rolled out
     And ClusterExtension is available
-    When ClusterExtension is updated to version "1.0.2"
+    When ClusterExtension version is updated to "1.0.2"
     Then ClusterExtension reports "${NAME}-1, ${NAME}-2" as active revisions
     And ClusterObjectSet "${NAME}-2" reports Progressing as True with Reason RollingOut
     And ClusterObjectSet "${NAME}-2" reports Available as False with Reason ProbeFailure

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -20,6 +20,7 @@ var opts = godog.Options{
 	Output:      colors.Colored(os.Stdout),
 	Concurrency: 1,
 	NoColors:    true,
+	Strict:      true,
 }
 
 func init() {

--- a/test/e2e/steps/steps.go
+++ b/test/e2e/steps/steps.go
@@ -99,7 +99,7 @@ func RegisterSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^(?i)bundle "([^"]+)" is installed in version "([^"]+)"$`, BundleInstalled)
 
 	sc.Step(`^(?i)ClusterExtension is applied(?:\s+.*)?$`, ResourceIsApplied)
-	sc.Step(`^(?i)ClusterExtension is updated to version "([^"]+)"$`, ClusterExtensionVersionUpdate)
+	sc.Step(`^(?i)ClusterExtension version is updated to "([^"]+)"$`, ClusterExtensionVersionUpdate)
 	sc.Step(`^(?i)ClusterExtension is updated(?:\s+.*)?$`, ResourceIsApplied)
 	sc.Step(`^(?i)ClusterObjectSet "([^"]+)" lifecycle is set to "([^"]+)"$`, ClusterObjectSetLifecycleUpdate)
 	sc.Step(`^(?i)ClusterExtension is available$`, ClusterExtensionIsAvailable)

--- a/test/upgrade-e2e/features/operator-upgrade.feature
+++ b/test/upgrade-e2e/features/operator-upgrade.feature
@@ -43,6 +43,6 @@ Feature: Operator upgrade verification
 
   Scenario: ClusterExtension remains functional after OLM upgrade
     Given ClusterExtension is reconciled
-    When ClusterExtension is updated to version "1.0.1"
+    When ClusterExtension version is updated to "1.0.1"
     Then ClusterExtension is available
     And bundle "${PACKAGE:test}.1.0.1" is installed in version "1.0.1"

--- a/test/upgrade-e2e/upgrade_test.go
+++ b/test/upgrade-e2e/upgrade_test.go
@@ -18,6 +18,7 @@ var opts = godog.Options{
 	Output:      colors.Colored(os.Stdout),
 	Concurrency: 1,
 	NoColors:    true,
+	Strict:      true,
 }
 
 func init() {


### PR DESCRIPTION
- Fix undefined steps causing HTTPProxy tests to be skipped
- Set "Strict" flag for godog by default to avoid undefined steps slipping by in the future
- Fix concurrent test run requiring two ctrl-c's to terminate
- Use parentheses instead of brackets in go test calls for E2E_TIMEOUT for consistency/correctness
- Fix ambiguous step definitions

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
