### PR TITLE
🐛 OCPBUGS-60963: fix crdUpgradeSafety reporting OneOf changes as unhandled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	pkg.package-operator.run/boxcutter v0.13.1
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
-	sigs.k8s.io/crdify v0.6.0
+	sigs.k8s.io/crdify v0.6.1-0.20260602124154-bb9957dbf465
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -811,8 +811,8 @@ sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/controller-tools v0.21.0 h1:KXDQza3bgjlPY6xLR63tI/40gzjhyUAvkCrwzd2/6cs=
 sigs.k8s.io/controller-tools v0.21.0/go.mod h1:DLIypi3Q2+azVAP8jr/mHXJgveYYHFjhnNOUuBJ10JE=
-sigs.k8s.io/crdify v0.6.0 h1:1id5uhODipmEvmMC8jlr7IbpHTnepySWmBNEiwv23WQ=
-sigs.k8s.io/crdify v0.6.0/go.mod h1:ZIFxaYNgKYmFtZCLPysncXQ8oqwnNlHQbRUfxJHZwzU=
+sigs.k8s.io/crdify v0.6.1-0.20260602124154-bb9957dbf465 h1:/i/qwIYxowBuOlNUY6d6E5PvNise/KlAqIOi78ma6g4=
+sigs.k8s.io/crdify v0.6.1-0.20260602124154-bb9957dbf465/go.mod h1:ZIFxaYNgKYmFtZCLPysncXQ8oqwnNlHQbRUfxJHZwzU=
 sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
 sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety_test.go
@@ -394,17 +394,14 @@ func TestUpgrade(t *testing.T) {
 				Manifest: getManifestString(t, "crd-complex-breaking-changes-new.json"),
 			},
 			// This test verifies detection of multiple breaking changes in a single CRD upgrade:
-			// 1. Type changed from "object" to "" - Properly detected by type validator
-			// 2. Nullable changed from false to true - Properly detected by nullable validator
-			// 3. OneOf constraint added - Reported as "unhandled" (needs crdify support)
-			//    See: https://github.com/kubernetes-sigs/crdify/issues/25
-			// The upgrade is correctly blocked, but OneOf changes need better categorization.
+			// 1. Type changed from "object" to "" - Detected by type validator
+			// 2. Nullable changed from false to true - Detected by nullable validator
+			// 3. OneOf constraint added - Detected by oneOf validator
 			requireErr: wantErrorMsgs([]string{
 				`validating upgrade for CRD "services.networking.example.com"`,
 				`type: type changed`,
 				`nullable: nullable added`,
-				`unhandled: unhandled changes found`,
-				`OneOf`,
+				`oneOf: oneOf constraint added`,
 			}),
 		},
 	}
