### PR TITLE
:bug: fix catalogd panic, paste error on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ extension-developer-e2e: $(OPERATOR_SDK) #EXHELP Run extension create, upgrade a
 	go test -count=1 -v ./test/extension-developer-e2e/...
 
 UNIT_TEST_DIRS := $(shell go list ./... | grep -vE "/test/|/testutils|/testutil/mock") $(shell go list ./test/internal/...)
-COVERAGE_PKGS := $(shell go list ./... | grep -vE "/test/|/testutils|/testutil/mock" | paste -sd,)
+COVERAGE_PKGS := $(shell go list ./... | grep -vE "/test/|/testutils|/testutil/mock" | paste -sd, -)
 COVERAGE_UNIT_DIR := $(ROOT_DIR)/coverage/unit
 
 .PHONY: envtest-k8s-bins #HELP Uses setup-envtest to download and install the binaries required to run ENVTEST-test based locally at the project/bin directory.
@@ -544,7 +544,6 @@ go-build-local: $(BINARIES)
 build-linux: build-deps go-build-linux #EXHELP Build manager binary for GOOS=linux and local GOARCH.
 go-build-linux: BUILDBIN := bin/linux
 go-build-linux: export GOOS=linux
-go-build-linux: export GOARCH=amd64
 go-build-linux: $(BINARIES)
 
 .PHONY: run-internal


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description
This PR fixes two issues, from least- to most-important: 
1. differing syntax for `paste` tool in linux, mac contexts.  `paste` on BSD requires an explicit indication of STDIN, whereas linux assumes STDIN if no file is specified.  POSIX behavior is to specify `-` if STDIN is indicated, which works for both platforms. 
2. `make run` and variants use the "linux" build targets, which claim in docs to use native GOARCH but actually hardcode it to amd64.  On Apple silicon the cross-compile now results in panics running these cross-compiled binaries using Rosetta (and Apple has stated it is sunsetting support for amd64 binaries on arm64 hardware, so it needs resolving anyway).  The GOARCH hardcoding was introduced during the change to helm templating (from kustomize) but appears to have been unnecessary.  

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
