### PR TITLE
:bug: Add network policy for prometheus-operator in e2e tests

### DIFF
--- a/helm/prometheus/templates/networkpolicy-prometheus-operator.yml
+++ b/helm/prometheus/templates/networkpolicy-prometheus-operator.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator
+  namespace: {{ .Values.namespaces.olmv1.name }}
+spec:
+  egress:
+    - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-operator
+  policyTypes:
+    - Egress


### PR DESCRIPTION
# Description

The `default-deny-all-traffic` NetworkPolicy in `olmv1-system` blocks all egress by default.
The prometheus-operator pod (`app.kubernetes.io/name: prometheus-operator`) had no matching
allow policy, causing API server connectivity timeouts (`dial tcp 10.96.0.1:443: i/o timeout`)
when scheduled on the second control-plane node in the 2-node kind cluster used by `experimental-e2e`.

The existing `networkpolicy-prometheus.yml` only covers the Prometheus server pod
(`app.kubernetes.io/name: prometheus`), not the operator.

This PR adds an egress-allowing NetworkPolicy for the prometheus-operator pod, matching
the existing pattern used for the Prometheus server pod.

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)