### PR TITLE
:seedling: fix(test): make e2e test bundle compatible with restricted SCC

### DIFF
--- a/test/e2e/features/install.feature
+++ b/test/e2e/features/install.feature
@@ -564,7 +564,7 @@ Feature: Install ClusterExtension
     Then ClusterExtension is rolled out
     And ClusterExtension is available
     And ClusterObjectSet "${NAME}-1" phase objects are managed in Kubernetes secrets
-    And ClusterObjectSet "${NAME}-1" referred secrets exist in "olmv1-system" namespace
+    And ClusterObjectSet "${NAME}-1" referred secrets exist in "${OLM_NAMESPACE}" namespace
     And ClusterObjectSet "${NAME}-1" referred secrets are immutable
     And ClusterObjectSet "${NAME}-1" referred secrets contain labels
       | key                                          | value     |

--- a/test/e2e/features/recover.feature
+++ b/test/e2e/features/recover.feature
@@ -85,7 +85,6 @@ Feature: Recover cluster extension from errors that might occur during its lifet
                 name: busybox
                 securityContext:
                   runAsNonRoot: true
-                  runAsUser: 1000
                   allowPrivilegeEscalation: false
                   capabilities:
                     drop:

--- a/test/e2e/features/revision.feature
+++ b/test/e2e/features/revision.feature
@@ -309,8 +309,6 @@ Feature: Install ClusterObjectSet
                   imagePullPolicy: IfNotPresent
                   name: busybox
                   securityContext:
-                    runAsNonRoot: true
-                    runAsUser: 1000
                     allowPrivilegeEscalation: false
                     capabilities:
                       drop:
@@ -397,8 +395,6 @@ Feature: Install ClusterObjectSet
                       "command": ["httpd"],
                       "args": ["-f", "-p", "8080"],
                       "securityContext": {
-                        "runAsNonRoot": true,
-                        "runAsUser": 1000,
                         "allowPrivilegeEscalation": false,
                         "capabilities": {
                           "drop": ["ALL"]
@@ -729,8 +725,6 @@ Feature: Install ClusterObjectSet
                           command: ["true"]
                         initialDelaySeconds: 65
                       securityContext:
-                        runAsNonRoot: true
-                        runAsUser: 1000
                         allowPrivilegeEscalation: false
                         capabilities:
                           drop:

--- a/test/e2e/steps/steps.go
+++ b/test/e2e/steps/steps.go
@@ -52,9 +52,21 @@ import (
 const (
 	olmDeploymentName      = "operator-controller-controller-manager"
 	catalogdDeploymentName = "catalogd-controller-manager"
-	timeout                = 5 * time.Minute
+	defaultTimeout         = 5 * time.Minute
 	tick                   = 1 * time.Second
 )
+
+// timeout is the per-step wait timeout. It defaults to defaultTimeout (5m) but
+// can be overridden via E2E_STEP_TIMEOUT to accommodate runtimes (e.g.
+// BoxcutterRuntime) that take longer to complete an installation.
+var timeout = func() time.Duration {
+	if s := os.Getenv("E2E_STEP_TIMEOUT"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			return d
+		}
+	}
+	return defaultTimeout
+}()
 
 var (
 	olmNamespace        = "olmv1-system"
@@ -337,6 +349,7 @@ func substituteScenarioVars(content string, sc *scenarioContext) string {
 		"NAME":           sc.clusterExtensionName,
 		"COS_NAME":       sc.clusterObjectSetName,
 		"SCENARIO_ID":    sc.id,
+		"OLM_NAMESPACE":  olmNamespace,
 	}
 	for orig, param := range sc.catalogPackageNames {
 		vars[fmt.Sprintf("PACKAGE:%s", orig)] = param
@@ -1833,7 +1846,7 @@ func MarkDeploymentReadiness(ctx context.Context, deploymentName, state string) 
 	default:
 		return fmt.Errorf("invalid state %s", state)
 	}
-	_, err = k8sClient("exec", podName, "-n", sc.namespace, "--", op, "/var/www/ready")
+	_, err = k8sClient("exec", podName, "-n", sc.namespace, "--", op, "/tmp/www/ready")
 	return err
 }
 

--- a/test/internal/catalog/bundle.go
+++ b/test/internal/catalog/bundle.go
@@ -238,7 +238,7 @@ func buildBundle(scenarioID, packageName, version string, opts []BundleOption) (
 					Name: scriptCMName,
 				},
 				Data: map[string]string{
-					"httpd.sh": "#!/bin/sh\necho true > /var/www/started\necho true > /var/www/ready\necho true > /var/www/live\nexec httpd -f -h /var/www -p 80\n",
+					"httpd.sh": "#!/bin/sh\nmkdir -p /tmp/www\necho true > /tmp/www/started\necho true > /tmp/www/ready\necho true > /tmp/www/live\nexec httpd -f -h /tmp/www -p 8080\n",
 				},
 			}).
 			WithBundleResource("networkpolicy.yaml", &networkingv1.NetworkPolicy{
@@ -338,7 +338,7 @@ func buildDeploymentSpec(
 							Image:   containerImage,
 							Command: []string{"/scripts/httpd.sh"},
 							Ports: []corev1.ContainerPort{
-								{ContainerPort: 80},
+								{ContainerPort: 8080},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -351,7 +351,7 @@ func buildDeploymentSpec(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/started",
-										Port: intstr.FromInt32(80),
+										Port: intstr.FromInt32(8080),
 									},
 								},
 								FailureThreshold: 30,
@@ -361,7 +361,7 @@ func buildDeploymentSpec(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/live",
-										Port: intstr.FromInt32(80),
+										Port: intstr.FromInt32(8080),
 									},
 								},
 								FailureThreshold: 1,
@@ -371,7 +371,7 @@ func buildDeploymentSpec(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/ready",
-										Port: intstr.FromInt32(80),
+										Port: intstr.FromInt32(8080),
 									},
 								},
 								InitialDelaySeconds: 1,


### PR DESCRIPTION
The e2e test operator ran busybox httpd on port 80 writing to /var/www/, both of which require root. Restricted SCC enforces non-root UIDs from a namespace-assigned range, causing the pod to crash with Permission denied. Similarly, several feature files hardcoded runAsUser:1000 which falls outside the allowed UID range on some k8s implementations.

Changes:
- bundle.go: switch httpd from port 80+/var/www to port 8080+/tmp/www so the pod starts under any SCC without root privileges
- steps.go: match the /tmp/www path in the readiness exec probe; add OLM_NAMESPACE as a substitution variable; make per-step timeout configurable via E2E_STEP_TIMEOUT env var (default 5m unchanged)
- install.feature: replace hardcoded "olmv1-system" with ${OLM_NAMESPACE} so referred-secret lookups work when OLM is deployed in a different namespace
- revision.feature, recover.feature: remove runAsUser:1000 from pod/ container specs; keep runAsNonRoot:true

Fixes OPRUN-4607

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
