### PR TITLE
:bug: fix(catalogd): apply TLS profile to catalog server (port 8443)

### DIFF
--- a/cmd/catalogd/main.go
+++ b/cmd/catalogd/main.go
@@ -393,9 +393,10 @@ func run(ctx context.Context) error {
 		CertFile:     cfg.certFile,
 		KeyFile:      cfg.keyFile,
 		LocalStorage: localStorage,
+		TLSOpts:      []func(*tls.Config){tlsOpts, tlsProfile},
 	}
 
-	err = serverutil.AddCatalogServerToManager(mgr, catalogServerConfig, cw)
+	err = serverutil.AddCatalogServerToManager(mgr, catalogServerConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to configure catalog server")
 		return err

--- a/internal/catalogd/serverutil/serverutil.go
+++ b/internal/catalogd/serverutil/serverutil.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/klauspost/compress/gzhttp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	catalogdmetrics "github.com/operator-framework/operator-controller/internal/catalogd/metrics"
@@ -27,6 +26,10 @@ type CatalogServerConfig struct {
 	CertFile     string
 	KeyFile      string
 	LocalStorage storage.Instance
+	// TLSOpts are optional functions applied to the TLS configuration when serving over HTTPS.
+	// Use these to configure cipher suites, minimum TLS version, curve preferences, and
+	// certificate retrieval (e.g. via a certwatcher).
+	TLSOpts []func(*tls.Config)
 }
 
 // AddCatalogServerToManager adds the catalog HTTP server to the manager and registers
@@ -34,11 +37,10 @@ type CatalogServerConfig struct {
 // NeedLeaderElection returns false, Start() is called on every pod immediately, so all
 // replicas bind the catalog port and become ready.  Non-leader pods serve requests but
 // return 404 (empty local cache); callers are expected to retry.
-func AddCatalogServerToManager(mgr ctrl.Manager, cfg CatalogServerConfig, cw *certwatcher.CertWatcher) error {
+func AddCatalogServerToManager(mgr ctrl.Manager, cfg CatalogServerConfig) error {
 	shutdownTimeout := 30 * time.Second
 	r := &catalogServerRunnable{
 		cfg: cfg,
-		cw:  cw,
 		server: &http.Server{
 			Addr:         cfg.CatalogAddr,
 			Handler:      storageServerHandlerWrapped(mgr.GetLogger().WithName("catalogd-http-server"), cfg),
@@ -69,7 +71,6 @@ func AddCatalogServerToManager(mgr ctrl.Manager, cfg CatalogServerConfig, cw *ce
 // non-leader pods serve the catalog port but return 404 (empty local cache).
 type catalogServerRunnable struct {
 	cfg             CatalogServerConfig
-	cw              *certwatcher.CertWatcher
 	server          *http.Server
 	shutdownTimeout time.Duration
 	// ready is closed by Start() once the server is about to begin serving.
@@ -94,9 +95,14 @@ func (r *catalogServerRunnable) Start(ctx context.Context) error {
 	}
 
 	if r.cfg.CertFile != "" && r.cfg.KeyFile != "" {
-		config := &tls.Config{
-			GetCertificate: r.cw.GetCertificate,
-			MinVersion:     tls.VersionTLS12,
+		// All TLS settings (GetCertificate, MinVersion, CipherSuites, NextProtos, etc.)
+		// are applied exclusively via TLSOpts, keeping TLS policy out of serverutil.
+		config := &tls.Config{} //nolint:gosec
+		for _, opt := range r.cfg.TLSOpts {
+			opt(config)
+		}
+		if config.GetCertificate == nil && config.GetConfigForClient == nil && len(config.Certificates) == 0 {
+			return fmt.Errorf("catalog server TLS misconfiguration: TLSOpts must configure a certificate source")
 		}
 		listener = tls.NewListener(listener, config)
 	}

--- a/internal/catalogd/serverutil/serverutil_test.go
+++ b/internal/catalogd/serverutil/serverutil_test.go
@@ -3,12 +3,23 @@ package serverutil
 import (
 	"compress/gzip"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
 	"io/fs"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
@@ -125,4 +136,138 @@ func (m *mockStorageInstance) ContentExists(catalog string) bool {
 }
 func (m *mockStorageInstance) BaseURL(catalog string) string {
 	return ""
+}
+
+// writeTempCert generates a self-signed TLS certificate and writes the PEM-encoded
+// cert and key to temporary files. The files are cleaned up when the test ends.
+func writeTempCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"Test"}},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	privDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER})
+
+	cf, err := os.CreateTemp(t.TempDir(), "cert*.pem")
+	require.NoError(t, err)
+	_, err = cf.Write(certPEM)
+	require.NoError(t, err)
+	require.NoError(t, cf.Close())
+
+	kf, err := os.CreateTemp(t.TempDir(), "key*.pem")
+	require.NoError(t, err)
+	_, err = kf.Write(keyPEM)
+	require.NoError(t, err)
+	require.NoError(t, kf.Close())
+
+	return cf.Name(), kf.Name()
+}
+
+// TestCatalogServerTLSOptsApplied verifies that TLSOpts provided in CatalogServerConfig
+// are applied to the TLS configuration when the catalog server starts.
+func TestCatalogServerTLSOptsApplied(t *testing.T) {
+	certFile, keyFile := writeTempCert(t)
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	// Track whether our TLSOpt was called and record the resulting MinVersion.
+	// Configure a certificate source and MinVersion, mirroring the real tlsOpts+tlsProfile pattern.
+	var observedMinVersion uint16
+	tlsOpt := func(c *tls.Config) {
+		c.Certificates = []tls.Certificate{cert}
+		c.MinVersion = tls.VersionTLS13
+		observedMinVersion = c.MinVersion
+	}
+
+	mockStorage := &mockStorageInstance{}
+	cfg := CatalogServerConfig{
+		CatalogAddr:  "127.0.0.1:0",
+		CertFile:     certFile,
+		KeyFile:      keyFile,
+		LocalStorage: mockStorage,
+		TLSOpts:      []func(*tls.Config){tlsOpt},
+	}
+	r := &catalogServerRunnable{
+		cfg: cfg,
+		server: &http.Server{
+			Handler:      storageServerHandlerWrapped(logr.Logger{}, cfg),
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Minute,
+		},
+		shutdownTimeout: time.Second,
+		ready:           make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Start(ctx)
+	}()
+
+	select {
+	case <-r.ready:
+	case err := <-errCh:
+		t.Fatalf("server failed to start: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not start in time")
+	}
+
+	require.EqualValues(t, tls.VersionTLS13, observedMinVersion, "TLSOpts must be applied to the TLS config")
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not stop in time")
+	}
+}
+
+// TestCatalogServerTLSOptsCertSourceRequired verifies that the catalog server
+// returns an error if TLSOpts do not configure any certificate source.
+func TestCatalogServerTLSOptsCertSourceRequired(t *testing.T) {
+	certFile, keyFile := writeTempCert(t)
+
+	mockStorage := &mockStorageInstance{}
+	cfg := CatalogServerConfig{
+		CatalogAddr:  "127.0.0.1:0",
+		CertFile:     certFile,
+		KeyFile:      keyFile,
+		LocalStorage: mockStorage,
+		TLSOpts:      []func(*tls.Config){},
+	}
+	r := &catalogServerRunnable{
+		cfg: cfg,
+		server: &http.Server{
+			Handler:      storageServerHandlerWrapped(logr.Logger{}, cfg),
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Minute,
+		},
+		shutdownTimeout: time.Second,
+		ready:           make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.Start(ctx)
+	require.ErrorContains(t, err, "TLSOpts must configure a certificate source")
 }


### PR DESCRIPTION
fix(catalogd): apply TLS profile to catalog server (port 8443) The catalogd HTTP server (port 8443) hardcoded MinVersion: tls.VersionTLS12 and ignored cipher suite/curve configuration.

The TLS profile flags (--tls-profile, --tls-custom-ciphers, etc.) were already parsed and applied to the webhook and metrics servers, but the catalog server's CatalogServerConfig had no field to receive them, and the server did not disable HTTP/2 (unlike the webhook and metrics servers, which set NextProtos=["http/1.1"] to mitigate https://github.com/advisories/GHSA-qppj-fm5r-hxr3 and https://github.com/advisories/GHSA-4374-p667-p6c8).

Add a TLSOpts field to CatalogServerConfig and apply all TLS settings exclusively via those functions, keeping TLS policy out of serverutil entirely. This includes GetCertificate (previously hardcoded from the certwatcher), so the cw parameter is removed from AddCatalogServerToManager. Wire both the TLS profile function and the HTTP/2-disabling opts into the catalog server config in main — consistent with how the webhook and metrics servers are already configured.

Fixes: OCPBUGS-86797
Relates-to: OPRUN-4415

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