@@ -423,6 +420,38 @@ func TestUpgrade(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpgrade_OneOfRemoved(t *testing.T) {
+	t.Run("removing oneOf subschemas should fail", func(t *testing.T) {
+		preflight := newMockPreflight(getCrdFromManifestFile(t, "crd-oneof-removed-old.json"), nil)
+		rel := &release.Release{
+			Name:     "test-release",
+			Manifest: getManifestString(t, "crd-oneof-removed-new.json"),
+		}
+		objs, err := applier.HelmReleaseToObjectsConverter{}.GetObjectsFromRelease(rel)
+		require.NoError(t, err)
+		err = preflight.Upgrade(context.Background(), objs)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "oneOf: allowed oneOf schemas removed")
+	})
+}
+
+func TestUpgrade_OneOfAdded(t *testing.T) {
+	t.Run("adding oneOf required constraints to existing property should report oneOf error", func(t *testing.T) {
+		preflight := newMockPreflight(getCrdFromManifestFile(t, "crd-oneof-safe-addition-old.json"), nil)
+		rel := &release.Release{
+			Name:     "test-release",
+			Manifest: getManifestString(t, "crd-oneof-safe-addition-new.json"),
+		}
+		objs, err := applier.HelmReleaseToObjectsConverter{}.GetObjectsFromRelease(rel)
+		require.NoError(t, err)
+		err = preflight.Upgrade(context.Background(), objs)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "oneOf: oneOf constraint added")
+		require.NotContains(t, err.Error(), "unhandled", "oneOf changes should be handled by the oneOf validator, not reported as unhandled")
+		require.NotContains(t, err.Error(), "type:", "type should not change when only oneOf constraints are added")
+	})
 }
 
 func TestUpgrade_UnhandledChanges_InSpec_DefaultPolicy(t *testing.T) {

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-removed-new.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-removed-new.json
@@ -1,0 +1,53 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "services.networking.example.com"
+    },
+    "spec": {
+        "group": "networking.example.com",
+        "versions": [
+            {
+                "name": "v1beta1",
+                "served": true,
+                "storage": true,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "tls": {
+                                        "type": "object",
+                                        "properties": {
+                                            "credentialName": {
+                                                "type": "string"
+                                            },
+                                            "httpsRedirect": {
+                                                "type": "boolean"
+                                            },
+                                            "mode": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Namespaced",
+        "names": {
+            "plural": "services",
+            "singular": "service",
+            "kind": "Service",
+            "shortNames": ["svc"]
+        }
+    },
+    "status": {
+        "storedVersions": ["v1beta1"]
+    }
+}

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-removed-old.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-removed-old.json
@@ -1,0 +1,61 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "services.networking.example.com"
+    },
+    "spec": {
+        "group": "networking.example.com",
+        "versions": [
+            {
+                "name": "v1beta1",
+                "served": true,
+                "storage": true,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "tls": {
+                                        "type": "object",
+                                        "oneOf": [
+                                            {
+                                                "required": ["mode", "credentialName"]
+                                            },
+                                            {
+                                                "required": ["httpsRedirect"]
+                                            }
+                                        ],
+                                        "properties": {
+                                            "credentialName": {
+                                                "type": "string"
+                                            },
+                                            "httpsRedirect": {
+                                                "type": "boolean"
+                                            },
+                                            "mode": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Namespaced",
+        "names": {
+            "plural": "services",
+            "singular": "service",
+            "kind": "Service",
+            "shortNames": ["svc"]
+        }
+    },
+    "status": {
+        "storedVersions": ["v1beta1"]
+    }
+}

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-safe-addition-new.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-safe-addition-new.json
@@ -1,0 +1,61 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "services.networking.example.com"
+    },
+    "spec": {
+        "group": "networking.example.com",
+        "versions": [
+            {
+                "name": "v1",
+                "served": true,
+                "storage": true,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "tls": {
+                                        "type": "object",
+                                        "oneOf": [
+                                            {
+                                                "required": ["mode", "credentialName"]
+                                            },
+                                            {
+                                                "required": ["httpsRedirect"]
+                                            }
+                                        ],
+                                        "properties": {
+                                            "credentialName": {
+                                                "type": "string"
+                                            },
+                                            "httpsRedirect": {
+                                                "type": "boolean"
+                                            },
+                                            "mode": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Namespaced",
+        "names": {
+            "plural": "services",
+            "singular": "service",
+            "kind": "Service",
+            "shortNames": ["svc"]
+        }
+    },
+    "status": {
+        "storedVersions": ["v1"]
+    }
+}

--- a/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-safe-addition-old.json
+++ b/internal/operator-controller/rukpak/preflights/crdupgradesafety/testdata/manifests/crd-oneof-safe-addition-old.json
@@ -1,0 +1,53 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "name": "services.networking.example.com"
+    },
+    "spec": {
+        "group": "networking.example.com",
+        "versions": [
+            {
+                "name": "v1",
+                "served": true,
+                "storage": true,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "tls": {
+                                        "type": "object",
+                                        "properties": {
+                                            "credentialName": {
+                                                "type": "string"
+                                            },
+                                            "httpsRedirect": {
+                                                "type": "boolean"
+                                            },
+                                            "mode": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "scope": "Namespaced",
+        "names": {
+            "plural": "services",
+            "singular": "service",
+            "kind": "Service",
+            "shortNames": ["svc"]
+        }
+    },
+    "status": {
+        "storedVersions": ["v1"]
+    }
+}


### PR DESCRIPTION
# Description

CRD upgrade safety checks reported OneOf schema changes as generic
"unhandled changes found" errors, blocking legitimate operator upgrades
(e.g. Serverless Operator 1.35.0 → 1.36.0).

Fixed by updating `sigs.k8s.io/crdify` to the latest master (bb9957dbf465)
which includes a dedicated `oneOf` validator
([kubernetes-sigs/crdify#54](https://github.com/kubernetes-sigs/crdify/pull/54))
that properly categorizes OneOf changes (constraint added, removed, subschemas modified).

## Changes
- Pin `sigs.k8s.io/crdify` to latest master (v0.6.1-0.20260602124154-bb9957dbf465)
- Update existing test expectation from `unhandled` to `oneOf` error
- Add new unit tests for OneOf removal and OneOf addition scenarios

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)