### PR TITLE
:book: Update limitations doc to call out no support for APIServices

### DIFF
--- a/docs/project/olmv1_limitations.md
+++ b/docs/project/olmv1_limitations.md
@@ -14,6 +14,7 @@ Currently, OLM v1 only supports installing operators packaged in [OLM v0 bundles
     * `olm.gvk.required`
     * `olm.package.required`
     * `olm.constraint`
+* **must not** define `APIService`s in the `ClusterServiceVersion`
 
 OLM v1 verifies these criteria at install time and will surface violations in the `ClusterExtensions`'s `.status.conditions`.
 


### PR DESCRIPTION
# Description

Bundles with APIServices were never supported by OLMv1. However, we forgot to call it out in the docs. This PR updates the docs.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented an additional OLM v1 installation limitation: `ClusterServiceVersion` resources must not define `APIService` entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->