### PR TITLE
🐛 Fix cache path to avoid /var/cache/dnf conflict

### DIFF
--- a/cmd/catalogd/main.go
+++ b/cmd/catalogd/main.go
@@ -129,7 +129,7 @@ func init() {
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "The namespace catalogd uses for internal state")
 	flags.StringVar(&cfg.catalogServerAddr, "catalogs-server-addr", ":8443", "The address where catalogs' content will be accessible")
 	flags.StringVar(&cfg.externalAddr, "external-address", "catalogd-service.olmv1-system.svc", "External address for http(s) server")
-	flags.StringVar(&cfg.cacheDir, "cache-dir", "/var/cache/", "Directory for file based caching")
+	flags.StringVar(&cfg.cacheDir, "cache-dir", "/var/cache/catalogd", "Directory for file based caching")
 	flags.DurationVar(&cfg.gcInterval, "gc-interval", 12*time.Hour, "Garbage collection interval")
 	flags.StringVar(&cfg.certFile, "tls-cert", "", "Certificate file for TLS")
 	flags.StringVar(&cfg.keyFile, "tls-key", "", "Key file for TLS")

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -181,7 +181,7 @@ func init() {
 	flags.BoolVar(&cfg.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache", "The local directory path used for filesystem based caching")
+	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache/operator-controller", "The local directory path used for filesystem based caching")
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "Configures the namespace that gets used to deploy system resources.")
 	flags.StringVar(&cfg.globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 


### PR DESCRIPTION
## Problem

On RHEL-based container images, operator-controller and catalogd pods crash on startup with:
```
chmod /var/cache/dnf: operation not permitted
```

This happens because:
1. Default cache path is `/var/cache` (operator-controller) or `/var/cache/` (catalogd)
2. RHEL base images contain `/var/cache/dnf` owned by root
3. Pods run as non-root (UID 1001)
4. `EnsureEmptyDirectory()` tries to chmod root-owned directories, which fails

## Solution

Change default cache paths to component-specific subdirectories to avoid conflicts with system directories:
- **operator-controller**: `/var/cache` → `/var/cache/operator-controller`
- **catalogd**: `/var/cache/` → `/var/cache/catalogd`

## Changes

### cmd/operator-controller/main.go
- Line 184: Update `--cache-path` default from `/var/cache` to `/var/cache/operator-controller`

### cmd/catalogd/main.go  
- Line 132: Update `--cache-dir` default from `/var/cache/` to `/var/cache/catalogd`

Both changes follow the same pattern: use a component-specific subdirectory under `/var/cache/` to avoid conflicts with system directories like `/var/cache/dnf`.

## Testing

- Build and deploy with new defaults
- Verify both operator-controller and catalogd pods start successfully on RHEL-based images
- Verify cache operations work correctly for both components
- Confirm no conflicts with existing system directories in `/var/cache/`

Related: OCPBUGS-89330