### PR TITLE
:seedling: Collect support-bundle diagnostics on e2e failure

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  SUPPORT_BUNDLE_VERSION: v0.129.1
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -47,12 +50,27 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install support-bundle
+        if: matrix.test.use-artifacts == true
+        run: |
+          curl -sL https://github.com/replicatedhq/troubleshoot/releases/download/${{ env.SUPPORT_BUNDLE_VERSION }}/support-bundle_linux_amd64.tar.gz | tar xz -C /usr/local/bin support-bundle
+          support-bundle version
+
       - name: Run e2e test
         run: |
           if [[ "${{ matrix.test.use-artifacts }}" == "true" ]]; then
             ARTIFACT_PATH=/tmp/artifacts E2E_SUMMARY_OUTPUT=$GITHUB_STEP_SUMMARY make ${{ matrix.test.make-target }}
           else
             make ${{ matrix.test.make-target }}
+          fi
+
+      - name: Collect support-bundle
+        if: failure() && matrix.test.use-artifacts == true
+        run: |
+          if kubectl cluster-info &>/dev/null; then
+            support-bundle --interactive=false -o /tmp/artifacts/support-bundle
+          else
+            echo "No cluster available, skipping support-bundle collection"
           fi
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,6 +68,7 @@ jobs:
         if: failure() && matrix.test.use-artifacts == true
         run: |
           if kubectl cluster-info &>/dev/null; then
+            mkdir -p /tmp/artifacts
             support-bundle --interactive=false -o /tmp/artifacts/support-bundle
           else
             echo "No cluster available, skipping support-bundle collection"


### PR DESCRIPTION
# Description

Collect cluster diagnostics using [troubleshoot.sh](https://troubleshoot.sh/) `support-bundle` CLI when e2e tests fail, so we have actionable data for debugging CI failures.

**Changes:**
- Add `SUPPORT_BUNDLE_VERSION` env var to the e2e workflow
- Install the `support-bundle` binary before tests run (for `use-artifacts: true` variants only)
- On failure, collect a support bundle if the kind cluster is still reachable
- The bundle is saved to `/tmp/artifacts/support-bundle.tar.gz` and uploaded via the existing `upload-artifact` step

The support bundle runs with default collectors (`clusterInfo` + `clusterResources`), which captures pods, deployments, events, nodes, CRDs, custom resources, and pod logs across all namespaces.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)