### PR TITLE
:seedling: Remove asciinema upload from update-demos target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -627,11 +627,11 @@ deploy-docs: venv
 
 # The demo script requires to install asciinema with: brew install asciinema to run on mac os envs.
 # Please ensure that all demos are named with the demo name and the suffix -demo-script.sh
-.PHONY: update-demos #EXHELP Update and upload the demos.
+.PHONY: update-demos #EXHELP Validate demo recordings.
 update-demos:
 	@for script in hack/demo/*-demo-script.sh; do \
 	  nm=$$(basename $$script -script.sh); \
-	  ./hack/demo/generate-asciidemo.sh -u -n $$nm $$(basename $$script); \
+	  ./hack/demo/generate-asciidemo.sh -n $$nm $$(basename $$script); \
 	done
 
 include Makefile.venv


### PR DESCRIPTION
## Summary
- Remove the `-u` (upload) flag from `make update-demos` so demo recordings are generated without uploading to asciinema.org
- Update the target's help text to reflect that it no longer uploads

## Why
asciinema.org has been unreachable from GitHub Actions runners (hosted on Azure) since ~June 16, 2026, causing the daily `demo` CI job to fail consistently. See [asciinema/asciinema-server#479](https://github.com/asciinema/asciinema-server/issues/479).

The upload was never essential to the CI job — the purpose is to validate that demo recordings can be generated successfully. According to the issue, the public asciinema server was not meant for CI. "Host your own" was the given alternative.

## Test plan
- [ ] Verify `make update-demos` runs successfully without the `-u` flag
- [ ] Confirm the `demo` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)