### PR TITLE
:seedling: Align ClusterObjectSet e2e cleanup with addedResources pattern

### DIFF
--- a/test/e2e/steps/hooks.go
+++ b/test/e2e/steps/hooks.go
@@ -268,9 +268,6 @@ func ScenarioCleanup(ctx context.Context, _ *godog.Scenario, err error) (context
 	}
 
 	forDeletion := sc.addedResources
-	if sc.clusterObjectSetName != "" && featureGates[features.BoxcutterRuntime] {
-		forDeletion = append(forDeletion, resource{name: sc.clusterObjectSetName, kind: "clusterobjectset"})
-	}
 	for _, catalogName := range sc.catalogs {
 		forDeletion = append(forDeletion, resource{name: catalogName, kind: "clustercatalog"})
 	}

--- a/test/e2e/steps/steps.go
+++ b/test/e2e/steps/steps.go
@@ -475,7 +475,8 @@ func ResourceIsApplied(ctx context.Context, yamlTemplate *godog.DocString) error
 	if res.GetKind() == "ClusterExtension" {
 		sc.addedResources = append(sc.addedResources, resource{name: res.GetName(), kind: "clusterextension"})
 	} else if res.GetKind() == "ClusterObjectSet" {
-		sc.clusterObjectSetName = res.GetName()
+		sc.clusterObjectSetName = res.GetName() // used for ${COS_NAME} variable substitution in YAML templates
+		sc.addedResources = append(sc.addedResources, resource{name: res.GetName(), kind: "clusterobjectset"})
 	} else {
 		namespace := res.GetNamespace()
 		if namespace == "" {


### PR DESCRIPTION
## Summary
- Follow-up to #2783 — applies the same `addedResources`-based cleanup pattern to ClusterObjectSets in the e2e test harness
- `ResourceIsApplied` now appends ClusterObjectSets to `addedResources` (alongside setting `clusterObjectSetName` for `${COS_NAME}` substitution)
- Removes the special-case `clusterObjectSetName` cleanup block from `ScenarioCleanup`, so multiple ClusterObjectSets per scenario are all cleaned up correctly

## Test plan
- [ ] Verify e2e tests compile (`go build ./test/e2e/...`)
- [ ] Run BoxcutterRuntime e2e scenarios that create ClusterObjectSets and confirm cleanup succeeds
- [ ] Verify no leaked ClusterObjectSets remain after scenario completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)