### PR TITLE
🐛 fix: missing olm.operatorNamespace annotation

### DIFF
--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators.go
@@ -59,6 +59,7 @@ var certVolumeConfigs = []certVolumeConfig{
 // BundleCSVDeploymentGenerator generates all deployments defined in rv1's cluster service version (CSV). The generated
 // resource aim to have parity with OLMv0 generated Deployment resources:
 // - olm.targetNamespaces annotation is set with the opts.TargetNamespace value
+// - olm.operatorNamespace annotation is set with the opts.InstallNamespace value
 // - the deployment spec's revision history limit is set to 1
 // - merges csv annotations to the deployment template's annotations
 func BundleCSVDeploymentGenerator(rv1 *bundle.RegistryV1, opts render.Options) ([]client.Object, error) {
@@ -78,10 +79,13 @@ func BundleCSVDeploymentGenerator(rv1 *bundle.RegistryV1, opts render.Options) (
 		// See https://github.com/operator-framework/operator-lifecycle-manager/blob/dfd0b2bea85038d3c0d65348bc812d297f16b8d2/pkg/controller/install/deployment.go#L142
 		annotations := util.MergeMaps(rv1.CSV.Annotations, depSpec.Spec.Template.Annotations)
 
-		// In OLMv0 CSVs are annotated with the OperatorGroup's .spec.targetNamespaces
+		// In OLMv0, CSVs are annotated with OperatorGroup information:
+		// - olm.targetNamespaces: the OperatorGroup's .spec.targetNamespaces
+		// - olm.operatorNamespace: the namespace where the OperatorGroup is defined (operator's install namespace)
 		// See https://github.com/operator-framework/operator-lifecycle-manager/blob/dfd0b2bea85038d3c0d65348bc812d297f16b8d2/pkg/controller/operators/olm/operatorgroup.go#L279
-		// When the CSVs annotations are copied to the deployment template's annotations, they bring with it this annotation
+		// When the CSVs annotations are copied to the deployment template's annotations, they bring with it these annotations
 		annotations["olm.targetNamespaces"] = strings.Join(opts.TargetNamespaces, ",")
+		annotations["olm.operatorNamespace"] = opts.InstallNamespace
 		depSpec.Spec.Template.Annotations = annotations
 
 		// Hardcode the deployment with RevisionHistoryLimit=1 to maintain parity with OLMv0 behaviour.

--- a/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
+++ b/internal/operator-controller/rukpak/render/registryv1/generators/generators_test.go
@@ -123,9 +123,10 @@ func Test_BundleCSVDeploymentGenerator_Succeeds(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
-									"csv":                  "annotation",
-									"olm.targetNamespaces": "watch-namespace-one,watch-namespace-two",
-									"pod":                  "annotation",
+									"csv":                   "annotation",
+									"olm.targetNamespaces":  "watch-namespace-one,watch-namespace-two",
+									"olm.operatorNamespace": "install-namespace",
+									"pod":                   "annotation",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -148,8 +149,9 @@ func Test_BundleCSVDeploymentGenerator_Succeeds(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
-									"csv":                  "annotation",
-									"olm.targetNamespaces": "watch-namespace-one,watch-namespace-two",
+									"csv":                   "annotation",
+									"olm.targetNamespaces":  "watch-namespace-one,watch-namespace-two",
+									"olm.operatorNamespace": "install-namespace",
 								},
 							},
 						},

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/all-namespaces/11_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/all-namespaces/11_deployment_argocd-operator-controller-manager.yaml
@@ -144,6 +144,7 @@ spec:
         containerImage: quay.io/argoprojlabs/argocd-operator@sha256:99aeec24cc406d06d18822347d9ac3ed053a702d8419191e4e681075fed7b9bb
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: ""
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/own-namespace/09_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/own-namespace/09_deployment_argocd-operator-controller-manager.yaml
@@ -144,6 +144,7 @@ spec:
         containerImage: quay.io/argoprojlabs/argocd-operator@sha256:99aeec24cc406d06d18822347d9ac3ed053a702d8419191e4e681075fed7b9bb
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: argocd-system
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/single-namespace/09_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/single-namespace/09_deployment_argocd-operator-controller-manager.yaml
@@ -144,6 +144,7 @@ spec:
         containerImage: quay.io/argoprojlabs/argocd-operator@sha256:99aeec24cc406d06d18822347d9ac3ed053a702d8419191e4e681075fed7b9bb
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: argocd-watch
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-deploymentconfig-options/11_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-deploymentconfig-options/11_deployment_argocd-operator-controller-manager.yaml
@@ -148,6 +148,7 @@ spec:
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
         foo: bar
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: ""
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-empty-affinity-subtype/11_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-empty-affinity-subtype/11_deployment_argocd-operator-controller-manager.yaml
@@ -144,6 +144,7 @@ spec:
         containerImage: quay.io/argoprojlabs/argocd-operator@sha256:99aeec24cc406d06d18822347d9ac3ed053a702d8419191e4e681075fed7b9bb
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: ""
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-empty-affinity/11_deployment_argocd-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/argocd-operator.v0.6.0/with-empty-affinity/11_deployment_argocd-operator-controller-manager.yaml
@@ -144,6 +144,7 @@ spec:
         containerImage: quay.io/argoprojlabs/argocd-operator@sha256:99aeec24cc406d06d18822347d9ac3ed053a702d8419191e4e681075fed7b9bb
         description: Argo CD is a declarative, GitOps continuous delivery tool for
           Kubernetes.
+        olm.operatorNamespace: argocd-system
         olm.targetNamespaces: ""
         operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/05_deployment_webhook-operator-controller-manager.yaml
+++ b/test/regression/convert/testdata/expected-manifests/webhook-operator.v0.0.5/all-webhook-types/05_deployment_webhook-operator-controller-manager.yaml
@@ -47,6 +47,7 @@ spec:
           ]
         capabilities: Basic Install
         kubectl.kubernetes.io/default-container: manager
+        olm.operatorNamespace: webhook-system
         olm.targetNamespaces: ""
         operators.operatorframework.io/builder: operator-sdk-v1.41.1
         operators.operatorframework.io/project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

# Description

<!--
Thank you for your contribution!

Please provide a summary of the changes and the motivation behind the change.
-->

OLMv0 sets the `olm.*` annotations from OperatorGroup on the `spec.template.metadata.annotation` section of the operator `Deployment`. To maintain interoperability OLM v1 does do the same for `olm.targetNamespaces` annotation - but does NOT do it for `olm.operatorNamespace`. There are opeators that rely on this (see linked issue)

Fixes: #2802

## Reviewer Checklist

- [x] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [x] Links to related GitHub Issue(s)
