### PR TITLE
🐛 Use $(HELM) instead of bare helm in lint-helm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ lint: lint-custom $(GOLANGCI_LINT) #HELP Run golangci linter.
 
 .PHONY: lint-helm
 lint-helm: $(HELM) $(CONFTEST) #HELP Run helm linter
-	helm lint helm/olmv1
-	(set -euo pipefail; helm template olmv1 helm/olmv1) | $(CONFTEST) test --policy hack/conftest/policy/ --combine -n main -
+	$(HELM) lint helm/olmv1
+	(set -euo pipefail; $(HELM) template olmv1 helm/olmv1) | $(CONFTEST) test --policy hack/conftest/policy/ --combine -n main -
 
 .PHONY: lint-deployed-resources
 lint-deployed-resources: $(KUBE_SCORE) #EXHELP Lint deployed resources.


### PR DESCRIPTION
# Description

The `lint-helm` Makefile target depends on `$(HELM)` but invoked `helm` directly in its recipe. This could pick up an unpinned system Helm binary (or fail if Helm isn't on `PATH`), which is inconsistent with how other targets use `$(HELM)` (e.g., line 192).

This change replaces all bare `helm` invocations in the `lint-helm` recipe with `$(HELM)` to use the pinned version consistently.

Addresses [review comment](https://github.com/operator-framework/operator-controller/pull/2757/files#r3389897550) from #2757.

## Reviewer Checklist

- [x] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)