### PR TITLE
:seedling: ci: add dependabot config for nested Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,22 @@ updates:
         patterns:
         - "k8s.io/*"
         - "sigs.k8s.io/*"
+  - package-ecosystem: "gomod"
+    directory: "/hack/ci/custom-linters/analyzers/testdata"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: ":seedling:"
+  - package-ecosystem: "gomod"
+    directory: "/hack/tools/test-profiling"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: ":seedling:"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- Adds dependabot entries for the two nested `go.mod` files that were not previously tracked:
  - `hack/ci/custom-linters/analyzers/testdata/`
  - `hack/tools/test-profiling/`

## Why

Dependabot was only watching the root `go.mod`. The nested modules drifted, which caused `unit-test-basic` to fail when the root module was bumped but the nested `testdata` module was not (root module upgraded to `v1.4.4`, testdata still had `v1.4.3`, and CI runs with `GOPROXY=off`).

With this change, dependabot will open PRs for all three Go modules independently, keeping them in sync.

## Test plan
- [ ] Dependabot opens PRs for the nested modules on the next daily run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily maintenance checks for selected development tooling.
  * Updates are now paced with a 14-day cooldown to reduce disruption.
  * Automated maintenance commits use a consistent format for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->