### PR TITLE
:bug: Fix support-bundle collection on e2e failure

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           if kubectl cluster-info &>/dev/null; then
             mkdir -p /tmp/artifacts
-            support-bundle --interactive=false -o /tmp/artifacts/support-bundle
+            support-bundle --interactive=false -o /tmp/artifacts/support-bundle test/e2e/support-bundle.yaml
           else
             echo "No cluster available, skipping support-bundle collection"
           fi

--- a/test/e2e/support-bundle.yaml
+++ b/test/e2e/support-bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: e2e-tests
+spec:
+  collectors:
+    - clusterResources: {}
+    - clusterInfo: {}
+    - logs: {}


### PR DESCRIPTION
## Summary
- Add `test/e2e/support-bundle.yaml` spec file with collectors for cluster diagnostics
- Pass the spec file to the `support-bundle` CLI in the e2e workflow

Fixes the `Error: no collectors specified to run` error introduced in #2750.

## Test plan
- [ ] Verify e2e workflow collects support-bundle artifacts on failure