### PR TITLE
🌱 Remove upstream registry stubs (testdata/push and build-test-registry.sh)

### DIFF
--- a/testdata/build-test-registry.sh
+++ b/testdata/build-test-registry.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# No-op: test registry is now deployed dynamically by Go test code.
-# This stub exists for backward compatibility with downstream CI.
-exit 0

--- a/testdata/push/push.go
+++ b/testdata/push/push.go
@@ -1,5 +1,0 @@
-// No-op: test registry images are now built and pushed dynamically by Go test code.
-// This stub exists for backward compatibility with downstream CI.
-package main
-
-func main() {}


### PR DESCRIPTION
Remove `testdata/push/` and `testdata/build-test-registry.sh` — stubs that were only kept for downstream CI compatibility.

Now that the downstream `openshift/registry.Dockerfile` has been deleted (OPRUN-4608), these are no longer needed.

Fixes: https://issues.redhat.com/browse/OPRUN-4609