### PR TITLE
🐛 fix: use static permissions in update-demos workflow

### DIFF
--- a/.github/workflows/update-demos.yaml
+++ b/.github/workflows/update-demos.yaml
@@ -24,7 +24,7 @@ jobs:
   generate-demos:
     runs-on: ubuntu-latest
     permissions:
-      contents: ${{ github.event_name == 'push' && 'write' || 'read' }}
+      contents: write
     env:
       TERM: linux
     steps:


### PR DESCRIPTION
# Description

GitHub Actions does not support expressions in the `permissions` block.
The dynamic expression introduced in #2801 was causing every `update-demos`
workflow run to fail with "workflow file issue" before any job could start.

This changes `contents: ${{ github.event_name == 'push' && 'write' || 'read' }}`
to static `contents: write` (matching the `pages.yaml` convention). The deploy
step is already gated by `if: github.event_name == 'push'`, so the write
permission on PR runs is unused.

**Failed runs:**
- https://github.com/operator-framework/operator-controller/actions/runs/28660077765
- https://github.com/operator-framework/operator-controller/actions/runs/28776270763

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)