### PR TITLE
:bug: OCPBUGS-92037: increase catalog HTTP client timeout from 10s to 5m

### DIFF
--- a/internal/operator-controller/catalogmetadata/client/httputil.go
+++ b/internal/operator-controller/catalogmetadata/client/httputil.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BuildHTTPClient(cpw *httputil.CertPoolWatcher) (*http.Client, error) {
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
 
 	pool, _, err := cpw.Get()
 	if err != nil {


### PR DESCRIPTION
# Description

The 10-second HTTP client timeout was too aggressive for large catalog responses,
causing timeouts when fetching catalogs. Increase it to 5 minutes.

See https://redhat.atlassian.net/browse/OCPBUGS-92037 for details of the bug.

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)