### PR TITLE
:seedling: Remove camilamacedo86 from OWNERS files

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - ci-approvers
+  - olmv1-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,5 @@
 aliases:
    olmv1-approvers:
-   - camilamacedo86
    - grokspawn
    - joelanford
    - kevinrizza
@@ -11,7 +10,6 @@ aliases:
 
    olmv1-reviewers:
    - ankitathomas
-   - camilamacedo86
    - dtfranz
    - fgiudici
    - grokspawn
@@ -33,15 +31,8 @@ aliases:
    cmd-approvers:
    - grokspawn
 
-   manifest-approvers:
-   - camilamacedo86
-
-   ci-approvers:
-   - camilamacedo86
-
    docs-approvers:
    - michaelryanpeter
 
    docs-draft-approvers:
-   - camilamacedo86
    - grokspawn

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - manifest-approvers
+  - olmv1-approvers

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - ci-approvers
+  - olmv1-approvers

--- a/helm/OWNERS
+++ b/helm/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - manifest-approvers
+  - olmv1-approvers

--- a/manifests/OWNERS
+++ b/manifests/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - manifest-approvers
+  - olmv1-approvers

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - manifest-approvers
+  - olmv1-approvers


### PR DESCRIPTION
## Summary
- Remove `camilamacedo86` from `olmv1-approvers`, `olmv1-reviewers`, and `docs-draft-approvers` alias groups
- Delete `manifest-approvers` and `ci-approvers` alias groups (she was the sole member)
- Replace `manifest-approvers` and `ci-approvers` references in OWNERS files (`config/`, `helm/`, `manifests/`, `scripts/`, `.github/`, `hack/`) with `olmv1-approvers`

Confirmed with Camila that she is okay with this removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)