### PR TITLE
:bug: Fix flaky generate-demos CI job

### DIFF
--- a/test/e2e/steps/demo_steps.go
+++ b/test/e2e/steps/demo_steps.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -41,6 +42,10 @@ func bash(ctx context.Context, script string) (string, error) {
 
 	if err != nil {
 		logger.V(1).Info("Failed to run", "command", script, "stderr", stderr, "error", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitErr.Stderr = stderrBuf.Bytes()
+		}
 	}
 	logger.V(1).Info("Output", "command", script, "output", stdout)
 
@@ -81,32 +86,81 @@ func CatalogReportsConditionWithoutReason(ctx context.Context, catalogUserName, 
 func ensureCatalogPortForward(ctx context.Context) (string, error) {
 	sc := scenarioCtx(ctx)
 	if sc.catalogAddr != "" {
-		return sc.catalogAddr, nil
+		if catalogPortForwardAlive(sc.catalogAddr) {
+			return sc.catalogAddr, nil
+		}
+		logger.V(1).Info("Catalog port-forward is dead, re-establishing", "addr", sc.catalogAddr)
+		resetCatalogPortForward(ctx)
 	}
 
-	addr, cleanup, err := portForward(ctx, componentNamespaces["catalogd"], "service/catalogd-service", 443)
+	ns := componentNamespaces["catalogd"]
+	target, err := catalogdLeaderPod(ctx, ns)
+	port := int32(443)
 	if err != nil {
-		return "", fmt.Errorf("failed to start catalog port-forward: %w", err)
+		logger.V(1).Info("Could not resolve catalogd leader pod, falling back to service", "error", err)
+		target = "service/catalogd-service"
+	} else {
+		port = 8443
+	}
+
+	addr, cleanup, err := portForward(ctx, ns, target, port)
+	if err != nil {
+		return "", fmt.Errorf("failed to start catalog port-forward to %s: %w", target, err)
 	}
 	sc.catalogAddr = addr
 	sc.catalogCleanup = cleanup
 
 	waitFor(ctx, func() bool {
-		client := &http.Client{
-			Timeout: 3 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-				DialContext:     (&net.Dialer{Timeout: 2 * time.Second}).DialContext,
-			},
-		}
-		resp, err := client.Get(fmt.Sprintf("https://%s/", addr))
-		if err != nil {
-			return false
-		}
-		resp.Body.Close()
-		return true
+		return catalogPortForwardAlive(addr)
 	})
 	return addr, nil
+}
+
+func catalogdLeaderPod(ctx context.Context, ns string) (string, error) {
+	holder, err := k8sClient(ctx, "get", "lease", "catalogd-operator-lock", "-n", ns,
+		"-o", "jsonpath={.spec.holderIdentity}")
+	if err != nil {
+		return "", fmt.Errorf("failed to get catalogd leader lease: %w", err)
+	}
+	holder = strings.TrimSpace(holder)
+	podName := holder
+	if idx := strings.LastIndex(holder, "_"); idx >= 0 {
+		podName = holder[:idx]
+	}
+	if podName == "" {
+		return "", fmt.Errorf("catalogd leader lease has empty holderIdentity")
+	}
+	logger.Info("Resolved catalogd leader pod", "holder", holder, "pod", podName)
+	return fmt.Sprintf("pod/%s", podName), nil
+}
+
+func catalogPortForwardAlive(addr string) bool {
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			DialContext:     (&net.Dialer{Timeout: 2 * time.Second}).DialContext,
+		},
+	}
+	resp, err := client.Get(fmt.Sprintf("https://%s/", addr))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return true
+}
+
+// resetCatalogPortForward tears down the cached port-forward so the next
+// call to ensureCatalogPortForward establishes a fresh connection.  With
+// CatalogdHA, non-leader pods return 404 (empty local cache); resetting
+// lets the next retry potentially reach the leader pod.
+func resetCatalogPortForward(ctx context.Context) {
+	sc := scenarioCtx(ctx)
+	if sc.catalogCleanup != nil {
+		sc.catalogCleanup()
+	}
+	sc.catalogAddr = ""
+	sc.catalogCleanup = nil
 }
 
 func catalogCurlJq(ctx context.Context, catalogName, jqFilter string) (string, error) {
@@ -114,46 +168,69 @@ func catalogCurlJq(ctx context.Context, catalogName, jqFilter string) (string, e
 	if err != nil {
 		return "", err
 	}
+	// pipefail: propagate curl exit code through the pipe (e.g. HTTP 404 from a non-leader catalogd pod).
+	// -sS: silent but show errors on stderr.  -k: skip TLS verification for the port-forward.
+	// --compressed: request gzip and stream-decompress (catalogd uses gzhttp); saves network for the large operatorhubio catalog.
+	// --fail: exit 22 on HTTP errors so non-JSON error bodies don't reach jq.
 	script := fmt.Sprintf(
-		`curl -s -k https://%s/catalogs/%s/api/v1/all | jq -s '%s'`,
+		`set -o pipefail; curl -sS -k --compressed --fail https://%s/catalogs/%s/api/v1/all | jq '%s'`,
 		addr, catalogName, jqFilter,
 	)
-	return bash(ctx, script)
+	out, err := bash(ctx, script)
+	if err != nil {
+		resetCatalogPortForward(ctx)
+	}
+	return out, err
 }
 
 func CatalogContainsSomePackages(ctx context.Context, catalogName string) error {
-	out, err := catalogCurlJq(ctx, catalogName,
-		`.[] | select(.schema == "olm.package") | .name`)
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(out) == "" {
-		return fmt.Errorf("catalog %q contains no packages", catalogName)
-	}
+	waitFor(ctx, func() bool {
+		out, err := catalogCurlJq(ctx, catalogName,
+			`objects | select(.schema == "olm.package") | .name`)
+		if err != nil {
+			logger.Info("Catalog query failed, retrying", "catalog", catalogName, "error", err, "stderr", stderrOutput(err))
+			return false
+		}
+		if strings.TrimSpace(out) == "" {
+			logger.Info("Catalog returned no packages, retrying", "catalog", catalogName)
+			return false
+		}
+		return true
+	})
 	return nil
 }
 
 func PackageHasSomeChannels(ctx context.Context, packageName, catalogName string) error {
-	out, err := catalogCurlJq(ctx, catalogName,
-		fmt.Sprintf(`.[] | select(.schema == "olm.channel") | select(.package == "%s") | .name`, packageName))
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(out) == "" {
-		return fmt.Errorf("package %q in catalog %q has no channels", packageName, catalogName)
-	}
+	waitFor(ctx, func() bool {
+		out, err := catalogCurlJq(ctx, catalogName,
+			fmt.Sprintf(`objects | select(.schema == "olm.channel") | select(.package == "%s") | .name`, packageName))
+		if err != nil {
+			logger.Info("Catalog query failed, retrying", "catalog", catalogName, "package", packageName, "error", err, "stderr", stderrOutput(err))
+			return false
+		}
+		if strings.TrimSpace(out) == "" {
+			logger.Info("Package has no channels, retrying", "catalog", catalogName, "package", packageName)
+			return false
+		}
+		return true
+	})
 	return nil
 }
 
 func PackageHasSomeBundles(ctx context.Context, packageName, catalogName string) error {
-	out, err := catalogCurlJq(ctx, catalogName,
-		fmt.Sprintf(`.[] | select(.schema == "olm.bundle") | select(.package == "%s") | .name`, packageName))
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(out) == "" {
-		return fmt.Errorf("package %q in catalog %q has no bundles", packageName, catalogName)
-	}
+	waitFor(ctx, func() bool {
+		out, err := catalogCurlJq(ctx, catalogName,
+			fmt.Sprintf(`objects | select(.schema == "olm.bundle") | select(.package == "%s") | .name`, packageName))
+		if err != nil {
+			logger.Info("Catalog query failed, retrying", "catalog", catalogName, "package", packageName, "error", err, "stderr", stderrOutput(err))
+			return false
+		}
+		if strings.TrimSpace(out) == "" {
+			logger.Info("Package has no bundles, retrying", "catalog", catalogName, "package", packageName)
+			return false
+		}
+		return true
+	})
 	return nil
 }
 


### PR DESCRIPTION
# Description

The `generate-demos` CI job fails ~45% of the time (9 of last 20 runs) with `jq` exit status 5 on the `ClusterCatalog Quickstart` scenario. The failure is always at the `catalog "operatorhubio" contains some packages` step.

Several issues contribute to the flakiness:

1. **`jq -s` (slurp mode) buffers the entire operatorhubio FBC response in memory** before processing, risking system errors (exit code 5) on the large operatorhubio catalog
2. **Catalog content queries run exactly once with no retry**, so any transient port-forward drop or network hiccup fails the step immediately
3. **`bash()` does not attach stderr to `ExitError`**, making failures opaque in CI logs
4. **With CatalogdHA, `kubectl port-forward` to the service deterministically picks the same pod** via `GetFirstPod` sorting; if that pod is not the leader, it returns 404 (empty local cache) for every retry — non-leader pods serve HTTP but only the leader reconciler downloads catalog content

This PR:
- Removes `jq -s` (slurp mode) so each JSON object is processed in constant memory via streaming, prefixing filters with `objects` to skip non-object values in the FBC stream
- Wraps `CatalogContainsSomePackages`, `PackageHasSomeChannels`, and `PackageHasSomeBundles` in `waitFor` for retry on transient errors (matching the pattern used by `PodHasContainerCount` and dozens of other steps)
- Adds `curl --compressed` to request gzip and stream-decompress (catalogd uses gzhttp), `--fail` with `set -o pipefail` to detect HTTP errors through the pipe
- Resolves the catalogd leader pod via the `catalogd-operator-lock` Lease and port-forwards directly to it on the container port (8443), falling back to the service when the lease cannot be read
- Resets port-forwards on query failure and re-establishes dead ones via liveness checks
- Injects stderr into `ExitError` in `bash()` to match the `k8sClient` diagnostics pattern
- Logs catalog query errors at V(0) so CI timeout failures are diagnosable

Tested with 10 consecutive CI passes after the fix (previously ~45% failure rate).

## Reviewer Checklist

- [ ] API Go Documentation
- [x] Tests: Unit Tests (and E2E Tests, if appropriate)
- [x] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)