### PR TITLE
:seedling: Apply cluster TLS profile to outgoing HTTP client

### DIFF
--- a/internal/shared/util/http/httputil.go
+++ b/internal/shared/util/http/httputil.go
@@ -2,8 +2,11 @@ package http
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/operator-framework/operator-controller/internal/shared/util/tlsprofiles"
 )
 
 func BuildHTTPClient(cpw *CertPoolWatcher) (*http.Client, error) {
@@ -18,6 +21,11 @@ func BuildHTTPClient(cpw *CertPoolWatcher) (*http.Client, error) {
 		RootCAs:    pool,
 		MinVersion: tls.VersionTLS12,
 	}
+	tlsProfile, err := tlsprofiles.GetTLSConfigFunc()
+	if err != nil {
+		return nil, fmt.Errorf("getting TLS config func: %w", err)
+	}
+	tlsProfile(tlsConfig)
 	httpClient.Transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
 		// Proxy must be set explicitly; a nil Proxy field means "no proxy" and

--- a/internal/shared/util/http/httputil_test.go
+++ b/internal/shared/util/http/httputil_test.go
@@ -2,6 +2,7 @@ package http_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/pem"
 	"io"
 	"net"
@@ -14,10 +15,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	httputil "github.com/operator-framework/operator-controller/internal/shared/util/http"
+	"github.com/operator-framework/operator-controller/internal/shared/util/tlsprofiles"
 )
 
 // startRecordingProxy starts a plain-HTTP CONNECT proxy that tunnels HTTPS
@@ -167,6 +170,34 @@ func TestBuildHTTPClientProxyTunnelsConnections(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("HTTPS connection to target server did not go through the proxy")
 	}
+}
+
+// TestBuildHTTPClientAppliesTLSProfile verifies that BuildHTTPClient applies
+// the configured TLS profile to the transport's TLSClientConfig. When the
+// "modern" profile is active the minimum TLS version must be 1.3.
+func TestBuildHTTPClientAppliesTLSProfile(t *testing.T) {
+	// Switch to the "modern" profile for this test and restore afterward.
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	tlsprofiles.AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{"--tls-profile=modern"}))
+	t.Cleanup(func() {
+		resetFS := pflag.NewFlagSet("reset", pflag.ContinueOnError)
+		tlsprofiles.AddFlags(resetFS)
+		require.NoError(t, resetFS.Parse([]string{"--tls-profile=intermediate"}))
+	})
+
+	cpw, err := httputil.NewCertPoolWatcher("", log.FromContext(context.Background()))
+	require.NoError(t, err)
+	t.Cleanup(cpw.Done)
+	require.NoError(t, cpw.Start(context.Background()))
+
+	client, err := httputil.BuildHTTPClient(cpw)
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion,
+		"modern TLS profile must set MinVersion to TLS 1.3")
 }
 
 // TestBuildHTTPClientProxyBlocksWhenRejected verifies that when the proxy


### PR DESCRIPTION
Use the configured TLS profile (set via --tls-profile flags) for the catalogd HTTP client, consistent with how the metrics server TLS is configured. Falls back to TLS 1.2 minimum when no profile is set.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
