### PR TITLE
:bug: Fix api-lint-diff to work from a git worktree

### DIFF
--- a/hack/api-lint-diff/run.sh
+++ b/hack/api-lint-diff/run.sh
@@ -30,8 +30,9 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Ensure we're in the repository root
-if [[ ! -d ".git" ]]; then
+# Ensure we're in the repository root (.git is a directory in a regular
+# checkout but a file in a worktree, so test existence rather than type)
+if [[ ! -e ".git" ]]; then
     echo -e "${RED}Error: Must be run from repository root${NC}"
     exit 1
 fi


### PR DESCRIPTION
# Description

`hack/api-lint-diff/run.sh` checks for the repository root by testing
`-d ".git"`. In a git worktree `.git` is a **file** (containing a
`gitdir:` pointer), not a directory, so the check always fails with
*"Must be run from repository root"*.

This switches the test from `-d` (directory) to `-e` (exists) so it
works in both regular checkouts and worktrees.

## Reviewer Checklist

- [x] API Go Documentation — N/A (no API changes)
- [x] Tests: Unit Tests (and E2E Tests, if appropriate) — manually verified in a worktree and in a non-git directory
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)