### PR TITLE
:seedling: Bump github.com/go-logr/logr from 1.4.3 to 1.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/go-logr/logr v1.4.3
+	github.com/go-logr/logr v1.4.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpj
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
-github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
+github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/hack/ci/custom-linters/analyzers/testdata/go.mod
+++ b/hack/ci/custom-linters/analyzers/testdata/go.mod
@@ -2,4 +2,4 @@ module testdata
 
 go 1.26.3
 
-require github.com/go-logr/logr v1.4.3
+require github.com/go-logr/logr v1.4.4

--- a/hack/ci/custom-linters/analyzers/testdata/go.sum
+++ b/hack/ci/custom-linters/analyzers/testdata/go.sum
@@ -1,2 +1,2 @@
-github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
-github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
+github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary

- Bumps `github.com/go-logr/logr` from `v1.4.3` to `v1.4.4` in the root module
- Also bumps it in `hack/ci/custom-linters/analyzers/testdata/` (a nested module), fixing the `unit-test-basic` CI failure in dependabot PR #2847

## Why #2847 was failing

The `TestSetupLogErrorCheck` test uses the `analysistest` framework to compile `testdata/main.go`, which imports `github.com/go-logr/logr`. The testdata has its own `go.mod` that was pinned to `v1.4.3`. CI runs with `GOPROXY=off`, so when the root module was bumped to `v1.4.4` the CI module cache no longer had `v1.4.3`, causing the import to fail with `could not import github.com/go-logr/logr (invalid package name: "")`.

Closes #2847.

## Test plan
- [ ] `unit-test-basic` CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the logging dependency to version 1.4.4.
  - Aligned the dependency version used in development and validation tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->